### PR TITLE
Make nlprule optional for WASM compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,13 @@ edition = "2021"
 name = "glossia"
 path = "src/bin/glossia.rs"
 
+[features]
+default = ["grammar"]
+grammar = ["nlprule"]
+
 [dependencies]
 rand = "0.8"
-nlprule = "0.6"
+nlprule = { version = "0.6", optional = true }
 anyhow = "1.0"
 reqwest = { version = "0.11", features = ["blocking"] }
 clap = { version = "4.4", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod types;
 
+#[cfg(feature = "grammar")]
 use nlprule::{Tokenizer, Rules};
+#[cfg(feature = "grammar")]
 use anyhow::{Result, Context};
 
 /// Helper enum to represent supported languages
@@ -9,6 +11,7 @@ pub enum Language {
     English,
 }
 
+#[cfg(feature = "grammar")]
 impl Language {
     /// Get the language code (ISO 639-1)
     fn code(&self) -> &'static str {
@@ -29,11 +32,13 @@ impl Language {
 }
 
 /// Grammar checker that wraps nlprule functionality
+#[cfg(feature = "grammar")]
 pub struct GrammarChecker {
     tokenizer: Tokenizer,
     rules: Rules,
 }
 
+#[cfg(feature = "grammar")]
 impl GrammarChecker {
     /// Create a new GrammarChecker from language, loading tokenizer and rules from paths
     pub fn from_paths(tokenizer_path: &str, rules_path: &str) -> Result<Self> {
@@ -41,7 +46,7 @@ impl GrammarChecker {
             .with_context(|| format!("Failed to load tokenizer from {}", tokenizer_path))?;
         let rules = Rules::new(rules_path)
             .with_context(|| format!("Failed to load rules from {}", rules_path))?;
-        
+
         Ok(Self { tokenizer, rules })
     }
 
@@ -50,7 +55,7 @@ impl GrammarChecker {
     pub fn from_language(language: Language) -> Result<Self> {
         let tokenizer_filename = language.tokenizer_filename();
         let rules_filename = language.rules_filename();
-        
+
         // Try multiple locations (check Docker location first to avoid corrupted local files)
         let locations = vec![
             "/opt/nlprule-data/", // Docker persistent location (check first)
@@ -58,17 +63,17 @@ impl GrammarChecker {
             "data/",              // data subdirectory
             "",                   // current directory
         ];
-        
+
         for location in &locations {
             let tokenizer_path = format!("{}{}", location, tokenizer_filename);
             let rules_path = format!("{}{}", location, rules_filename);
-            
-            if std::path::Path::new(&tokenizer_path).exists() && 
+
+            if std::path::Path::new(&tokenizer_path).exists() &&
                std::path::Path::new(&rules_path).exists() {
                 return Self::from_paths(&tokenizer_path, &rules_path);
             }
         }
-        
+
         // If none found, try the default (current directory) and let it error with a helpful message
         Self::from_paths(&tokenizer_filename, &rules_filename)
             .with_context(|| format!(
@@ -100,6 +105,7 @@ impl GrammarChecker {
 }
 
 #[cfg(test)]
+#[cfg(feature = "grammar")]
 mod tests {
     use super::*;
 
@@ -113,14 +119,14 @@ mod tests {
                 return Ok(());
             }
         };
-        
+
         let sentence = "The quick brown fox jumps over the lazy dog.";
         let suggestions = grammar_checker.check(sentence);
-        
+
         // This is a complete, grammatically correct sentence
         // It should have few or no suggestions
         println!("Suggestions for test sentence: {:?}", suggestions);
-        
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Add `grammar` feature flag (enabled by default) that gates the `nlprule` dependency
- Gate `GrammarChecker`, `Language` impl, and related tests behind `#[cfg(feature = "grammar")]`
- Downstream WASM consumers can now use `default-features = false` to exclude `nlprule` → `onig_sys`, which cannot compile for `wasm32-unknown-unknown`

## Test plan
- [x] `cargo check --lib` (default features, grammar enabled) — compiles
- [x] `cargo check --no-default-features --lib` (grammar disabled) — compiles with no warnings
- [ ] Existing tests pass with default features: `cargo test`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)