### PR TITLE
Gate get_wordlist_path re-export behind cfg(not(wasm32))

### DIFF
--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -7,6 +7,8 @@ pub mod utils;
 // Re-export public API items
 pub use types::{PayloadTok, Lexicon, GenerationMode, SentenceLengthMode};
 pub use core::{generate_text, generate_text_with_original_payload, max_subsequence_embedding, plan_sentence, fill_slots};
-pub use data::{load_payload_words, load_payload_words_for_wordlist, load_cover_words_by_pos, load_cover_words_by_pos_for_wordlist, build_pos_mapping, build_pos_mapping_for_wordlist, tag_word, select_random_words, wordlist_filenames, default_wordlist, load_payload_tree, load_cover_tree, load_cover_word_pos_tags, get_embedded_yaml, has_embedded_files, get_available_languages, get_available_wordlists, get_wordlist_path};
+pub use data::{load_payload_words, load_payload_words_for_wordlist, load_cover_words_by_pos, load_cover_words_by_pos_for_wordlist, build_pos_mapping, build_pos_mapping_for_wordlist, tag_word, select_random_words, wordlist_filenames, default_wordlist, load_payload_tree, load_cover_tree, load_cover_word_pos_tags, get_embedded_yaml, has_embedded_files, get_available_languages, get_available_wordlists};
+#[cfg(not(target_arch = "wasm32"))]
+pub use data::get_wordlist_path;
 pub use cache::{SequenceCache, print_sentence_kinds_once};
 pub use utils::{normalize_token_for_bip39, wrap_payload_with_bars, wrap_payload_with_color, word_wrap, capitalize, payload_fits, get_grammar, starts_with_vowel_sound};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,10 @@ pub use generator::{
     tag_word, select_random_words, wordlist_filenames, default_wordlist,
     load_payload_tree, load_cover_tree, load_cover_word_pos_tags,
     get_embedded_yaml, has_embedded_files, get_available_languages,
-    get_available_wordlists, get_wordlist_path,
+    get_available_wordlists,
 };
+#[cfg(not(target_arch = "wasm32"))]
+pub use generator::get_wordlist_path;
 
 // Re-export merkle functions
 pub use merkle::{WordlistTree, merkleize, parse_merkleized, verify_merkleized};


### PR DESCRIPTION
## Summary
- Gate `get_wordlist_path` re-export behind `#[cfg(not(target_arch = "wasm32"))]` in both `src/generator/mod.rs` and `src/lib.rs`
- The function itself is already gated in `data.rs` but was re-exported unconditionally, causing compilation failure on `wasm32-unknown-unknown` targets

## Test plan
- [x] `wasm-pack build --target web --release` compiles successfully
- [ ] `cargo test` passes with default (native) features

🤖 Generated with [Claude Code](https://claude.com/claude-code)