### PR TITLE
Add Czech presets to web editor

### DIFF
--- a/web/editor.html
+++ b/web/editor.html
@@ -513,6 +513,7 @@ mark {
         <button class="btn-sm preset-btn" data-meta="encode into latin compactly" title="Latin prose encoding">Latin</button>
         <button class="btn-sm preset-btn" data-meta="encode into latin bip39" title="BIP39 seed phrase as Latin (base-N, fewer words)">Latin BIP39</button>
         <button class="btn-sm preset-btn" data-meta="encode into latin spells" title="Harry Potter spell format">Spells</button>
+        <button class="btn-sm preset-btn" data-meta="encode into czech naturally" title="Czech prose (official BIP39 Czech wordlist)">Czech</button>
       </div>
       <div class="preset-tab-content" data-tab="crypto">
         <button class="btn-sm preset-btn" data-meta="encode into pgp" title="PGP encrypted message armor">PGP Message</button>
@@ -559,6 +560,7 @@ mark {
       <div class="preset-tab-content" data-tab="pipelines">
         <button class="btn-sm preset-btn" data-meta="transcode from latin into english" title="Translate Latin prose to English prose">Latin &rarr; English</button>
         <button class="btn-sm preset-btn" data-meta="transcode from english into latin" title="Translate English prose to Latin prose">English &rarr; Latin</button>
+        <button class="btn-sm preset-btn" data-meta="transcode from czech into english" title="Translate Czech prose to English prose">Czech &rarr; English</button>
         <button class="btn-sm preset-btn" data-meta="encode into english naturally" title="Encode raw hex as English prose">Hex &rarr; English</button>
         <button class="btn-sm preset-btn" data-meta="encode into latin compactly" title="Encode raw data as Latin prose">Data &rarr; Latin</button>
       </div>
@@ -580,7 +582,7 @@ mark {
             <code>transcode from &lt;source&gt; into &lt;target&gt;</code>
           </div>
           <div style="margin-bottom:0.5rem;">
-            <strong style="color:var(--text);">Targets:</strong> english, latin, pgp, nostr, music, hex, base64, ascii7
+            <strong style="color:var(--text);">Targets:</strong> english, latin, czech, pgp, nostr, music, hex, base64, ascii7
           </div>
           <div>
             <strong style="color:var(--text);">Modifiers:</strong> naturally, compactly, minimally, optimally


### PR DESCRIPTION
The editor.html page was never updated when Czech was made selectable
(commit e50bee5 only touched web/index.html), so the editor lacked the
Czech preset button and omitted czech from the targets help text. The
dynamic dialect dropdown already lists Czech via get_all_dialects; this
brings the editor's static UI in line with the demo.

- Add 'Czech' text preset (encode into czech naturally)
- Add 'Czech -> English' pipeline preset
- List czech in the Targets help line

https://claude.ai/code/session_01A9tyuYtBQ3p1csFpLG9nLk