### PR TITLE
Add PR preview deploys via gh-pages subfolder

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -11,17 +11,16 @@ on:
       - 'languages/**'
   workflow_dispatch:
 
+# Pushing the built site to the gh-pages branch requires write access.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: pages
+  group: pages-deploy
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,24 +28,23 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build WASM
         run: ./build_web.sh
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      # Deploy the production site to the root of gh-pages. clean-exclude keeps
+      # the pr-preview/ directory (managed by the PR Preview workflow) intact so
+      # production deploys don't wipe live preview deployments.
+      - name: Deploy to GitHub Pages (production)
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: web
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          branch: gh-pages
+          folder: web
+          clean: true
+          clean-exclude: |
+            pr-preview/

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,55 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+
+# contents: write to push the preview into gh-pages; pull-requests: write so the
+# action can post/update the preview-link comment on the PR.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    # Skip pull requests from forks: their restricted GITHUB_TOKEN cannot push to
+    # gh-pages, so a preview deploy would always fail.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+
+      # The build steps are skipped when a PR is closed: pr-preview-action only
+      # needs to tear down the existing preview directory in that case.
+      - name: Install Rust
+        if: github.event.action != 'closed'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        if: github.event.action != 'closed'
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        if: github.event.action != 'closed'
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM
+        if: github.event.action != 'closed'
+        run: ./build_web.sh
+
+      # On open/synchronize/reopen: deploy web/ to gh-pages under
+      # pr-preview/pr-<N>/ and comment the URL. On close: remove that directory.
+      - name: Deploy PR preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./web/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,4 +15,5 @@
 - [Email Dialect](./email-dialect.md)
 - [Nostr Seal](./nostr-seal.md)
 - [Project Structure](./project-structure.md)
+- [Deployment & CI](./deployment.md)
 - [Whitepaper](./whitepaper.md)

--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -1,0 +1,51 @@
+# Deployment & CI
+
+Glossia uses GitHub Actions for continuous integration and for deploying the
+WASM web app to GitHub Pages.
+
+## Workflows
+
+| Workflow | File | Trigger | Purpose |
+|----------|------|---------|---------|
+| CI | `.github/workflows/ci.yml` | every PR, push to `master` | `cargo build` + `cargo test` |
+| Deploy Web App | `.github/workflows/deploy-web.yml` | push to `master` (web/src/Cargo/languages paths) + manual | Build WASM, deploy production site |
+| PR Preview | `.github/workflows/pr-preview.yml` | PR opened/updated/reopened/closed | Build WASM, deploy a per-PR preview |
+
+## GitHub Pages source
+
+Both the production deploy and PR previews publish to the **`gh-pages`
+branch** (production at the root, previews under `pr-preview/pr-<N>/`). Pages
+can only serve from a single source, so they must share one branch.
+
+> **One-time setup:** In the repository settings under **Settings → Pages**,
+> set the **Source** to **Deploy from a branch** and choose the **`gh-pages`**
+> branch (folder `/ (root)`). The `gh-pages` branch is created automatically by
+> the first production deploy after this change.
+>
+> The custom domain (`glossia.io`) is preserved via the `CNAME` file in
+> `web/`, which the production deploy publishes to the root of `gh-pages`.
+
+## How previews work
+
+On every push to a (non-fork) pull request, the **PR Preview** workflow builds
+the WASM bundle and deploys `web/` into `pr-preview/pr-<N>/` on the `gh-pages`
+branch using [`rossjrw/pr-preview-action`](https://github.com/rossjrw/pr-preview-action).
+The action posts a comment on the PR with the live URL, e.g.
+`https://glossia.io/pr-preview/pr-42/`. When the PR is closed or merged, the
+preview directory is removed automatically.
+
+Production deploys use
+[`JamesIves/github-pages-deploy-action`](https://github.com/JamesIves/github-pages-deploy-action)
+with `clean-exclude: pr-preview/`, so publishing a new production build never
+wipes the live previews of open PRs.
+
+The web app loads its WASM via relative paths (`./glossia.js`, with `init()`
+resolving the `.wasm` relative to the module URL), so it works correctly when
+served from a subpath.
+
+## Limitations
+
+- **Fork PRs are skipped.** A pull request from a fork uses a restricted
+  `GITHUB_TOKEN` that cannot push to `gh-pages`, so no preview is built for it.
+- Previews share the production domain under `/pr-preview/...`; they are not
+  isolated environments.


### PR DESCRIPTION
Migrate production web deploy from the GitHub Actions Pages source to the
gh-pages branch so per-PR previews can coexist with production under one
Pages source. Production publishes to the branch root (clean-exclude keeps
pr-preview/ intact); a new PR Preview workflow deploys web/ to
pr-preview/pr-<N>/ via rossjrw/pr-preview-action and tears it down on close.

Document the workflows and the required one-time Pages source setting.

https://claude.ai/code/session_0139ubY9u1xopK1SQPddg4sB