### PR TITLE
Fix detect→decode pipeline: length-invariant hit_rate (#26), bare-word transcode (#23), and raw codec consistency

### DIFF
--- a/languages/czech/grammar.yaml
+++ b/languages/czech/grammar.yaml
@@ -301,6 +301,14 @@ grammar:
               weight: 1.0
               lambda: "λnp:(e->t). λprep:(e->(e->t)). prep(np)"
 
+    # BIP39 transcode: re-express a BIP39 seed as Czech prose.
+    # Uses base_n (rebase) instead of bitpack to avoid padding-word overhead;
+    # inherits the base (body) prose rules. Mirror of English/Latin bip39 dialect.
+    bip39:
+      codec: base_n
+      payload_wordlist: "default"
+      cover_wordlist: "default"
+
     payload_only:
       payload_wordlist: "default"
       cover_wordlist: "default"

--- a/languages/english/grammar.yaml
+++ b/languages/english/grammar.yaml
@@ -457,6 +457,17 @@ grammar:
               weight: 0.10
               lambda: "λn:(e->t). λadj:(e->e). λdet:((e->t)->(e->t)). λprep:(e->(e->t)). prep(det(n))"
 
+    # BIP39 transcode: weave a BIP39 seed phrase into natural English prose.
+    # Uses base_n (rebase) instead of bitpack — no padding word, no re-chunking —
+    # so the exact input mnemonic words are preserved verbatim, just interspersed
+    # with cover words. Inherits the base (body) prose rules. Mirror of Latin's
+    # bip39 dialect, but here payload == cover language (English), so the seed
+    # words appear directly in the sentence.
+    bip39:
+      codec: base_n
+      payload_wordlist: "default"
+      cover_wordlist: "default"
+
     payload_only:
       payload_wordlist: "default"
       cover_wordlist: "default"

--- a/src/generator/data.rs
+++ b/src/generator/data.rs
@@ -933,11 +933,14 @@ pub struct DialectMatch {
     pub wordlist: String,
     /// Available dialects for this language (e.g., ["body", "subject", "prose"]).
     pub dialects: Vec<String>,
-    /// Number of input words that matched this payload wordlist.
+    /// Number of input word tokens that matched this payload wordlist, counted
+    /// **with multiplicity** (a payload word appearing 3 times counts as 3).
     pub hits: usize,
-    /// Total number of input words tested.
+    /// Total number of input word tokens tested (with duplicates).
     pub total: usize,
-    /// Hit rate: `hits / total` (0.0 to 1.0).
+    /// Hit rate: `hits / total` (0.0 to 1.0). Because both numerator and
+    /// denominator count tokens with multiplicity, this is length-invariant —
+    /// it does not decay as the input grows (see issue #26).
     pub hit_rate: f64,
     /// Size of the payload wordlist.
     pub wordlist_size: usize,
@@ -1254,7 +1257,14 @@ pub fn detect_dialect_with(input_words: &[String], filter: &DialectFilter) -> Ve
         .collect();
 
     let total = normalized.len();
-    let input_set: HashSet<&str> = normalized.iter().map(|s| s.as_str()).collect();
+
+    // Count occurrences of each distinct word. The binary searches run once per
+    // *distinct* word (the keys), but `hit_rate` is scored with *multiplicity*
+    // (see the loop below), so we keep the per-word counts here.
+    let mut input_counts: HashMap<&str, usize> = HashMap::new();
+    for w in &normalized {
+        *input_counts.entry(w.as_str()).or_insert(0) += 1;
+    }
 
     let mut results: Vec<DialectMatch> = Vec::new();
 
@@ -1277,10 +1287,18 @@ pub fn detect_dialect_with(input_words: &[String], filter: &DialectFilter) -> Ve
                 None => continue,
             };
 
+            // Count matched words *with multiplicity*: every input token that is
+            // a payload word counts, not just the distinct ones. Scoring distinct
+            // matches over a with-duplicates total (the old behavior) made
+            // `hit_rate` decay as ~1/length, so long-but-valid encoded bodies sank
+            // below downstream thresholds purely as a function of length (issue
+            // #26). An occurrence-over-total ratio is length- and entropy-
+            // invariant, which is what makes the issue #14 `min_hit_rate` filter a
+            // trustworthy confidence signal rather than a length-sensitive one.
             let mut hits = 0usize;
-            for word in &input_set {
+            for (word, &count) in &input_counts {
                 if binary_search_sorted_words(sorted_words, word) {
-                    hits += 1;
+                    hits += count;
                 }
             }
 
@@ -1463,6 +1481,40 @@ mod tests {
         assert_eq!(best.language, "english", "Best match should be English");
         assert_eq!(best.hits, 5, "All 5 words should be hits");
         assert!((best.hit_rate - 1.0).abs() < 0.001, "Hit rate should be 1.0");
+    }
+
+    #[test]
+    fn test_detect_dialect_hit_rate_length_invariant() {
+        // Regression for issue #26: `hit_rate` must not decay with input length.
+        // The old metric (distinct matches ÷ total-with-duplicates) fell as
+        // ~1/length; the occurrence-based metric stays flat. Repeating an
+        // all-payload-word input lengthens it without diluting the rate.
+        let base = ["abandon", "ability", "able"];
+        let short: Vec<String> = base.iter().map(|s| s.to_string()).collect();
+        let long: Vec<String> = base
+            .iter()
+            .cycle()
+            .take(base.len() * 20)
+            .map(|s| s.to_string())
+            .collect();
+
+        let short_best = detect_dialect_best(&short).expect("short input should detect");
+        let long_best = detect_dialect_best(&long).expect("long input should detect");
+
+        // Every token is a payload word, so the rate is 1.0 regardless of length.
+        assert!(
+            (short_best.hit_rate - 1.0).abs() < 1e-9,
+            "short hit_rate should be 1.0, got {}",
+            short_best.hit_rate
+        );
+        assert!(
+            (long_best.hit_rate - 1.0).abs() < 1e-9,
+            "long hit_rate should be 1.0, got {} — metric decayed with length",
+            long_best.hit_rate
+        );
+        // hits counts with multiplicity: 60 tokens, all matching.
+        assert_eq!(long_best.hits, base.len() * 20);
+        assert_eq!(long_best.total, base.len() * 20);
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -873,11 +873,12 @@ impl Pipeline {
                 .map_err(|e| PipelineError::EncodeError(e))?;
             let payload_tree = WordlistTree::new(payload_words);
 
-            let codec = Grammar::from_language_dialect(language, "body")
-                .map(|g| g.codec().to_string())
-                .unwrap_or_else(|_| "bitpack".to_string());
+            // Raw output is bare payload words with no padding header, so it must
+            // use base-N — the same codec the raw decode path uses. (bitpack would
+            // prepend a padding-count word that the bare-word decoder doesn't
+            // expect, breaking the round-trip.)
             let (_, data) = codec::detect_mode(input);
-            let words = codec::encode_base_n(&data, &payload_tree, &codec)
+            let words = codec::encode_base_n(&data, &payload_tree, "base_n")
                 .map_err(|e| PipelineError::EncodeError(format!("{}", e)))?;
 
             return Ok(words.join(" "));
@@ -917,11 +918,12 @@ impl Pipeline {
                 .map_err(|e| PipelineError::EncodeError(e))?;
             let payload_tree = WordlistTree::new(payload_words);
 
-            let codec = Grammar::from_language_dialect(language, "body")
-                .map(|g| g.codec().to_string())
-                .unwrap_or_else(|_| "bitpack".to_string());
+            // Raw output is bare payload words with no padding header, so it must
+            // use base-N — the same codec the raw decode path uses. (bitpack would
+            // prepend a padding-count word that the bare-word decoder doesn't
+            // expect, breaking the round-trip.)
             let (_, data) = codec::detect_mode(input);
-            let words = codec::encode_base_n(&data, &payload_tree, &codec)
+            let words = codec::encode_base_n(&data, &payload_tree, "base_n")
                 .map_err(|e| PipelineError::EncodeError(format!("{}", e)))?;
 
             let output = words.join(" ");
@@ -2309,6 +2311,36 @@ mod tests {
         assert_eq!(decode_codec_for_input("base_n", 4, 4), "base_n");
         // No payload words extracted → keep the declared codec.
         assert_eq!(decode_codec_for_input("bitpack", 0, 0), "bitpack");
+    }
+
+    #[test]
+    fn test_raw_encode_decode_round_trip() {
+        // Regression: the "raw" dialect must use the SAME codec on encode and
+        // decode. Previously raw-encode used bitpack (prepending a padding-count
+        // word) while raw-decode used base_n, so the bytes did not survive the
+        // round-trip and the output carried a spurious leading word.
+        let input = "cafe"; // hex → bytes 0xca 0xfe
+
+        let encode = Pipeline::from_params(
+            Endpoint::Format(DataMode::Hex),
+            Endpoint::language_full("english", "bip39", "raw"),
+        );
+        let bare_words = encode.execute(input).unwrap();
+
+        // base-N of 0xcafe is exactly 2 words; bitpack would add a 3rd padding
+        // word. Asserting the count locks in the "no header" property.
+        assert_eq!(
+            bare_words.split_whitespace().count(),
+            2,
+            "raw output must be bare data words with no padding header, got: {bare_words:?}"
+        );
+
+        let decode = Pipeline::from_params(
+            Endpoint::language_full("english", "bip39", "raw"),
+            Endpoint::Format(DataMode::Hex),
+        );
+        let decoded = decode.execute(&bare_words).unwrap();
+        assert_eq!(decoded, input, "raw encode/decode must round-trip");
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1036,7 +1036,24 @@ impl Pipeline {
         // Raw mnemonics have no bitpack header — always use base_n.
         let bytes = codec::decode_base_n(&words, &payload_tree, "base_n")
             .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
-        Ok((codec::hex_encode(&bytes), words))
+        // Raw output defaults to hex (back-compat); honor an explicit format target.
+        let output = match self.target_format() {
+            Some(fmt) => render_decoded_bytes(&bytes, Some(fmt)),
+            None => codec::hex_encode(&bytes),
+        };
+        Ok((output, words))
+    }
+
+    /// The explicit output format requested by the pipeline target, if any.
+    ///
+    /// `Some(mode)` when the target is a `Format` endpoint (e.g. `… into hex`);
+    /// `None` for an `Auto` or `Language` target, so each decode path keeps its
+    /// own default rendering.
+    fn target_format(&self) -> Option<DataMode> {
+        match &self.target {
+            Endpoint::Format(mode) => Some(*mode),
+            _ => None,
+        }
     }
 
     /// Decode: language prose → extract payload words → binary → data string.
@@ -1068,7 +1085,7 @@ impl Pipeline {
             .map(|c| c.payload_language().to_string())
             .unwrap_or_else(|_| language.to_string());
 
-        decode_from_language_with_payload_lang(input, language, &payload_lang, wordlist, self.verbose, dialect)
+        decode_from_language_with_payload_lang(input, language, &payload_lang, wordlist, self.verbose, dialect, self.target_format())
     }
 
     /// Transcode: source prose → binary → target prose.
@@ -1185,7 +1202,7 @@ impl Pipeline {
             .unwrap_or_else(|_| language.to_string());
 
         let (decoded, extracted) = decode_from_language_rich_with_payload_lang(
-            input, language, &payload_lang, wordlist, self.verbose, dialect)?;
+            input, language, &payload_lang, wordlist, self.verbose, dialect, self.target_format())?;
 
         Ok(PipelineResult {
             output: decoded,
@@ -1743,6 +1760,23 @@ fn strip_email_header_labels(text: &str) -> String {
     result
 }
 
+/// Render decoded bytes into a textual representation.
+///
+/// `Some(mode)` forces the representation requested by the pipeline target:
+/// `Hex` → lowercase hex, `Base64` → base64, `Ascii7`/`Bytes8` → UTF-8 (lossy).
+/// `None` keeps the back-compatible auto behavior: the UTF-8 string when the
+/// bytes are valid UTF-8, otherwise lowercase hex.
+fn render_decoded_bytes(bytes: &[u8], format: Option<DataMode>) -> String {
+    match format {
+        Some(DataMode::Hex) => codec::hex_encode(bytes),
+        Some(DataMode::Base64) => codec::base64_encode(bytes),
+        Some(DataMode::Ascii7) | Some(DataMode::Bytes8) => {
+            String::from_utf8_lossy(bytes).into_owned()
+        }
+        None => String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| codec::hex_encode(bytes)),
+    }
+}
+
 /// Decode language prose back to the original data string.
 ///
 /// Prose → extract payload words (filter out cover words) → binary → string.
@@ -1752,7 +1786,7 @@ pub fn decode_from_language(
     wordlist: &str,
     verbose: bool,
 ) -> Result<String, PipelineError> {
-    decode_from_language_with_payload_lang(text, language, language, wordlist, verbose, "body")
+    decode_from_language_with_payload_lang(text, language, language, wordlist, verbose, "body", None)
 }
 
 /// Choose the decode codec for a sequence of extracted payload words.
@@ -1806,6 +1840,7 @@ fn decode_from_language_with_payload_lang(
     wordlist: &str,
     verbose: bool,
     grammar_dialect: &str,
+    format: Option<DataMode>,
 ) -> Result<String, PipelineError> {
     // Strip email header labels if the input looks like an RFC 5322 message.
     // This prevents header names like "Subject" from colliding with payload words.
@@ -1893,10 +1928,7 @@ fn decode_from_language_with_payload_lang(
     };
     let bytes = codec::decode_base_n(&extracted, &*payload_tree, codec_name)
         .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
-    match String::from_utf8(bytes.clone()) {
-        Ok(s) => Ok(s),
-        Err(_) => Ok(codec::hex_encode(&bytes)),
-    }
+    Ok(render_decoded_bytes(&bytes, format))
 }
 
 /// Decode language prose, returning both the decoded text and extracted payload words.
@@ -1906,7 +1938,7 @@ pub fn decode_from_language_rich(
     wordlist: &str,
     verbose: bool,
 ) -> Result<(String, Vec<String>), PipelineError> {
-    decode_from_language_rich_with_payload_lang(text, language, language, wordlist, verbose, "body")
+    decode_from_language_rich_with_payload_lang(text, language, language, wordlist, verbose, "body", None)
 }
 
 /// Internal rich decode with separate grammar language and payload language.
@@ -1917,6 +1949,7 @@ fn decode_from_language_rich_with_payload_lang(
     wordlist: &str,
     verbose: bool,
     grammar_dialect: &str,
+    format: Option<DataMode>,
 ) -> Result<(String, Vec<String>), PipelineError> {
     // Strip email header labels if the input looks like an RFC 5322 message.
     let text = strip_email_header_labels(text);
@@ -1998,10 +2031,7 @@ fn decode_from_language_rich_with_payload_lang(
     };
     let bytes = codec::decode_base_n(&extracted, &*payload_tree, codec_name)
         .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
-    let decoded = match String::from_utf8(bytes.clone()) {
-        Ok(s) => s,
-        Err(_) => codec::hex_encode(&bytes),
-    };
+    let decoded = render_decoded_bytes(&bytes, format);
 
     Ok((decoded, extracted))
 }
@@ -2440,6 +2470,58 @@ mod tests {
             seed.split_whitespace().collect::<Vec<_>>(),
             "english bip39 dialect must round-trip to the original seed"
         );
+    }
+
+    #[test]
+    fn test_decode_honors_target_format() {
+        // Regression for #28: decode into a Format endpoint must render the
+        // recovered bytes in that format, not always UTF-8-else-hex.
+        let key = "sk-test-ABC123xyz";
+
+        let prose = Pipeline::from_params(
+            Endpoint::Auto,
+            Endpoint::language_full("english", "bip39", "body"),
+        )
+        .with_seed(42)
+        .execute(key)
+        .unwrap();
+
+        let decode = |fmt: DataMode| {
+            Pipeline::from_params(
+                Endpoint::language_full("english", "bip39", "body"),
+                Endpoint::Format(fmt),
+            )
+            .execute(&prose)
+            .unwrap()
+        };
+
+        // hex target -> hex of the bytes (and decodes back to the key)
+        let hex = decode(DataMode::Hex);
+        assert_eq!(
+            codec::hex_decode(&hex).expect("valid hex"),
+            key.as_bytes(),
+            "into hex must yield hex of the bytes, got {hex:?}"
+        );
+
+        // base64 target -> base64 of the bytes (and decodes back to the key)
+        let b64 = decode(DataMode::Base64);
+        assert_eq!(
+            codec::base64_decode(&b64).expect("valid base64"),
+            key.as_bytes(),
+            "into base64 must yield base64 of the bytes, got {b64:?}"
+        );
+
+        // ascii target -> the original string
+        assert_eq!(decode(DataMode::Ascii7), key, "into ascii must yield the string");
+
+        // Auto (no explicit format) keeps the UTF-8-else-hex behavior.
+        let auto = Pipeline::from_params(
+            Endpoint::language_full("english", "bip39", "body"),
+            Endpoint::Auto,
+        )
+        .execute(&prose)
+        .unwrap();
+        assert_eq!(auto, key, "Auto decode must be unchanged");
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -2404,6 +2404,45 @@ mod tests {
     }
 
     #[test]
+    fn test_english_bip39_dialect_preserves_seed_words() {
+        // The english "bip39" dialect uses base_n, so encoding a BIP39 seed weaves
+        // the exact seed words into prose (with cover words) instead of re-chunking
+        // them via bitpack. Verify every seed word survives and the seed round-trips.
+        let seed = "abandon ability able about above absent absorb access accident account accuse achieve";
+
+        let encode = Pipeline::from_params(
+            Endpoint::language_full("english", "bip39", "raw"),
+            Endpoint::language_full("english", "bip39", "bip39"),
+        )
+        .with_seed(42);
+        let prose = encode.execute(seed).unwrap();
+
+        // Every seed word appears verbatim in the prose (interspersed with cover).
+        for w in seed.split_whitespace() {
+            assert!(
+                prose.split_whitespace().any(|t| {
+                    t.trim_matches(|c: char| !c.is_alphanumeric())
+                        .eq_ignore_ascii_case(w)
+                }),
+                "seed word {w:?} missing from english bip39 prose: {prose:?}"
+            );
+        }
+
+        // Round-trips back to the exact seed (prose → bytes → raw seed words).
+        let recovered = Pipeline::from_params(
+            Endpoint::language_full("english", "bip39", "bip39"),
+            Endpoint::language_full("english", "bip39", "raw"),
+        )
+        .execute(&prose)
+        .unwrap();
+        assert_eq!(
+            recovered.split_whitespace().collect::<Vec<_>>(),
+            seed.split_whitespace().collect::<Vec<_>>(),
+            "english bip39 dialect must round-trip to the original seed"
+        );
+    }
+
+    #[test]
     fn test_transcode_bare_mnemonic_english_to_latin() {
         // Regression for issue #23: bare payload words (a raw BIP39 mnemonic, not
         // Glossia-encoded prose) carry no bitpack padding header, so transcoding

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1718,6 +1718,45 @@ pub fn decode_from_language(
     decode_from_language_with_payload_lang(text, language, language, wordlist, verbose, "body")
 }
 
+/// Choose the decode codec for a sequence of extracted payload words.
+///
+/// Framed Glossia prose carries a leading padding-count word and is interspersed
+/// with cover/function words, so it round-trips through the grammar's declared
+/// codec (`bitpack` for power-of-two wordlists). A *bare* payload sequence — e.g.
+/// a raw BIP39 mnemonic typed directly rather than produced by Glossia's encoder
+/// — has no padding word and no cover words: every input token is a payload word.
+/// Handing such input to `bitpack` misreads the first word as a padding count,
+/// leaving `(N-1) * bits_per_word` data bits that are almost never byte-aligned,
+/// so the decode aborts with "data_bits not byte-aligned" (issue #23).
+///
+/// When every input token is a payload word (`payload_words == total_tokens`) the
+/// input is unframed; decode it as a plain base-N integer instead — the same
+/// interpretation the `raw` dialect path uses for bare mnemonics. Only `bitpack`
+/// is rerouted; `base_n` already handles unframed input.
+fn decode_codec_for_input<'a>(
+    grammar_codec: &'a str,
+    total_tokens: usize,
+    payload_words: usize,
+) -> &'a str {
+    if grammar_codec == "bitpack" && payload_words > 0 && payload_words == total_tokens {
+        "base_n"
+    } else {
+        grammar_codec
+    }
+}
+
+/// Count whitespace-delimited input tokens that survive alphanumeric trimming.
+///
+/// Used to detect bare/unframed payload input: when this equals the number of
+/// extracted payload words, the input carries no cover words (see
+/// [`decode_codec_for_input`]).
+fn alnum_token_count(text: &str) -> usize {
+    text.split_whitespace()
+        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
+        .filter(|w| !w.is_empty())
+        .count()
+}
+
 /// Internal decode with separate grammar language and payload language.
 ///
 /// `grammar_lang` determines which grammar.yaml to load (for payload_separator).
@@ -1808,7 +1847,14 @@ fn decode_from_language_with_payload_lang(
     }
 
     // 4. Payload words → binary → data string (base-N decoding).
-    let bytes = codec::decode_base_n(&extracted, &*payload_tree, grammar.codec())
+    // Bare/unframed input (a raw mnemonic: all tokens are payload words) has no
+    // bitpack padding header, so decode it as base-N instead (issue #23).
+    let codec_name = if payload_separator.is_empty() {
+        grammar.codec()
+    } else {
+        decode_codec_for_input(grammar.codec(), alnum_token_count(text), extracted.len())
+    };
+    let bytes = codec::decode_base_n(&extracted, &*payload_tree, codec_name)
         .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
     match String::from_utf8(bytes.clone()) {
         Ok(s) => Ok(s),
@@ -1906,7 +1952,14 @@ fn decode_from_language_rich_with_payload_lang(
     }
 
     // 4. Payload words → binary → data string (base-N decoding).
-    let bytes = codec::decode_base_n(&extracted, &*payload_tree, grammar.codec())
+    // Bare/unframed input (a raw mnemonic: all tokens are payload words) has no
+    // bitpack padding header, so decode it as base-N instead (issue #23).
+    let codec_name = if payload_separator.is_empty() {
+        grammar.codec()
+    } else {
+        decode_codec_for_input(grammar.codec(), alnum_token_count(text), extracted.len())
+    };
+    let bytes = codec::decode_base_n(&extracted, &*payload_tree, codec_name)
         .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
     let decoded = match String::from_utf8(bytes.clone()) {
         Ok(s) => s,
@@ -2244,6 +2297,56 @@ mod tests {
         );
         let decoded = decode_pipeline.execute(&latin_prose).unwrap();
         assert_eq!(decoded, input, "Transcode round-trip should recover original");
+    }
+
+    #[test]
+    fn test_decode_codec_for_input_detects_bare_vs_framed() {
+        // Every input token is a payload word → unframed bare mnemonic → base_n.
+        assert_eq!(decode_codec_for_input("bitpack", 4, 4), "base_n");
+        // Cover words present (more tokens than payload words) → framed → bitpack.
+        assert_eq!(decode_codec_for_input("bitpack", 9, 4), "bitpack");
+        // Non-bitpack codecs already handle unframed input and are never rerouted.
+        assert_eq!(decode_codec_for_input("base_n", 4, 4), "base_n");
+        // No payload words extracted → keep the declared codec.
+        assert_eq!(decode_codec_for_input("bitpack", 0, 0), "bitpack");
+    }
+
+    #[test]
+    fn test_transcode_bare_mnemonic_english_to_latin() {
+        // Regression for issue #23: bare payload words (a raw BIP39 mnemonic, not
+        // Glossia-encoded prose) carry no bitpack padding header, so transcoding
+        // them must not fail with "data_bits not byte-aligned". They decode as a
+        // plain base-N integer, matching the `raw` dialect path.
+        let bare = "abandon ability able about";
+
+        let transcode = Pipeline::from_params(
+            Endpoint::language_full("english", "bip39", "body"),
+            Endpoint::language("latin"),
+        )
+        .with_seed(42);
+        let latin = transcode
+            .execute(bare)
+            .expect("bare-word transcode should succeed, not error on byte alignment");
+        assert!(!latin.is_empty(), "Latin prose should not be empty");
+
+        // Byte-lossless: the Latin output must decode to the same bytes the bare
+        // English words decode to directly.
+        let from_english = Pipeline::from_params(
+            Endpoint::language_full("english", "bip39", "body"),
+            Endpoint::Auto,
+        )
+        .execute(bare)
+        .unwrap();
+        let from_latin = Pipeline::from_params(
+            Endpoint::language("latin"),
+            Endpoint::Auto,
+        )
+        .execute(&latin)
+        .unwrap();
+        assert_eq!(
+            from_english, from_latin,
+            "bare-word transcode must be byte-lossless"
+        );
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -995,6 +995,50 @@ impl Pipeline {
         })
     }
 
+    /// Decode bare/raw payload words (e.g. a BIP39 mnemonic) into hex bytes.
+    ///
+    /// Raw input carries no Glossia header or cover words, so every payload word
+    /// is data and decoding is a plain base-N integer (no bitpack padding word).
+    /// Returns the hex-encoded bytes and the extracted payload words. Shared by
+    /// [`Self::do_decode`] and [`Self::do_decode_rich`] so both agree.
+    fn decode_raw_words(
+        &self,
+        input: &str,
+        language: &str,
+        wordlist: &str,
+    ) -> Result<(String, Vec<String>), PipelineError> {
+        let wordlist_name = if wordlist == "default" {
+            let dw = crate::generator::default_wordlist(language);
+            if dw == "default" { wordlist } else { dw }
+        } else {
+            wordlist
+        };
+        let payload_words = load_payload_words_for_wordlist(language, wordlist_name)
+            .map_err(|e| PipelineError::DecodeError(e))?;
+        let payload_tree = WordlistTree::new(payload_words);
+
+        let words: Vec<String> = input
+            .split_whitespace()
+            .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
+            .filter(|w| !w.is_empty() && payload_tree.contains(w))
+            .collect();
+
+        if words.is_empty() {
+            return Err(PipelineError::DecodeError(
+                "no payload words found in input".to_string(),
+            ));
+        }
+
+        if self.verbose {
+            eprintln!("Raw decode: {} payload words via base-N", words.len());
+        }
+
+        // Raw mnemonics have no bitpack header — always use base_n.
+        let bytes = codec::decode_base_n(&words, &payload_tree, "base_n")
+            .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
+        Ok((codec::hex_encode(&bytes), words))
+    }
+
     /// Decode: language prose → extract payload words → binary → data string.
     fn do_decode(&self, input: &str, source: &Endpoint) -> Result<String, PipelineError> {
         let (language, wordlist, dialect) = match source {
@@ -1014,36 +1058,8 @@ impl Pipeline {
         // "raw" dialect: input is raw payload words (e.g. BIP39 mnemonic) without
         // Glossia header or cover words. Decode directly via base-N.
         if dialect == "raw" {
-            let wordlist_name = if wordlist == "default" {
-                let dw = crate::generator::default_wordlist(language);
-                if dw == "default" { wordlist } else { dw }
-            } else {
-                wordlist
-            };
-            let payload_words = load_payload_words_for_wordlist(language, wordlist_name)
-                .map_err(|e| PipelineError::DecodeError(e))?;
-            let payload_tree = WordlistTree::new(payload_words);
-
-            let words: Vec<String> = input
-                .split_whitespace()
-                .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
-                .filter(|w| !w.is_empty() && payload_tree.contains(w))
-                .collect();
-
-            if words.is_empty() {
-                return Err(PipelineError::DecodeError(
-                    "no payload words found in input".to_string(),
-                ));
-            }
-
-            if self.verbose {
-                eprintln!("Raw decode: {} payload words via base-N", words.len());
-            }
-
-            // Raw mnemonics have no bitpack header — always use base_n.
-            let bytes = codec::decode_base_n(&words, &payload_tree, "base_n")
-                .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
-            return Ok(codec::hex_encode(&bytes));
+            let (output, _) = self.decode_raw_words(input, language, wordlist)?;
+            return Ok(output);
         }
 
         // Resolve payload_language: if the dialect declares a different language
@@ -1140,6 +1156,25 @@ impl Pipeline {
                 payload_words: extracted,
                 data_mode: None,
                 stats: None,
+                resolved_source: None,
+            });
+        }
+
+        // "raw" dialect: bare payload words (e.g. BIP39 mnemonic), all payload and
+        // no cover — decode via base-N, same as the plain do_decode raw branch.
+        if dialect == "raw" {
+            let (output, words) = self.decode_raw_words(input, language, wordlist)?;
+            let payload_count = words.len();
+            return Ok(PipelineResult {
+                output,
+                payload_words: words,
+                data_mode: None,
+                stats: Some(PipelineStats {
+                    payload_count,
+                    cover_count: 0,
+                    total_words: payload_count,
+                    ratio: 1.0,
+                }),
                 resolved_source: None,
             });
         }
@@ -2341,6 +2376,31 @@ mod tests {
         );
         let decoded = decode.execute(&bare_words).unwrap();
         assert_eq!(decoded, input, "raw encode/decode must round-trip");
+    }
+
+    #[test]
+    fn test_raw_decode_rich_returns_stats() {
+        // Regression: do_decode_rich had no `raw` branch, so a rich decode of bare
+        // payload words fell through to the prose decoder. It now decodes via
+        // base-N and reports all-payload stats, agreeing with the plain do_decode.
+        let bare = "add garlic"; // base-N of 0xcafe in english/bip39
+
+        let pipeline = Pipeline::from_params(
+            Endpoint::language_full("english", "bip39", "raw"),
+            Endpoint::Format(DataMode::Hex),
+        );
+
+        let plain = pipeline.execute(bare).unwrap();
+        let rich = pipeline.execute_rich(bare).unwrap();
+
+        assert_eq!(rich.output, plain, "rich and plain raw decode must agree");
+        assert_eq!(rich.output, "cafe");
+        assert_eq!(rich.payload_words, vec!["add".to_string(), "garlic".to_string()]);
+        let stats = rich.stats.expect("raw decode should report stats");
+        assert_eq!(stats.payload_count, 2);
+        assert_eq!(stats.cover_count, 0);
+        assert_eq!(stats.total_words, 2);
+        assert_eq!(stats.ratio, 1.0);
     }
 
     #[test]

--- a/tests/test_vectors.json
+++ b/tests/test_vectors.json
@@ -89,10 +89,10 @@
     },
     {
       "id": "bip39-mnemonic-12-words",
-      "description": "Well-known 12-word BIP39 test mnemonic (all-zero entropy)",
+      "description": "Well-known 12-word BIP39 test mnemonic (all-zero entropy). Detected as a seed and encoded via the word-preserving english bip39 dialect (base_n); the seed words survive in the prose and the entropy round-trips.",
       "input": { "value": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", "format": "bip39" },
-      "encoding": { "language": "english", "wordlist": "bip39", "dialect": "body", "codec": "bitpack", "seed": 42 },
-      "expected_decoded": { "value": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about", "format": "bip39" }
+      "encoding": { "language": "english", "wordlist": "bip39", "dialect": "bip39", "codec": "base_n", "seed": 42 },
+      "expected_decoded": { "value": "000000000000000000000003", "format": "hex" }
     },
     {
       "id": "btc-bech32-address",

--- a/web/index.html
+++ b/web/index.html
@@ -719,53 +719,108 @@ footer a:hover { text-decoration: underline; }
         .demo-hint { color: var(--text-dim); font-size: 0.8rem; text-align: center; margin-top: 0.85rem; }
         #demo .panel-header { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; }
         #demo .panel-header .lang-row { margin-left: auto; }
-        #left-box { flex: 1; min-height: 160px; padding: 0.75rem 0.85rem; font-size: 0.9rem;
+        .io-input { flex: 1; min-height: 160px; padding: 0.75rem 0.85rem; font-size: 0.9rem;
           font-family: var(--font-mono); line-height: 1.7; color: var(--text); outline: none;
           white-space: pre-wrap; overflow-wrap: anywhere; overflow-y: auto; }
-        #left-box:empty::before { content: attr(data-placeholder); color: var(--text-dim); }
-        #left-box u, #right-box u { text-decoration-color: var(--accent); text-underline-offset: 2px; }
+        .io-input:empty::before { content: attr(data-placeholder); color: var(--text-dim); }
+        .io-input u, .output-area u { text-decoration-color: var(--accent); text-underline-offset: 2px; }
+        .usecase-tabs { display: flex; gap: 0; border-bottom: 2px solid var(--border); margin-bottom: 1rem; }
+        .usecase-tab { padding: 0.5rem 1rem; font-family: var(--font-mono); font-size: 0.85rem; font-weight: 500;
+          color: var(--text-dim); cursor: pointer; border: none; background: none;
+          border-bottom: 2px solid transparent; margin-bottom: -2px; transition: all 0.15s; }
+        .usecase-tab:hover { color: var(--text); }
+        .usecase-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
       </style>
-      <div class="section-header">
-        <h3>BIP39 Seed Phrase</h3>
-        <p>Turn a recovery phrase into a readable sentence &mdash; and back again, byte-for-byte</p>
+
+      <div class="usecase-tabs">
+        <button class="usecase-tab active" data-uc="bip39">BIP39 Seed</button>
+        <button class="usecase-tab" data-uc="apikey">API Key</button>
       </div>
 
-      <div class="panels">
-        <!-- Left panel: input -->
-        <div class="panel panel-left">
-          <div class="panel-header">
-            <span class="dialect-label" id="left-label">BIP39 seed</span>
+      <!-- ─── BIP39 panel ─────────────────────────────────────────── -->
+      <div id="panel-bip39">
+        <div class="section-header">
+          <h3>BIP39 Seed Phrase</h3>
+          <p>Turn a recovery phrase into a readable sentence &mdash; and back again, byte-for-byte</p>
+        </div>
+
+        <div class="panels">
+          <div class="panel panel-left">
+            <div class="panel-header">
+              <span class="dialect-label" id="left-label">BIP39 seed</span>
+            </div>
+            <div class="panel-body">
+              <div contenteditable="true" spellcheck="false" id="left-box" class="io-input" data-placeholder="Click &ldquo;Generate seed&rdquo;, or paste a BIP39 mnemonic&hellip;"></div>
+            </div>
+            <div class="panel-footer">
+              <button class="btn-sm" id="gen-btn" onclick="generateSeed()" title="Generate a random 12-word BIP39 seed">&#127922; Generate seed</button>
+              <div id="demo-error" class="error-msg hidden" style="padding:0;"></div>
+            </div>
           </div>
-          <div class="panel-body">
-            <div contenteditable="true" spellcheck="false" id="left-box" data-placeholder="Click &ldquo;Generate seed&rdquo;, or paste a BIP39 mnemonic&hellip;"></div>
-          </div>
-          <div class="panel-footer">
-            <button class="btn-sm" id="gen-btn" onclick="generateSeed()" title="Generate a random 12-word BIP39 seed">&#127922; Generate seed</button>
-            <div id="demo-error" class="error-msg hidden" style="padding:0;"></div>
+
+          <button class="swap-btn" id="swap-btn" onclick="toggleMode()" title="Switch between Encode and Decode" aria-label="Swap encode/decode">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"/></svg>
+          </button>
+
+          <div class="panel panel-right">
+            <div class="panel-header">
+              <span class="dialect-label" id="right-label">English sentences</span>
+              <div class="lang-row" id="right-langs"></div>
+            </div>
+            <div class="panel-body">
+              <div class="output-area empty" id="right-box">Output will appear here</div>
+            </div>
+            <div class="panel-footer">
+              <button class="btn-sm" id="copy-btn" onclick="copyOutput()">Copy</button>
+            </div>
           </div>
         </div>
 
-        <!-- Swap button: encode <-> decode -->
-        <button class="swap-btn" id="swap-btn" onclick="toggleMode()" title="Switch between Encode and Decode" aria-label="Swap encode/decode">
-          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"/></svg>
-        </button>
-
-        <!-- Right panel: output -->
-        <div class="panel panel-right">
-          <div class="panel-header">
-            <span class="dialect-label" id="right-label">English sentences</span>
-            <div class="lang-row" id="right-langs"></div>
-          </div>
-          <div class="panel-body">
-            <div class="output-area empty" id="right-box">Output will appear here</div>
-          </div>
-          <div class="panel-footer">
-            <button class="btn-sm" id="copy-btn" onclick="copyOutput()">Copy</button>
-          </div>
-        </div>
+        <p class="demo-hint" id="demo-hint"></p>
       </div>
 
-      <p class="demo-hint" id="demo-hint"></p>
+      <!-- ─── API Key panel ───────────────────────────────────────── -->
+      <div id="panel-apikey" class="hidden">
+        <div class="section-header">
+          <h3>API Key / Secret Token</h3>
+          <p>Turn an opaque key into a readable sentence &mdash; dictate it, paste it, decode it back byte-for-byte</p>
+        </div>
+
+        <div class="panels">
+          <div class="panel panel-left">
+            <div class="panel-header">
+              <span class="dialect-label" id="ak-left-label">API key</span>
+            </div>
+            <div class="panel-body">
+              <div contenteditable="true" spellcheck="false" id="ak-left-box" class="io-input" data-placeholder="Click &ldquo;Generate key&rdquo;, or paste an API key / hex / base64&hellip;"></div>
+            </div>
+            <div class="panel-footer">
+              <button class="btn-sm" id="ak-gen-btn" onclick="akGenerate()" title="Generate a realistic sk- API key">&#127922; Generate key</button>
+              <div id="ak-error" class="error-msg hidden" style="padding:0;"></div>
+            </div>
+          </div>
+
+          <button class="swap-btn" id="ak-swap-btn" onclick="akToggle()" title="Switch between Encode and Decode" aria-label="Swap encode/decode">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"/></svg>
+          </button>
+
+          <div class="panel panel-right">
+            <div class="panel-header">
+              <span class="dialect-label" id="ak-right-label">English sentences</span>
+              <div class="lang-row" id="ak-langs"></div>
+              <div class="lang-row hidden" id="ak-fmts"></div>
+            </div>
+            <div class="panel-body">
+              <div class="output-area empty" id="ak-right-box">Output will appear here</div>
+            </div>
+            <div class="panel-footer">
+              <button class="btn-sm" id="ak-copy-btn" onclick="akCopy()">Copy</button>
+            </div>
+          </div>
+        </div>
+
+        <p class="demo-hint" id="ak-hint"></p>
+      </div>
     </section>
 
     <!-- ═══════════════════════════════════════════════════════════
@@ -965,7 +1020,7 @@ function buildLangButtons() {
 }
 
 function updateLangHighlights() {
-  document.querySelectorAll('.lang-btn').forEach(b => {
+  document.querySelectorAll('#right-langs .lang-btn').forEach(b => {
     b.classList.toggle('active', b.dataset.lang === currentLang);
   });
 }
@@ -1111,6 +1166,190 @@ window.copyOutput = function() {
   navigator.clipboard.writeText(el.dataset.plainText || '').catch(() => {});
 };
 
+// ═══ API Key panel ═══════════════════════════════════════════════════
+//
+// Symmetric Google-Translate model, but the two sides are different domains:
+//   encode: key (format auto-detected) -> prose; right buttons pick the LANGUAGE
+//   decode: prose (language auto-detected) -> key; right buttons pick the FORMAT
+
+let akMode = 'encode';
+let akLang = 'english';      // TARGET language (right buttons, encode), persists
+let akFormat = 'ascii7';     // TARGET format (right buttons, decode), persists
+let akDetLang = 'english';   // SOURCE language auto-detected from left prose (decode)
+let akDetFmt = '';           // SOURCE format auto-detected from the key (encode), display only
+let akTimer = null;
+
+const AK_LANGS = [
+  { id: 'english', label: 'English', source: 'english/bip39/body' },
+  { id: 'latin',   label: 'Latin',   source: 'latin/default/body' },
+  { id: 'czech',   label: 'Czech',   source: 'czech/default/body' },
+];
+const AK_FORMATS = [
+  { id: 'ascii7', label: 'ASCII',  word: 'ascii7' },
+  { id: 'hex',    label: 'Hex',    word: 'hex' },
+  { id: 'base64', label: 'Base64', word: 'base64' },
+];
+const AK_FMT_LABEL = { ascii7: 'ASCII', bytes8: 'bytes', hex: 'hex', base64: 'base64' };
+function akLangById(id) { return AK_LANGS.find(l => l.id === id) || AK_LANGS[0]; }
+function akFmtById(id) { return AK_FORMATS.find(f => f.id === id) || AK_FORMATS[0]; }
+
+function akLeftText() { return document.getElementById('ak-left-box').innerText; }
+function akSetLeftPlain(t) { document.getElementById('ak-left-box').textContent = t; }
+function akShowError(m) { const e = document.getElementById('ak-error'); e.textContent = m; e.classList.remove('hidden'); }
+function akClearError() { document.getElementById('ak-error').classList.add('hidden'); }
+
+function akSetOutput(text, html) {
+  const el = document.getElementById('ak-right-box');
+  if (!text) { el.classList.add('empty'); el.textContent = 'Output will appear here'; el.dataset.plainText = ''; return; }
+  el.classList.remove('empty');
+  el.innerHTML = (html != null) ? html : escapeHtml(text).replace(/\n/g, '<br>');
+  el.dataset.plainText = text;
+}
+
+function akBuildButtons() {
+  const langRow = document.getElementById('ak-langs');
+  langRow.innerHTML = '';
+  for (const l of AK_LANGS) {
+    const b = document.createElement('button');
+    b.className = 'btn-sm lang-btn';
+    b.dataset.akLang = l.id;
+    b.textContent = l.label;
+    b.title = l.label + ' prose';
+    b.addEventListener('click', () => { akLang = l.id; akRun(); });
+    langRow.appendChild(b);
+  }
+  const fmtRow = document.getElementById('ak-fmts');
+  fmtRow.innerHTML = '';
+  for (const f of AK_FORMATS) {
+    const b = document.createElement('button');
+    b.className = 'btn-sm lang-btn';
+    b.dataset.akFmt = f.id;
+    b.textContent = f.label;
+    b.title = 'Decode to ' + f.label;
+    b.addEventListener('click', () => { akFormat = f.id; akRun(); });
+    fmtRow.appendChild(b);
+  }
+}
+
+function akUpdateHighlights() {
+  document.querySelectorAll('#ak-langs .lang-btn').forEach(b => b.classList.toggle('active', b.dataset.akLang === akLang));
+  document.querySelectorAll('#ak-fmts .lang-btn').forEach(b => b.classList.toggle('active', b.dataset.akFmt === akFormat));
+}
+
+// Decode mode: auto-detect the SOURCE language of the left prose.
+function akDetectLeftLang() {
+  const text = akLeftText().trim();
+  if (!text) return;
+  try {
+    const matches = JSON.parse(wasmDetectDialect(text));
+    if (Array.isArray(matches)) {
+      const best = matches.find(m => AK_LANGS.some(l => l.id === m.language));
+      if (best) akDetLang = best.language;
+    }
+  } catch (e) { /* keep detected language */ }
+}
+
+function akUpdateChrome() {
+  const genBtn = document.getElementById('ak-gen-btn');
+  const hint = document.getElementById('ak-hint');
+  const langRow = document.getElementById('ak-langs');
+  const fmtRow = document.getElementById('ak-fmts');
+  if (akMode === 'encode') {
+    // key (left, source) -> prose (right, target language).
+    const fmt = akDetFmt ? (AK_FMT_LABEL[akDetFmt] || akDetFmt) : '';
+    document.getElementById('ak-left-label').textContent = 'API key' + (fmt ? ' · ' + fmt : '');
+    document.getElementById('ak-right-label').textContent = akLangById(akLang).label + ' sentences';
+    langRow.classList.remove('hidden');
+    fmtRow.classList.add('hidden');
+    genBtn.classList.remove('hidden');
+    hint.textContent = 'Encodes the key into ' + akLangById(akLang).label +
+      ' prose (payload words underlined). Pick the target language on the right; press ⇄ to decode.';
+  } else {
+    // prose (left, source auto-detected) -> key (right, target format).
+    document.getElementById('ak-left-label').textContent = akLangById(akDetLang).label + ' sentences (detected)';
+    document.getElementById('ak-right-label').textContent = 'Key · ' + akFmtById(akFormat).label;
+    langRow.classList.add('hidden');
+    fmtRow.classList.remove('hidden');
+    genBtn.classList.add('hidden');
+    hint.textContent = 'Detected ' + akLangById(akDetLang).label +
+      ' prose (payload words underlined); recovering the key as ' + akFmtById(akFormat).label +
+      '. Pick the output format on the right; press ⇄ to encode.';
+  }
+  akUpdateHighlights();
+}
+
+function akUnderlineLeft(prose, words) {
+  const el = document.getElementById('ak-left-box');
+  const focused = (document.activeElement === el);
+  el.innerHTML = underlineProse(prose, normSet(words));
+  if (focused) placeCaretEnd(el);
+}
+
+function akRun() {
+  if (!ready) return;
+  akClearError();
+  akUpdateChrome();
+  const text = akLeftText().trim();
+  if (!text) { akSetOutput(''); return; }
+  try {
+    if (akMode === 'encode') {
+      const r = JSON.parse(wasmTranscode(text, 'encode into ' + akLang + ' naturally', SEED));
+      if (r.error) { akShowError(r.error); akSetOutput(''); return; }
+      akDetFmt = r.data_mode || '';
+      const out = (r.output || '').trim();
+      akSetOutput(out, underlineProse(out, normSet(r.payload_words || [])));
+      akUpdateChrome();   // refresh the detected-format chip
+    } else {
+      const meta = 'transcode from ' + akLangById(akDetLang).source + ' into ' + akFmtById(akFormat).word;
+      const r = JSON.parse(wasmTranscode(text, meta, SEED));
+      if (r.error) { akShowError(r.error); akSetOutput(''); return; }
+      akSetOutput((r.output || '').trim());
+      akUnderlineLeft(text, r.payload_words || []);   // payload words of the source prose
+    }
+  } catch (e) {
+    akShowError(e.message || String(e));
+    akSetOutput('');
+  }
+}
+
+function akRandomKey() {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const rv = crypto.getRandomValues(new Uint8Array(32));
+  let s = 'sk-';
+  for (const v of rv) s += alphabet[v % alphabet.length];
+  return s;
+}
+
+window.akGenerate = function() {
+  if (!ready) return;
+  if (akMode !== 'encode') { akMode = 'encode'; }
+  akClearError();
+  akSetLeftPlain(akRandomKey());
+  akRun();
+};
+
+window.akToggle = function() {
+  const out = document.getElementById('ak-right-box').dataset.plainText || '';
+  akMode = (akMode === 'encode') ? 'decode' : 'encode';
+  akSetLeftPlain(out);
+  if (akMode === 'decode') akDetectLeftLang();
+  akRun();
+};
+
+window.akCopy = function() {
+  const el = document.getElementById('ak-right-box');
+  navigator.clipboard.writeText(el.dataset.plainText || '').catch(() => {});
+};
+
+// ═══ Use-case selector ═══════════════════════════════════════════════
+
+window.selectUseCase = function(uc) {
+  document.querySelectorAll('.usecase-tab').forEach(t => t.classList.toggle('active', t.dataset.uc === uc));
+  document.getElementById('panel-bip39').classList.toggle('hidden', uc !== 'bip39');
+  document.getElementById('panel-apikey').classList.toggle('hidden', uc !== 'apikey');
+  // Re-sync the shown panel's labels/highlights.
+  if (uc === 'apikey') { akUpdateChrome(); } else { updateChrome(); }
+};
 // ─── Theme toggle ────────────────────────────────────────────────────
 
 const toggleBtn = document.getElementById('theme-toggle');
@@ -1148,6 +1387,19 @@ async function startup() {
     });
     updateChrome();
     generateSeed();
+
+    // API Key panel
+    akBuildButtons();
+    document.getElementById('ak-left-box').addEventListener('input', () => {
+      clearTimeout(akTimer);
+      akTimer = setTimeout(() => {
+        if (akMode === 'decode') akDetectLeftLang();
+        akRun();
+      }, 250);
+    });
+    document.querySelectorAll('.usecase-tab').forEach(t =>
+      t.addEventListener('click', () => selectUseCase(t.dataset.uc)));
+    akGenerate();
   } catch (e) {
     console.error('Failed to load WASM:', e);
     document.getElementById('loading').innerHTML =

--- a/web/index.html
+++ b/web/index.html
@@ -722,8 +722,6 @@ footer a:hover { text-decoration: underline; }
       <div class="preset-tabs">
         <button class="preset-tab active" data-tab="text">Text</button>
         <button class="preset-tab" data-tab="crypto">Crypto</button>
-        <button class="preset-tab" data-tab="music">Music</button>
-        <button class="preset-tab" data-tab="image">Image</button>
         <button class="preset-tab" data-tab="pipelines">Pipelines</button>
       </div>
       <div class="preset-tab-content active" data-tab="text">
@@ -750,36 +748,6 @@ footer a:hover { text-decoration: underline; }
         <button class="btn-sm preset-btn" data-meta="encode into ascii7" title="Plain ASCII message">ASCII7</button>
         <button class="btn-sm preset-btn" data-meta="encode into cs raw" title="Raw encoding, no armor">Raw</button>
       </div>
-      <div class="preset-tab-content" data-tab="music">
-        <button class="btn-sm preset-btn" data-meta="encode into music" title="Chromatic scored notation">Chromatic</button>
-        <button class="btn-sm preset-btn" data-meta="encode into music pentatonic" title="Pentatonic scale notation">Pentatonic</button>
-        <button class="btn-sm preset-btn" data-meta="encode into music blues" title="Blues scale notation">Blues</button>
-      </div>
-      <div class="preset-tab-content" data-tab="image" style="flex-direction:column; gap:0.25rem;">
-        <div class="image-row">
-          <span class="image-group-label">Layout</span>
-          <button class="btn-sm image-layout-btn active" data-layout="voronoi" title="Voronoi mosaic layout">Voronoi</button>
-          <button class="btn-sm image-layout-btn" data-layout="grid" title="Rectangular grid layout">Grid</button>
-          <button class="btn-sm image-layout-btn" data-layout="constellation" title="Circular dots on dark background">Constellation</button>
-          <button class="btn-sm image-layout-btn" data-layout="patches" title="4-column patch grid">Patches</button>
-        </div>
-        <div class="image-row">
-          <span class="image-group-label">Shape</span>
-          <button class="btn-sm image-shape-btn active" data-shape="rect" title="Rectangular canvas">Rect</button>
-          <button class="btn-sm image-shape-btn" data-shape="disk" title="Circular clipping">Disk</button>
-        </div>
-        <div class="image-row">
-          <span class="image-group-label">Palette</span>
-          <button class="btn-sm image-palette-btn active" data-palette="viridis" title="Deep purple through teal to yellow-green (128 colors)">viridis</button>
-          <button class="btn-sm image-palette-btn" data-palette="plasma" title="Dark purple through magenta to orange-yellow (128 colors)">plasma</button>
-          <button class="btn-sm image-palette-btn" data-palette="inferno" title="Near-black through red-orange to bright yellow (128 colors)">inferno</button>
-          <button class="btn-sm image-palette-btn" data-palette="magma" title="Near-black through purple-pink to pale white (64 colors)">magma</button>
-          <button class="btn-sm image-palette-btn" data-palette="cividis" title="Dark blue through olive-grey to yellow, CVD-safe (128 colors)">cividis</button>
-          <button class="btn-sm image-palette-btn" data-palette="turbo" title="Dark blue through rainbow to dark red (8 colors)">turbo</button>
-          <button class="btn-sm image-palette-btn" data-palette="mako" title="Deep purple-black through teal to pale cyan (64 colors)">mako</button>
-          <button class="btn-sm image-palette-btn" data-palette="rocket" title="Near-black through magenta to pale white (32 colors)">rocket</button>
-        </div>
-      </div>
       <div class="preset-tab-content" data-tab="pipelines">
         <button class="btn-sm preset-btn" data-meta="transcode from latin into english" title="Translate Latin prose to English prose">Latin &rarr; English</button>
         <button class="btn-sm preset-btn" data-meta="transcode from english into latin" title="Translate English prose to Latin prose">English &rarr; Latin</button>
@@ -802,6 +770,7 @@ footer a:hover { text-decoration: underline; }
         </div>
         <div class="panel-footer">
           <div id="random-btns" style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
+            <button class="btn-sm" onclick="randomApiKey()" title="Generate a realistic sk-style API key — read it aloud or paste it into chat, then decode it back byte-for-byte">API Key</button>
             <button class="btn-sm" onclick="randomWords(12)" title="Generate 12 random BIP39 words">BIP39 (12)</button>
             <button class="btn-sm" onclick="randomWords(24)" title="Generate 24 random BIP39 words">BIP39 (24)</button>
             <button class="btn-sm" onclick="randomHex()" title="Generate random hex string">Hex</button>
@@ -866,7 +835,7 @@ footer a:hover { text-decoration: underline; }
             <code>transcode from &lt;source&gt; into &lt;target&gt;</code>
           </div>
           <div style="margin-bottom:0.5rem;">
-            <strong style="color:var(--text);">Targets:</strong> english, latin, czech, pgp, nostr, music, hex, base64, ascii7
+            <strong style="color:var(--text);">Targets:</strong> english, latin, czech, pgp, nostr, hex, base64, ascii7
           </div>
           <div>
             <strong style="color:var(--text);">Modifiers:</strong> naturally, compactly, minimally, optimally
@@ -1720,6 +1689,20 @@ window.randomWords = function(count) {
     errEl.textContent = e.message || String(e);
     errEl.classList.remove('hidden');
   }
+};
+
+window.randomApiKey = function() {
+  // A realistic "sk-"-style secret token: the headline last-mile scenario —
+  // turn an opaque key into readable prose you can dictate or paste, then
+  // decode it back byte-for-byte.
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const length = 48;
+  const randomValues = crypto.getRandomValues(new Uint8Array(length));
+  const chars = Array.from(randomValues)
+    .map(v => alphabet[v % alphabet.length])
+    .join('');
+  document.getElementById('input-area').value = 'sk-' + chars;
+  autoRunNow();
 };
 
 window.randomHex = function() {

--- a/web/index.html
+++ b/web/index.html
@@ -771,6 +771,7 @@ footer a:hover { text-decoration: underline; }
               <div class="output-area empty" id="right-box">Output will appear here</div>
             </div>
             <div class="panel-footer">
+              <button class="btn-sm" id="cover-btn" onclick="toggleCover()" title="Show or hide the cover words">Hide cover</button>
               <button class="btn-sm" id="copy-btn" onclick="copyOutput()">Copy</button>
             </div>
           </div>
@@ -814,6 +815,7 @@ footer a:hover { text-decoration: underline; }
               <div class="output-area empty" id="ak-right-box">Output will appear here</div>
             </div>
             <div class="panel-footer">
+              <button class="btn-sm" id="ak-cover-btn" onclick="akToggleCover()" title="Show or hide the cover words">Hide cover</button>
               <button class="btn-sm" id="ak-copy-btn" onclick="akCopy()">Copy</button>
             </div>
           </div>
@@ -976,6 +978,24 @@ function placeCaretEnd(el) {
   s.addRange(r);
 }
 
+// Cover-word visibility for the prose output (shared by both panels).
+let showCover = true;
+
+// The cleaned payload words present in prose, in order (cover words dropped).
+function payloadTokens(text, set) {
+  return text.split(/\s+/)
+    .map(t => t.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, ''))
+    .filter(t => t && set.has(norm(t)));
+}
+function payloadOnlyText(text, set) { return payloadTokens(text, set).join(' '); }
+
+// Render prose either in full (cover words present, payload underlined) or
+// payload-only (cover words removed, payload underlined).
+function renderProse(text, set) {
+  if (showCover) return underlineProse(text, set);
+  return payloadTokens(text, set).map(t => '<u>' + escapeHtml(t) + '</u>').join(' ');
+}
+
 // ─── Left box (contenteditable) accessors ────────────────────────────
 
 function leftText() { return document.getElementById('left-box').innerText; }
@@ -1075,6 +1095,14 @@ function updateChrome() {
       target.label + (currentLang === 'english' ? ' (BIP39).' : ' words.') +
       ' Pick the target language on the right; press ⇄ to go back to encoding.';
   }
+  // Cover toggle only applies to the prose output (right box in encode mode).
+  const coverBtn = document.getElementById('cover-btn');
+  if (mode === 'encode') {
+    coverBtn.classList.remove('hidden');
+    coverBtn.textContent = showCover ? 'Hide cover' : 'Show cover';
+  } else {
+    coverBtn.classList.add('hidden');
+  }
   updateLangHighlights();
 }
 
@@ -1119,8 +1147,9 @@ function run() {
     if (result.error) { showError(result.error); setOutput(''); return; }
     const out = (result.output || '').trim();
     if (mode === 'encode') {
-      // Right box holds the prose — underline its payload words.
-      setOutput(out, underlineProse(out, normSet(result.payload_words || [])));
+      // Right box holds the prose — underline payload words, honor cover toggle.
+      const set = normSet(result.payload_words || []);
+      setOutput(showCover ? out : payloadOnlyText(out, set), renderProse(out, set));
     } else {
       // Right box holds bare seed words (no underline); left box holds the
       // prose — underline its payload words.
@@ -1164,6 +1193,12 @@ window.toggleMode = function() {
 window.copyOutput = function() {
   const el = document.getElementById('right-box');
   navigator.clipboard.writeText(el.dataset.plainText || '').catch(() => {});
+};
+
+window.toggleCover = function() {
+  showCover = !showCover;
+  run();          // re-encode from the (stable) seed and re-render per showCover
+  updateChrome();
 };
 
 // ═══ API Key panel ═══════════════════════════════════════════════════
@@ -1275,6 +1310,14 @@ function akUpdateChrome() {
       ' prose (payload words underlined); recovering the key as ' + akFmtById(akFormat).label +
       '. Pick the output format on the right; press ⇄ to encode.';
   }
+  // Cover toggle only applies to the prose output (right box in encode mode).
+  const coverBtn = document.getElementById('ak-cover-btn');
+  if (akMode === 'encode') {
+    coverBtn.classList.remove('hidden');
+    coverBtn.textContent = showCover ? 'Hide cover' : 'Show cover';
+  } else {
+    coverBtn.classList.add('hidden');
+  }
   akUpdateHighlights();
 }
 
@@ -1297,7 +1340,8 @@ function akRun() {
       if (r.error) { akShowError(r.error); akSetOutput(''); return; }
       akDetFmt = r.data_mode || '';
       const out = (r.output || '').trim();
-      akSetOutput(out, underlineProse(out, normSet(r.payload_words || [])));
+      const set = normSet(r.payload_words || []);
+      akSetOutput(showCover ? out : payloadOnlyText(out, set), renderProse(out, set));
       akUpdateChrome();   // refresh the detected-format chip
     } else {
       const meta = 'transcode from ' + akLangById(akDetLang).source + ' into ' + akFmtById(akFormat).word;
@@ -1341,14 +1385,19 @@ window.akCopy = function() {
   navigator.clipboard.writeText(el.dataset.plainText || '').catch(() => {});
 };
 
+window.akToggleCover = function() {
+  showCover = !showCover;
+  akRun();        // re-encode from the (stable) key and re-render per showCover
+};
+
 // ═══ Use-case selector ═══════════════════════════════════════════════
 
 window.selectUseCase = function(uc) {
   document.querySelectorAll('.usecase-tab').forEach(t => t.classList.toggle('active', t.dataset.uc === uc));
   document.getElementById('panel-bip39').classList.toggle('hidden', uc !== 'bip39');
   document.getElementById('panel-apikey').classList.toggle('hidden', uc !== 'apikey');
-  // Re-sync the shown panel's labels/highlights.
-  if (uc === 'apikey') { akUpdateChrome(); } else { updateChrome(); }
+  // Re-render the shown panel so labels, highlights, and cover state are current.
+  if (uc === 'apikey') { akRun(); } else { updateChrome(); run(); }
 };
 // ─── Theme toggle ────────────────────────────────────────────────────
 

--- a/web/index.html
+++ b/web/index.html
@@ -874,13 +874,12 @@ const SEED = 42n;               // fixed seed -> deterministic prose
 // "bip39" dialect, so the seed round-trips byte-for-byte. English shares the
 // payload wordlist with BIP39, so the seed words appear verbatim in the prose;
 // Latin/Czech re-express the same entropy in their own (more compact) wordlists.
-//   encodeMeta : seed -> prose in this language
-//   source     : how to read this language's prose (decode source endpoint)
-//   rawTarget  : bare payload words in this language (decode target endpoint)
+//   source    : prose endpoint  — bip39-dialect prose in this language
+//   rawTarget : bare endpoint   — bare payload words in this language
 const LANGS = [
-  { id: 'english', label: 'English', encodeMeta: 'encode into english bip39', source: 'english/bip39/bip39', rawTarget: 'english/bip39/raw' },
-  { id: 'latin',   label: 'Latin',   encodeMeta: 'encode into latin bip39',   source: 'latin/default/bip39', rawTarget: 'latin/default/raw' },
-  { id: 'czech',   label: 'Czech',   encodeMeta: 'encode into czech bip39',   source: 'czech/default/bip39', rawTarget: 'czech/default/raw' },
+  { id: 'english', label: 'English', source: 'english/bip39/bip39', rawTarget: 'english/bip39/raw' },
+  { id: 'latin',   label: 'Latin',   source: 'latin/default/bip39', rawTarget: 'latin/default/raw' },
+  { id: 'czech',   label: 'Czech',   source: 'czech/default/bip39', rawTarget: 'czech/default/raw' },
 ];
 
 function langById(id) { return LANGS.find(l => l.id === id) || LANGS[0]; }
@@ -965,19 +964,21 @@ function updateChrome() {
   const hint = document.getElementById('demo-hint');
 
   // The buttons live above the right box in both modes and always name the
-  // TARGET language (Google-Translate style: target on the right).
+  // TARGET language (Google-Translate style: target on the right). The left box
+  // is the SOURCE, whose language is auto-detected in both modes.
+  const srcSeedLabel = detectedLang === 'english' ? 'BIP39 seed' : (source.label + ' seed words');
+  const tgtSeedLabel = currentLang === 'english' ? 'BIP39 seed' : (target.label + ' seed words');
   if (mode === 'encode') {
-    // seed (left, source) -> prose (right, target language).
-    document.getElementById('left-label').textContent = 'BIP39 seed';
+    // bare seed words (left, source) -> prose (right, target language).
+    document.getElementById('left-label').textContent = srcSeedLabel;
     document.getElementById('right-label').textContent = target.label + ' sentences';
     genBtn.classList.remove('hidden');
     hint.textContent = 'Generates a 12-word seed and weaves it into ' + target.label +
       ' prose. Pick the target language on the right; press ⇄ to decode a sentence back into a seed.';
   } else {
     // prose (left, source auto-detected) -> seed words (right, target language).
-    const seedLabel = currentLang === 'english' ? 'BIP39 seed' : (target.label + ' seed words');
     document.getElementById('left-label').textContent = source.label + ' sentences (detected)';
-    document.getElementById('right-label').textContent = seedLabel;
+    document.getElementById('right-label').textContent = tgtSeedLabel;
     genBtn.classList.add('hidden');
     hint.textContent = 'Detected ' + source.label + ' on the left; showing the seed as ' +
       target.label + (currentLang === 'english' ? ' (BIP39).' : ' words.') +
@@ -994,12 +995,15 @@ function run() {
   const text = document.getElementById('left-box').value.trim();
   if (!text) { setOutput(''); return; }
 
-  // currentLang is the TARGET (right buttons). In decode, the SOURCE is the
-  // auto-detected language of the left prose.
-  const target = langById(currentLang);
+  // currentLang is the TARGET (right buttons); detectedLang is the SOURCE
+  // (auto-detected from the left box, in both modes). Encode and decode are
+  // mirror transcodes: encode reads bare words and writes prose; decode reads
+  // prose and writes bare words.
+  const src = langById(detectedLang);
+  const tgt = langById(currentLang);
   const meta = (mode === 'encode')
-    ? target.encodeMeta
-    : 'transcode from ' + langById(detectedLang).source + ' into ' + target.rawTarget;
+    ? 'transcode from ' + src.rawTarget + ' into ' + tgt.source   // bare seed words -> prose
+    : 'transcode from ' + src.source + ' into ' + tgt.rawTarget;  // prose -> bare seed words
 
   try {
     const result = JSON.parse(wasmTranscode(text, meta, SEED));
@@ -1021,6 +1025,8 @@ window.generateSeed = function() {
     const words = JSON.parse(wasmRandomWords(12, 'english', 'bip39', BigInt(Date.now())));
     if (words.error) { showError(words.error); return; }
     document.getElementById('left-box').value = words.join(' ');
+    detectLeftLanguage();   // a freshly generated seed detects as English
+    updateChrome();
     run();
   } catch (e) {
     showError(e.message || String(e));
@@ -1032,7 +1038,7 @@ window.toggleMode = function() {
   const out = document.getElementById('right-box').dataset.plainText || '';
   mode = (mode === 'encode') ? 'decode' : 'encode';
   document.getElementById('left-box').value = out;
-  if (mode === 'decode') detectLeftLanguage();  // pick up the prose's language
+  detectLeftLanguage();  // pick up the source language of whatever's now on the left
   updateChrome();
   run();
 };
@@ -1056,7 +1062,8 @@ async function startup() {
     document.getElementById('left-box').addEventListener('input', () => {
       clearTimeout(inputTimer);
       inputTimer = setTimeout(() => {
-        if (mode === 'decode') { detectLeftLanguage(); updateChrome(); }
+        detectLeftLanguage();   // re-detect the source language as the user edits/pastes
+        updateChrome();
         run();
       }, 250);
     });

--- a/web/index.html
+++ b/web/index.html
@@ -871,9 +871,10 @@ let inputTimer = null;
 const SEED = 42n;               // fixed seed -> deterministic prose
 
 // Languages offered for the BIP39 panel. Each has a word-preserving base_n
-// "bip39" dialect, so the seed round-trips byte-for-byte. English shares the
-// payload wordlist with BIP39, so the seed words appear verbatim in the prose;
-// Latin/Czech re-express the same entropy in their own (more compact) wordlists.
+// "bip39" dialect, so the seed round-trips byte-for-byte. English and Czech use
+// 2^11 (2048-word) lists — same word count as the seed; English even shares the
+// BIP39 wordlist, so the seed words appear verbatim in the prose. Latin uses a
+// 2^15 list, so the same 12-word seed becomes ~9 Latin words.
 //   source    : prose endpoint  — bip39-dialect prose in this language
 //   rawTarget : bare endpoint   — bare payload words in this language
 const LANGS = [

--- a/web/index.html
+++ b/web/index.html
@@ -730,7 +730,6 @@ footer a:hover { text-decoration: underline; }
         <div class="panel panel-left">
           <div class="panel-header">
             <span class="dialect-label" id="left-label">BIP39 seed</span>
-            <div class="lang-row hidden" id="left-langs"></div>
           </div>
           <div class="panel-body">
             <textarea id="left-box" placeholder="Click &ldquo;Generate seed&rdquo;, or paste a BIP39 mnemonic&hellip;"></textarea>
@@ -913,19 +912,31 @@ function setOutput(text) {
 // ─── Language buttons ────────────────────────────────────────────────
 
 function buildLangButtons() {
-  for (const rowId of ['left-langs', 'right-langs']) {
-    const row = document.getElementById(rowId);
-    row.innerHTML = '';
-    for (const l of LANGS) {
-      const b = document.createElement('button');
-      b.className = 'btn-sm lang-btn';
-      b.dataset.lang = l.id;
-      b.textContent = l.label;
-      b.title = l.label + ' prose';
-      b.addEventListener('click', () => selectLang(l.id));
-      row.appendChild(b);
-    }
+  const row = document.getElementById('right-langs');
+  row.innerHTML = '';
+  for (const l of LANGS) {
+    const b = document.createElement('button');
+    b.className = 'btn-sm lang-btn';
+    b.dataset.lang = l.id;
+    b.textContent = l.label;
+    b.title = l.label + ' prose';
+    b.addEventListener('click', () => selectLang(l.id));
+    row.appendChild(b);
   }
+}
+
+// Auto-detect which language the left-box prose is written in (decode mode),
+// restricted to the languages this panel supports.
+function detectLeftLanguage() {
+  const text = document.getElementById('left-box').value.trim();
+  if (!text) return;
+  try {
+    const matches = JSON.parse(wasmDetectDialect(text));
+    if (Array.isArray(matches)) {
+      const best = matches.find(m => LANGS.some(l => l.id === m.language));
+      if (best) currentLang = best.language;
+    }
+  } catch (e) { /* keep current language */ }
 }
 
 function updateLangHighlights() {
@@ -944,29 +955,26 @@ function selectLang(id) {
 
 function updateChrome() {
   const lang = langById(currentLang);
-  const leftLangs = document.getElementById('left-langs');
-  const rightLangs = document.getElementById('right-langs');
   const genBtn = document.getElementById('gen-btn');
   const hint = document.getElementById('demo-hint');
 
+  // The language buttons live above the right box in both modes and always
+  // name the *prose* language.
   if (mode === 'encode') {
-    // seed (left) -> prose (right); language sits above the prose (right).
+    // seed (left) -> prose (right); buttons pick the prose language.
     document.getElementById('left-label').textContent = 'BIP39 seed';
     document.getElementById('right-label').textContent = lang.label + ' sentences';
-    leftLangs.classList.add('hidden');
-    rightLangs.classList.remove('hidden');
     genBtn.classList.remove('hidden');
     hint.textContent = 'Generates a 12-word seed and weaves it into ' + lang.label +
       ' prose. Pick a language above the sentence; press ⇄ to decode a sentence back into the seed.';
   } else {
-    // prose (left) -> seed (right); language sits above the prose (left).
+    // prose (left, auto-detected) -> mnemonic (right). Buttons highlight the
+    // detected prose language; click one to re-read the prose as that language.
     document.getElementById('left-label').textContent = lang.label + ' sentences';
     document.getElementById('right-label').textContent = 'BIP39 seed';
-    leftLangs.classList.remove('hidden');
-    rightLangs.classList.add('hidden');
     genBtn.classList.add('hidden');
-    hint.textContent = 'Decoding ' + lang.label + ' prose back into the BIP39 seed. ' +
-      'Edit the sentence on the left, or press ⇄ to go back to encoding.';
+    hint.textContent = 'Detected ' + lang.label + ' prose on the left and recovered the BIP39 seed. ' +
+      'Paste any sentence to decode it; press ⇄ to go back to encoding.';
   }
   updateLangHighlights();
 }
@@ -1015,6 +1023,7 @@ window.toggleMode = function() {
   const out = document.getElementById('right-box').dataset.plainText || '';
   mode = (mode === 'encode') ? 'decode' : 'encode';
   document.getElementById('left-box').value = out;
+  if (mode === 'decode') detectLeftLanguage();  // pick up the prose's language
   updateChrome();
   run();
 };
@@ -1037,7 +1046,10 @@ async function startup() {
     buildLangButtons();
     document.getElementById('left-box').addEventListener('input', () => {
       clearTimeout(inputTimer);
-      inputTimer = setTimeout(run, 250);
+      inputTimer = setTimeout(() => {
+        if (mode === 'decode') { detectLeftLanguage(); updateChrome(); }
+        run();
+      }, 250);
     });
     updateChrome();
     generateSeed();

--- a/web/index.html
+++ b/web/index.html
@@ -719,6 +719,11 @@ footer a:hover { text-decoration: underline; }
         .demo-hint { color: var(--text-dim); font-size: 0.8rem; text-align: center; margin-top: 0.85rem; }
         #demo .panel-header { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; }
         #demo .panel-header .lang-row { margin-left: auto; }
+        #left-box { flex: 1; min-height: 160px; padding: 0.75rem 0.85rem; font-size: 0.9rem;
+          font-family: var(--font-mono); line-height: 1.7; color: var(--text); outline: none;
+          white-space: pre-wrap; overflow-wrap: anywhere; overflow-y: auto; }
+        #left-box:empty::before { content: attr(data-placeholder); color: var(--text-dim); }
+        #left-box u, #right-box u { text-decoration-color: var(--accent); text-underline-offset: 2px; }
       </style>
       <div class="section-header">
         <h3>BIP39 Seed Phrase</h3>
@@ -732,7 +737,7 @@ footer a:hover { text-decoration: underline; }
             <span class="dialect-label" id="left-label">BIP39 seed</span>
           </div>
           <div class="panel-body">
-            <textarea id="left-box" placeholder="Click &ldquo;Generate seed&rdquo;, or paste a BIP39 mnemonic&hellip;"></textarea>
+            <div contenteditable="true" spellcheck="false" id="left-box" data-placeholder="Click &ldquo;Generate seed&rdquo;, or paste a BIP39 mnemonic&hellip;"></div>
           </div>
           <div class="panel-footer">
             <button class="btn-sm" id="gen-btn" onclick="generateSeed()" title="Generate a random 12-word BIP39 seed">&#127922; Generate seed</button>
@@ -866,7 +871,7 @@ import init, {
 let ready = false;
 let mode = 'encode';            // 'encode' (seed -> prose) or 'decode' (prose -> seed words)
 let currentLang = 'english';    // TARGET language (the right-side buttons), persists across modes
-let detectedLang = 'english';   // SOURCE language auto-detected from the left prose (decode only)
+let detectedLang = 'english';   // SOURCE language auto-detected from the left box (both modes)
 let inputTimer = null;
 const SEED = 42n;               // fixed seed -> deterministic prose
 
@@ -891,6 +896,36 @@ function escapeHtml(s) {
   return d.innerHTML;
 }
 
+// Normalize a word for payload-set membership: lowercase, strip non-alphanumerics
+// (Unicode-aware, so Czech/Latin accents are kept).
+function norm(w) { return w.toLowerCase().replace(/[^\p{L}\p{N}]/gu, ''); }
+function normSet(words) { return new Set((words || []).map(norm).filter(Boolean)); }
+
+// Wrap each prose word that is a payload word in <u>…</u>; whitespace preserved.
+function underlineProse(text, payloadSet) {
+  return text.split(/(\s+)/).map(tok => {
+    if (tok === '') return '';
+    if (/^\s+$/.test(tok)) return tok.replace(/\n/g, '<br>');
+    const n = norm(tok);
+    const esc = escapeHtml(tok);
+    return (n && payloadSet.has(n)) ? '<u>' + esc + '</u>' : esc;
+  }).join('');
+}
+
+function placeCaretEnd(el) {
+  const r = document.createRange();
+  r.selectNodeContents(el);
+  r.collapse(false);
+  const s = window.getSelection();
+  s.removeAllRanges();
+  s.addRange(r);
+}
+
+// ─── Left box (contenteditable) accessors ────────────────────────────
+
+function leftText() { return document.getElementById('left-box').innerText; }
+function setLeftPlain(text) { document.getElementById('left-box').textContent = text; }
+
 function showError(msg) {
   const e = document.getElementById('demo-error');
   e.textContent = msg;
@@ -900,7 +935,7 @@ function clearError() {
   document.getElementById('demo-error').classList.add('hidden');
 }
 
-function setOutput(text) {
+function setOutput(text, html) {
   const el = document.getElementById('right-box');
   if (!text) {
     el.classList.add('empty');
@@ -909,7 +944,7 @@ function setOutput(text) {
     return;
   }
   el.classList.remove('empty');
-  el.innerHTML = escapeHtml(text).replace(/\n/g, '<br>');
+  el.innerHTML = (html != null) ? html : escapeHtml(text).replace(/\n/g, '<br>');
   el.dataset.plainText = text;
 }
 
@@ -929,21 +964,6 @@ function buildLangButtons() {
   }
 }
 
-// Auto-detect the SOURCE language of the left-box prose (decode mode),
-// restricted to the languages this panel supports. Sets detectedLang; the
-// TARGET language (currentLang / right buttons) is left untouched.
-function detectLeftLanguage() {
-  const text = document.getElementById('left-box').value.trim();
-  if (!text) return;
-  try {
-    const matches = JSON.parse(wasmDetectDialect(text));
-    if (Array.isArray(matches)) {
-      const best = matches.find(m => LANGS.some(l => l.id === m.language));
-      if (best) detectedLang = best.language;
-    }
-  } catch (e) { /* keep detected language */ }
-}
-
 function updateLangHighlights() {
   document.querySelectorAll('.lang-btn').forEach(b => {
     b.classList.toggle('active', b.dataset.lang === currentLang);
@@ -956,7 +976,22 @@ function selectLang(id) {
   run();
 }
 
-// ─── Chrome (labels, which language row is shown) ─────────────────────
+// Auto-detect the SOURCE language of the left box (both modes), restricted to
+// the languages this panel supports. Sets detectedLang; the TARGET language
+// (currentLang / right buttons) is left untouched.
+function detectLeftLanguage() {
+  const text = leftText().trim();
+  if (!text) return;
+  try {
+    const matches = JSON.parse(wasmDetectDialect(text));
+    if (Array.isArray(matches)) {
+      const best = matches.find(m => LANGS.some(l => l.id === m.language));
+      if (best) detectedLang = best.language;
+    }
+  } catch (e) { /* keep detected language */ }
+}
+
+// ─── Chrome (labels, hint) ───────────────────────────────────────────
 
 function updateChrome() {
   const target = langById(currentLang);
@@ -964,9 +999,9 @@ function updateChrome() {
   const genBtn = document.getElementById('gen-btn');
   const hint = document.getElementById('demo-hint');
 
-  // The buttons live above the right box in both modes and always name the
-  // TARGET language (Google-Translate style: target on the right). The left box
-  // is the SOURCE, whose language is auto-detected in both modes.
+  // Buttons live above the right box in both modes and always name the TARGET
+  // language (Google-Translate style). The left box is the SOURCE, whose
+  // language is auto-detected in both modes.
   const srcSeedLabel = detectedLang === 'english' ? 'BIP39 seed' : (source.label + ' seed words');
   const tgtSeedLabel = currentLang === 'english' ? 'BIP39 seed' : (target.label + ' seed words');
   if (mode === 'encode') {
@@ -975,13 +1010,13 @@ function updateChrome() {
     document.getElementById('right-label').textContent = target.label + ' sentences';
     genBtn.classList.remove('hidden');
     hint.textContent = 'Generates a 12-word seed and weaves it into ' + target.label +
-      ' prose. Pick the target language on the right; press ⇄ to decode a sentence back into a seed.';
+      ' prose (payload words underlined). Pick the target language on the right; press ⇄ to decode.';
   } else {
     // prose (left, source auto-detected) -> seed words (right, target language).
     document.getElementById('left-label').textContent = source.label + ' sentences (detected)';
     document.getElementById('right-label').textContent = tgtSeedLabel;
     genBtn.classList.add('hidden');
-    hint.textContent = 'Detected ' + source.label + ' on the left; showing the seed as ' +
+    hint.textContent = 'Detected ' + source.label + ' on the left (payload words underlined); showing the seed as ' +
       target.label + (currentLang === 'english' ? ' (BIP39).' : ' words.') +
       ' Pick the target language on the right; press ⇄ to go back to encoding.';
   }
@@ -990,16 +1025,34 @@ function updateChrome() {
 
 // ─── Core encode / decode ────────────────────────────────────────────
 
+// Extract the payload words actually present in a piece of prose, in its own
+// language (source==target), so they can be underlined.
+function prosePayloadSet(proseText, langId) {
+  const l = langById(langId);
+  try {
+    const r = JSON.parse(wasmTranscode(proseText, 'transcode from ' + l.source + ' into ' + l.rawTarget, SEED));
+    if (r.error) return new Set();
+    return normSet((r.output || '').split(/\s+/).filter(Boolean));
+  } catch (e) { return new Set(); }
+}
+
+// Re-render the left box with payload words underlined (decode: left holds prose).
+function underlineLeft(proseText) {
+  const set = prosePayloadSet(proseText, detectedLang);
+  const el = document.getElementById('left-box');
+  const focused = (document.activeElement === el);
+  el.innerHTML = underlineProse(proseText, set);
+  if (focused) placeCaretEnd(el);
+}
+
 function run() {
   if (!ready) return;
   clearError();
-  const text = document.getElementById('left-box').value.trim();
+  const text = leftText().trim();
   if (!text) { setOutput(''); return; }
 
   // currentLang is the TARGET (right buttons); detectedLang is the SOURCE
-  // (auto-detected from the left box, in both modes). Encode and decode are
-  // mirror transcodes: encode reads bare words and writes prose; decode reads
-  // prose and writes bare words.
+  // (auto-detected from the left box). Encode and decode are mirror transcodes.
   const src = langById(detectedLang);
   const tgt = langById(currentLang);
   const meta = (mode === 'encode')
@@ -1009,7 +1062,16 @@ function run() {
   try {
     const result = JSON.parse(wasmTranscode(text, meta, SEED));
     if (result.error) { showError(result.error); setOutput(''); return; }
-    setOutput((result.output || '').trim());
+    const out = (result.output || '').trim();
+    if (mode === 'encode') {
+      // Right box holds the prose — underline its payload words.
+      setOutput(out, underlineProse(out, normSet(result.payload_words || [])));
+    } else {
+      // Right box holds bare seed words (no underline); left box holds the
+      // prose — underline its payload words.
+      setOutput(out);
+      underlineLeft(text);
+    }
   } catch (e) {
     showError(e.message || String(e));
     setOutput('');
@@ -1020,12 +1082,12 @@ function run() {
 
 window.generateSeed = function() {
   if (!ready) return;
-  if (mode !== 'encode') { mode = 'encode'; updateChrome(); }
+  if (mode !== 'encode') { mode = 'encode'; }
   clearError();
   try {
     const words = JSON.parse(wasmRandomWords(12, 'english', 'bip39', BigInt(Date.now())));
     if (words.error) { showError(words.error); return; }
-    document.getElementById('left-box').value = words.join(' ');
+    setLeftPlain(words.join(' '));
     detectLeftLanguage();   // a freshly generated seed detects as English
     updateChrome();
     run();
@@ -1038,8 +1100,8 @@ window.toggleMode = function() {
   // Move the current output into the input box, then flip direction.
   const out = document.getElementById('right-box').dataset.plainText || '';
   mode = (mode === 'encode') ? 'decode' : 'encode';
-  document.getElementById('left-box').value = out;
-  detectLeftLanguage();  // pick up the source language of whatever's now on the left
+  setLeftPlain(out);
+  detectLeftLanguage();   // pick up the source language of whatever's now on the left
   updateChrome();
   run();
 };

--- a/web/index.html
+++ b/web/index.html
@@ -864,8 +864,9 @@ import init, {
 } from './glossia.js';
 
 let ready = false;
-let mode = 'encode';            // 'encode' (seed -> prose) or 'decode' (prose -> seed)
-let currentLang = 'english';
+let mode = 'encode';            // 'encode' (seed -> prose) or 'decode' (prose -> seed words)
+let currentLang = 'english';    // TARGET language (the right-side buttons), persists across modes
+let detectedLang = 'english';   // SOURCE language auto-detected from the left prose (decode only)
 let inputTimer = null;
 const SEED = 42n;               // fixed seed -> deterministic prose
 
@@ -873,10 +874,13 @@ const SEED = 42n;               // fixed seed -> deterministic prose
 // "bip39" dialect, so the seed round-trips byte-for-byte. English shares the
 // payload wordlist with BIP39, so the seed words appear verbatim in the prose;
 // Latin/Czech re-express the same entropy in their own (more compact) wordlists.
+//   encodeMeta : seed -> prose in this language
+//   source     : how to read this language's prose (decode source endpoint)
+//   rawTarget  : bare payload words in this language (decode target endpoint)
 const LANGS = [
-  { id: 'english', label: 'English', encodeMeta: 'encode into english bip39', source: 'english/bip39/bip39' },
-  { id: 'latin',   label: 'Latin',   encodeMeta: 'encode into latin bip39',   source: 'latin/default/bip39' },
-  { id: 'czech',   label: 'Czech',   encodeMeta: 'encode into czech bip39',   source: 'czech/default/bip39' },
+  { id: 'english', label: 'English', encodeMeta: 'encode into english bip39', source: 'english/bip39/bip39', rawTarget: 'english/bip39/raw' },
+  { id: 'latin',   label: 'Latin',   encodeMeta: 'encode into latin bip39',   source: 'latin/default/bip39', rawTarget: 'latin/default/raw' },
+  { id: 'czech',   label: 'Czech',   encodeMeta: 'encode into czech bip39',   source: 'czech/default/bip39', rawTarget: 'czech/default/raw' },
 ];
 
 function langById(id) { return LANGS.find(l => l.id === id) || LANGS[0]; }
@@ -925,8 +929,9 @@ function buildLangButtons() {
   }
 }
 
-// Auto-detect which language the left-box prose is written in (decode mode),
-// restricted to the languages this panel supports.
+// Auto-detect the SOURCE language of the left-box prose (decode mode),
+// restricted to the languages this panel supports. Sets detectedLang; the
+// TARGET language (currentLang / right buttons) is left untouched.
 function detectLeftLanguage() {
   const text = document.getElementById('left-box').value.trim();
   if (!text) return;
@@ -934,9 +939,9 @@ function detectLeftLanguage() {
     const matches = JSON.parse(wasmDetectDialect(text));
     if (Array.isArray(matches)) {
       const best = matches.find(m => LANGS.some(l => l.id === m.language));
-      if (best) currentLang = best.language;
+      if (best) detectedLang = best.language;
     }
-  } catch (e) { /* keep current language */ }
+  } catch (e) { /* keep detected language */ }
 }
 
 function updateLangHighlights() {
@@ -954,27 +959,29 @@ function selectLang(id) {
 // ─── Chrome (labels, which language row is shown) ─────────────────────
 
 function updateChrome() {
-  const lang = langById(currentLang);
+  const target = langById(currentLang);
+  const source = langById(detectedLang);
   const genBtn = document.getElementById('gen-btn');
   const hint = document.getElementById('demo-hint');
 
-  // The language buttons live above the right box in both modes and always
-  // name the *prose* language.
+  // The buttons live above the right box in both modes and always name the
+  // TARGET language (Google-Translate style: target on the right).
   if (mode === 'encode') {
-    // seed (left) -> prose (right); buttons pick the prose language.
+    // seed (left, source) -> prose (right, target language).
     document.getElementById('left-label').textContent = 'BIP39 seed';
-    document.getElementById('right-label').textContent = lang.label + ' sentences';
+    document.getElementById('right-label').textContent = target.label + ' sentences';
     genBtn.classList.remove('hidden');
-    hint.textContent = 'Generates a 12-word seed and weaves it into ' + lang.label +
-      ' prose. Pick a language above the sentence; press ⇄ to decode a sentence back into the seed.';
+    hint.textContent = 'Generates a 12-word seed and weaves it into ' + target.label +
+      ' prose. Pick the target language on the right; press ⇄ to decode a sentence back into a seed.';
   } else {
-    // prose (left, auto-detected) -> mnemonic (right). Buttons highlight the
-    // detected prose language; click one to re-read the prose as that language.
-    document.getElementById('left-label').textContent = lang.label + ' sentences';
-    document.getElementById('right-label').textContent = 'BIP39 seed';
+    // prose (left, source auto-detected) -> seed words (right, target language).
+    const seedLabel = currentLang === 'english' ? 'BIP39 seed' : (target.label + ' seed words');
+    document.getElementById('left-label').textContent = source.label + ' sentences (detected)';
+    document.getElementById('right-label').textContent = seedLabel;
     genBtn.classList.add('hidden');
-    hint.textContent = 'Detected ' + lang.label + ' prose on the left and recovered the BIP39 seed. ' +
-      'Paste any sentence to decode it; press ⇄ to go back to encoding.';
+    hint.textContent = 'Detected ' + source.label + ' on the left; showing the seed as ' +
+      target.label + (currentLang === 'english' ? ' (BIP39).' : ' words.') +
+      ' Pick the target language on the right; press ⇄ to go back to encoding.';
   }
   updateLangHighlights();
 }
@@ -987,10 +994,12 @@ function run() {
   const text = document.getElementById('left-box').value.trim();
   if (!text) { setOutput(''); return; }
 
-  const lang = langById(currentLang);
+  // currentLang is the TARGET (right buttons). In decode, the SOURCE is the
+  // auto-detected language of the left prose.
+  const target = langById(currentLang);
   const meta = (mode === 'encode')
-    ? lang.encodeMeta
-    : 'transcode from ' + lang.source + ' into english/bip39/raw';
+    ? target.encodeMeta
+    : 'transcode from ' + langById(detectedLang).source + ' into ' + target.rawTarget;
 
   try {
     const result = JSON.parse(wasmTranscode(text, meta, SEED));

--- a/web/index.html
+++ b/web/index.html
@@ -731,8 +731,9 @@ footer a:hover { text-decoration: underline; }
         <button class="btn-sm preset-btn" data-meta="encode into english optimally" title="Generate 50 variations, pick the best">Optimal</button>
         <button class="btn-sm preset-btn" data-meta="encode into english subject" title="Email subject line format">Subject</button>
         <button class="btn-sm preset-btn" data-meta="encode into english prose" title="Literary prose format">Prose</button>
+        <button class="btn-sm preset-btn" data-meta="encode into english bip39" title="Weave a BIP39 seed into English prose — keeps your exact seed words, just adds cover words (base-N)">English BIP39</button>
         <button class="btn-sm preset-btn" data-meta="encode into latin compactly" title="Latin prose encoding">Latin</button>
-        <button class="btn-sm preset-btn" data-meta="encode into latin bip39" title="BIP39 seed phrase as Latin (base-N, fewer words)">Latin BIP39</button>
+        <button class="btn-sm preset-btn" data-meta="encode into latin bip39" title="Same BIP39 seed as Latin — fewer words (2^15 wordlist, base-N)">Latin BIP39</button>
         <button class="btn-sm preset-btn" data-meta="encode into latin spells" title="Harry Potter spell format">Spells</button>
         <button class="btn-sm preset-btn" data-meta="encode into czech naturally" title="Czech prose (official BIP39 Czech wordlist)">Czech</button>
       </div>
@@ -1684,6 +1685,11 @@ window.randomWords = function(count) {
       return;
     }
     document.getElementById('input-area').value = words.join(' ');
+    // A BIP39 seed is itself English/bip39 words, so default to the
+    // word-preserving "english bip39" dialect (base-N): the user sees their
+    // exact seed words woven into prose, not re-chunked by bitpack. From here
+    // they can click "Latin BIP39" to see the same seed in fewer Latin words.
+    document.getElementById('meta-input').value = 'encode into english bip39';
     autoRunNow();
   } catch (e) {
     errEl.textContent = e.message || String(e);

--- a/web/index.html
+++ b/web/index.html
@@ -1111,6 +1111,22 @@ window.copyOutput = function() {
   navigator.clipboard.writeText(el.dataset.plainText || '').catch(() => {});
 };
 
+// ─── Theme toggle ────────────────────────────────────────────────────
+
+const toggleBtn = document.getElementById('theme-toggle');
+function updateToggleIcon() {
+  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+  toggleBtn.innerHTML = isDark ? '&#9790;' : '&#9728;';
+}
+toggleBtn.addEventListener('click', () => {
+  const current = document.documentElement.getAttribute('data-theme');
+  const next = current === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('glossia-theme', next);
+  updateToggleIcon();
+});
+updateToggleIcon();
+
 // ─── Startup ─────────────────────────────────────────────────────────
 
 async function startup() {

--- a/web/index.html
+++ b/web/index.html
@@ -712,159 +712,56 @@ footer a:hover { text-decoration: underline; }
          INTERACTIVE DEMO
          ═══════════════════════════════════════════════════════════ -->
     <section class="demo-section" id="demo">
+      <style>
+        .lang-row { display: flex; gap: 0.35rem; flex-wrap: wrap; }
+        .lang-btn.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+        .lang-btn.active:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+        .demo-hint { color: var(--text-dim); font-size: 0.8rem; text-align: center; margin-top: 0.85rem; }
+        #demo .panel-header { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; }
+        #demo .panel-header .lang-row { margin-left: auto; }
+      </style>
       <div class="section-header">
-        <h3>Interactive Demo</h3>
-        <p>Experience the transformation live — encode and decode instantly in your browser</p>
+        <h3>BIP39 Seed Phrase</h3>
+        <p>Turn a recovery phrase into a readable sentence &mdash; and back again, byte-for-byte</p>
       </div>
 
-    <!-- Tabbed preset bar -->
-    <div style="margin-bottom:0.75rem;">
-      <div class="preset-tabs">
-        <button class="preset-tab active" data-tab="text">Text</button>
-        <button class="preset-tab" data-tab="crypto">Crypto</button>
-        <button class="preset-tab" data-tab="pipelines">Pipelines</button>
-      </div>
-      <div class="preset-tab-content active" data-tab="text">
-        <button class="btn-sm preset-btn" data-meta="encode into english naturally" title="Natural readable prose (default)">Natural</button>
-        <button class="btn-sm preset-btn" data-meta="encode into english compactly" title="Shortest sentences, maximum payload density">Compact</button>
-        <button class="btn-sm preset-btn" data-meta="encode into english minimally" title="Aggressive word count minimization">Minimal</button>
-        <button class="btn-sm preset-btn" data-meta="encode into english optimally" title="Generate 50 variations, pick the best">Optimal</button>
-        <button class="btn-sm preset-btn" data-meta="encode into english subject" title="Email subject line format">Subject</button>
-        <button class="btn-sm preset-btn" data-meta="encode into english prose" title="Literary prose format">Prose</button>
-        <button class="btn-sm preset-btn" data-meta="encode into english bip39" title="Weave a BIP39 seed into English prose — keeps your exact seed words, just adds cover words (base-N)">English BIP39</button>
-        <button class="btn-sm preset-btn" data-meta="encode into latin compactly" title="Latin prose encoding">Latin</button>
-        <button class="btn-sm preset-btn" data-meta="encode into latin bip39" title="Same BIP39 seed as Latin — fewer words (2^15 wordlist, base-N)">Latin BIP39</button>
-        <button class="btn-sm preset-btn" data-meta="encode into latin spells" title="Harry Potter spell format">Spells</button>
-        <button class="btn-sm preset-btn" data-meta="encode into czech naturally" title="Czech prose (official BIP39 Czech wordlist)">Czech</button>
-      </div>
-      <div class="preset-tab-content" data-tab="crypto">
-        <button class="btn-sm preset-btn" data-meta="encode into pgp" title="PGP encrypted message armor">PGP Message</button>
-        <button class="btn-sm preset-btn" data-meta="encode into cs/default/nip04" title="NIP-04 encrypted message">NIP-04</button>
-        <button class="btn-sm preset-btn" data-meta="encode into cs/default/nip44" title="NIP-44 encrypted message">NIP-44</button>
-        <button class="btn-sm preset-btn" data-meta="encode into cs/default/nip04_bip39" title="NIP-04 encrypted (BIP39 words)">NIP-04 (BIP39)</button>
-        <button class="btn-sm preset-btn" data-meta="encode into cs/default/nip44_bip39" title="NIP-44 encrypted (BIP39 words)">NIP-44 (BIP39)</button>
-        <button class="btn-sm preset-btn" data-meta="encode into cs/default/sig_nostr" title="Nostr signature">Nostr Sig</button>
-        <button class="btn-sm preset-btn" data-meta="encode into cs/default/sig_bip39" title="Nostr signature (BIP39 words)">Nostr Sig (BIP39)</button>
-        <button class="btn-sm preset-btn" data-meta="encode into cs/default/sig_pgp" title="PGP signature armor">PGP Sig</button>
-        <button class="btn-sm preset-btn" data-meta="encode into ascii7" title="Plain ASCII message">ASCII7</button>
-        <button class="btn-sm preset-btn" data-meta="encode into cs raw" title="Raw encoding, no armor">Raw</button>
-      </div>
-      <div class="preset-tab-content" data-tab="pipelines">
-        <button class="btn-sm preset-btn" data-meta="transcode from latin into english" title="Translate Latin prose to English prose">Latin &rarr; English</button>
-        <button class="btn-sm preset-btn" data-meta="transcode from english into latin" title="Translate English prose to Latin prose">English &rarr; Latin</button>
-        <button class="btn-sm preset-btn" data-meta="transcode from czech into english" title="Translate Czech prose to English prose">Czech &rarr; English</button>
-        <button class="btn-sm preset-btn" data-meta="encode into english naturally" title="Encode raw hex as English prose">Hex &rarr; English</button>
-        <button class="btn-sm preset-btn" data-meta="encode into latin compactly" title="Encode raw data as Latin prose">Data &rarr; Latin</button>
-      </div>
-    </div>
+      <div class="panels">
+        <!-- Left panel: input -->
+        <div class="panel panel-left">
+          <div class="panel-header">
+            <span class="dialect-label" id="left-label">BIP39 seed</span>
+            <div class="lang-row hidden" id="left-langs"></div>
+          </div>
+          <div class="panel-body">
+            <textarea id="left-box" placeholder="Click &ldquo;Generate seed&rdquo;, or paste a BIP39 mnemonic&hellip;"></textarea>
+          </div>
+          <div class="panel-footer">
+            <button class="btn-sm" id="gen-btn" onclick="generateSeed()" title="Generate a random 12-word BIP39 seed">&#127922; Generate seed</button>
+            <div id="demo-error" class="error-msg hidden" style="padding:0;"></div>
+          </div>
+        </div>
 
-    <!-- Side-by-side panels -->
-    <div class="panels">
-      <!-- Left panel: Input -->
-      <div class="panel panel-left">
-        <div class="panel-header">
-          <span class="dialect-label" id="input-dialect-label">Input: english/bip39</span>
-        </div>
-        <div class="panel-body">
-          <textarea id="input-area" placeholder="Type text to encode...">Hello, Glossia!</textarea>
-          <div id="input-image-preview" class="hidden" style="padding: 0.75rem 0.85rem;"></div>
-        </div>
-        <div class="panel-footer">
-          <div id="random-btns" style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
-            <button class="btn-sm" onclick="randomApiKey()" title="Generate a realistic sk-style API key — read it aloud or paste it into chat, then decode it back byte-for-byte">API Key</button>
-            <button class="btn-sm" onclick="randomWords(12)" title="Generate 12 random BIP39 words">BIP39 (12)</button>
-            <button class="btn-sm" onclick="randomWords(24)" title="Generate 24 random BIP39 words">BIP39 (24)</button>
-            <button class="btn-sm" onclick="randomHex()" title="Generate random hex string">Hex</button>
-            <button class="btn-sm" onclick="randomBase64()" title="Generate random base64 string">Base64</button>
-            <button class="btn-sm" onclick="randomBitcoinKey()" title="Generate random Bitcoin address (bc1...)">BTC Address</button>
-            <button class="btn-sm" onclick="randomNostrKey()" title="Generate random Nostr pubkey (npub...)">Nostr Key</button>
-          </div>
-          <div id="input-error" class="error-msg hidden" style="padding:0;"></div>
-        </div>
-        <div class="panel-footer" id="input-stats-footer" style="display:none;">
-          <div class="stats-bar">
-            <span>Format: <span class="stat-value" id="stat-input-format">-</span></span>
-            <span>Words: <span class="stat-value" id="stat-input-words">-</span></span>
-            <span>Bytes: <span class="stat-value" id="stat-input-bytes">-</span></span>
-            <span id="input-bits-info" style="margin-left: auto;"></span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Swap button -->
-      <button class="swap-btn" id="swap-btn" title="Switch between Encode and Decode" aria-label="Swap mode">
-        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"/></svg>
-      </button>
-
-      <!-- Right panel: Output only -->
-      <div class="panel panel-right">
-        <div class="panel-header">
-          <span class="dialect-label" id="output-dialect-label">Encoding with: english/bip39</span>
-          <button class="btn-sm" id="copy-btn" onclick="copyOutput()" style="display:none;">Copy</button>
-          <button class="btn-sm" id="save-btn" onclick="saveImage()" style="display:none;">Save SVG</button>
-        </div>
-        <div class="panel-body">
-          <div class="output-area empty" id="output-area">
-            Output will appear here
-          </div>
-        </div>
-        <div class="panel-footer" id="stats-footer" style="display:none;">
-          <div class="stats-bar" id="stats-bar">
-            <span>Payload: <span class="stat-value" id="stat-payload">0</span></span>
-            <span>Cover: <span class="stat-value" id="stat-cover">0</span></span>
-            <span>Total: <span class="stat-value" id="stat-total">0</span></span>
-            <span>Ratio: <span class="stat-value" id="stat-ratio">0%</span></span>
-            <span id="output-bits-info" style="margin-left: auto;"></span>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Controls section -->
-    <div class="controls-section">
-      <div class="control-group" style="flex: 3; min-width: 280px; position: relative;">
-        <label for="meta-input">
-          Meta Instruction
-          <span class="help-icon" id="help-toggle" title="Show pipeline syntax help">?</span>
-        </label>
-        <input type="text" id="meta-input" value="encode into english naturally" style="width: 100%;">
-        <div class="help-popover" id="help-popover">
-          <h5>Pipeline Syntax</h5>
-          <div style="margin-bottom:0.5rem;">
-            <code>encode into &lt;target&gt; [modifier]</code><br>
-            <code>decode from &lt;source&gt;</code><br>
-            <code>transcode from &lt;source&gt; into &lt;target&gt;</code>
-          </div>
-          <div style="margin-bottom:0.5rem;">
-            <strong style="color:var(--text);">Targets:</strong> english, latin, czech, pgp, nostr, hex, base64, ascii7
-          </div>
-          <div>
-            <strong style="color:var(--text);">Modifiers:</strong> naturally, compactly, minimally, optimally
-          </div>
-        </div>
-      </div>
-      <div class="control-group" style="min-width:140px;">
-        <label for="dialect-select">Dialect</label>
-        <select id="dialect-select" style="width:100%;">
-          <option value="">-- from presets --</option>
-        </select>
-      </div>
-      <div class="control-group">
-        <label for="seed">Seed</label>
-        <input type="number" id="seed" value="42" min="0">
-      </div>
-      <div class="control-group">
-        <button class="btn-toggle" id="cover-toggle" title="Toggle cover words on/off">
-          &#9745; Cover
+        <!-- Swap button: encode <-> decode -->
+        <button class="swap-btn" id="swap-btn" onclick="toggleMode()" title="Switch between Encode and Decode" aria-label="Swap encode/decode">
+          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"/></svg>
         </button>
+
+        <!-- Right panel: output -->
+        <div class="panel panel-right">
+          <div class="panel-header">
+            <span class="dialect-label" id="right-label">English sentences</span>
+            <div class="lang-row" id="right-langs"></div>
+          </div>
+          <div class="panel-body">
+            <div class="output-area empty" id="right-box">Output will appear here</div>
+          </div>
+          <div class="panel-footer">
+            <button class="btn-sm" id="copy-btn" onclick="copyOutput()">Copy</button>
+          </div>
+        </div>
       </div>
-    </div>
 
-    <!-- Action button (hidden, auto-run handles all operations) -->
-    <div class="action-row" style="display:none;">
-      <button class="primary" id="action-btn">Transcode</button>
-    </div>
-
+      <p class="demo-hint" id="demo-hint"></p>
     </section>
 
     <!-- ═══════════════════════════════════════════════════════════
@@ -968,840 +865,164 @@ import init, {
 } from './glossia.js';
 
 let ready = false;
-let metaInstruction = 'encode into english naturally';
-
-// Store last result for cover word toggle
-let lastEncodedText = '';
-let lastPayloadWords = [];
-let lastStats = {};
-let lastDataMode = null;
-let lastSource = null;
-let lastTarget = null;
-let lastResolvedSource = null;
-let lastIsImageOutput = false;
-let lastImageDialect = '';
-let showCoverWords = true;
-
-
-// ─── Dialect catalog ─────────────────────────────────────────────────
-
-let allDialects = [];
-
-function buildDialectCatalog() {
-  try {
-    allDialects = JSON.parse(wasmGetAllDialects());
-  } catch (e) {
-    console.warn('Failed to load dialects:', e);
-    return;
-  }
-
-  populateDialectDropdown(allDialects);
-}
-
-function resolveWordlistName(language, wordlist) {
-  if (wordlist === 'default') {
-    try {
-      return wasmGetDefaultWordlist(language) || 'default';
-    } catch (e) { return 'default'; }
-  }
-  return wordlist;
-}
-
-
-function buildMetaForDialect(language, dialect) {
-  // Build a meta instruction for a given language/dialect combination
-  if (language === 'cs') {
-    // Crypto signature dialects
-    const csMap = {
-      'nip04': 'encode into cs/default/nip04',
-      'nip44': 'encode into cs/default/nip44',
-      'nip04_bip39': 'encode into cs/default/nip04_bip39',
-      'nip44_bip39': 'encode into cs/default/nip44_bip39',
-      'pgp': 'encode into cs/default/pgp',
-      'sig': 'encode into cs/default/sig',
-      'sig_pgp': 'encode into cs/default/sig_pgp',
-      'sig_nostr': 'encode into cs/default/sig_nostr',
-      'sig_bip39': 'encode into cs/default/sig_bip39',
-      'ascii7': 'encode into cs/default/ascii7',
-      'raw': 'encode into cs/default/raw',
-    };
-    return csMap[dialect] || 'encode into ' + language + ' ' + dialect;
-  }
-  if (dialect === 'spells') return 'encode into latin spells';
-  if (dialect === 'bip39') return 'encode into ' + language + ' bip39';
-  if (dialect === 'subject') return 'encode into ' + language + ' subject';
-  if (dialect === 'prose') return 'encode into ' + language + ' prose';
-  if (dialect === 'payload_only') return 'encode into ' + language;
-  return 'encode into ' + language + ' naturally';
-}
-
-
-// ─── Dialect dropdown ────────────────────────────────────────────────
-
-function populateDialectDropdown(data) {
-  const select = document.getElementById('dialect-select');
-  // Keep the first default option
-  data.forEach(langGroup => {
-    const optgroup = document.createElement('optgroup');
-    optgroup.label = langGroup.language_display;
-
-    langGroup.dialects.forEach(d => {
-      const option = document.createElement('option');
-      option.value = langGroup.language + '|' + d.dialect;
-      const resolvedWl = resolveWordlistName(langGroup.language, d.payload_wordlist);
-      option.textContent = d.payload_wordlist === 'default'
-        ? d.display_name.replace('default', 'default (' + resolvedWl + ')')
-        : d.display_name;
-      optgroup.appendChild(option);
-    });
-
-    select.appendChild(optgroup);
-  });
-}
-
-document.getElementById('dialect-select').addEventListener('change', (e) => {
-  const val = e.target.value;
-  if (!val) return;
-  const [lang, dialect] = val.split('|');
-  const meta = buildMetaForDialect(lang, dialect);
-  document.getElementById('meta-input').value = meta;
-  autoRunNow();
-});
-
-// ─── Preset tabs ─────────────────────────────────────────────────────
-
-document.querySelectorAll('.preset-tab').forEach(tab => {
-  tab.addEventListener('click', () => {
-    const tabName = tab.dataset.tab;
-    document.querySelectorAll('.preset-tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tabName));
-    document.querySelectorAll('.preset-tab-content').forEach(c => c.classList.toggle('active', c.dataset.tab === tabName));
-  });
-});
-
-// ─── Help popover ────────────────────────────────────────────────────
-
-document.getElementById('help-toggle').addEventListener('click', (e) => {
-  e.stopPropagation();
-  document.getElementById('help-popover').classList.toggle('visible');
-});
-document.addEventListener('click', (e) => {
-  const popover = document.getElementById('help-popover');
-  if (!popover.contains(e.target) && e.target.id !== 'help-toggle') {
-    popover.classList.remove('visible');
-  }
-});
-
-// ─── Load preset (shared by catalog, pipeline guide, hero) ──────────
-
-window.loadPreset = function(meta) {
-  document.getElementById('meta-input').value = meta;
-  autoRunNow();
-  // Scroll to demo
-  const demo = document.getElementById('demo');
-  if (demo) {
-    demo.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }
-};
-
-
-// ─── Core transcode function ─────────────────────────────────────────
-
-function doTranscode() {
-  if (!ready) return;
-
-  const input = document.getElementById('input-area').value;
-  const instruction = document.getElementById('meta-input').value.trim();
-  const seed = parseInt(document.getElementById('seed').value) || 0;
-
-  if (!instruction) return;
-
-  // If result is an encode (not decode-from-image), restore textarea visibility
-  const isDecodeFromImage = instruction.toLowerCase().startsWith('decode from image');
-  if (!isDecodeFromImage) {
-    const preview = document.getElementById('input-image-preview');
-    if (preview && !preview.classList.contains('hidden')) {
-      preview.innerHTML = '';
-      preview.classList.add('hidden');
-      document.getElementById('input-area').style.display = '';
-    }
-  }
-
-  const errEl = document.getElementById('input-error');
-  errEl.classList.add('hidden');
-
-  // ── Image SVG decode: use hex colors extracted from the SVG ─────
-  if (isDecodeFromImage) {
-    const preview = document.getElementById('input-image-preview');
-    if (preview && preview.dataset.hexColors) {
-      try {
-        const hexColors = preview.dataset.hexColors;
-        const palette = preview.dataset.palette || 'viridis';
-        const decodeResult = JSON.parse(wasmDecodeImageFromColors(hexColors, palette));
-
-        if (decodeResult.error) {
-          errEl.textContent = decodeResult.error;
-          errEl.classList.remove('hidden');
-          return;
-        }
-
-        const outEl = document.getElementById('output-area');
-        outEl.classList.remove('empty');
-        outEl.textContent = decodeResult.decoded_text || '';
-        outEl.dataset.plainText = decodeResult.decoded_text || '';
-        document.getElementById('copy-btn').style.display = '';
-        document.getElementById('save-btn').style.display = 'none';
-
-        // Update labels
-        document.getElementById('input-dialect-label').textContent = 'Input: image/' + palette;
-        document.getElementById('output-dialect-label').textContent = 'Output: decoded';
-
-        // Show output bits info
-        const outputBitsEl = document.getElementById('output-bits-info');
-        if (decodeResult.bits_per_color) {
-          outputBitsEl.textContent = decodeResult.payload_words.length + ' colors x '
-            + decodeResult.bits_per_color.toFixed(2) + ' bits/color = '
-            + Math.floor(decodeResult.payload_words.length * decodeResult.bits_per_color) + ' bits';
-        }
-
-        // Show decode stats
-        document.getElementById('stat-payload').textContent = decodeResult.payload_words ? decodeResult.payload_words.length : 0;
-        document.getElementById('stat-cover').textContent = 0;
-        document.getElementById('stat-total').textContent = decodeResult.payload_words ? decodeResult.payload_words.length : 0;
-        document.getElementById('stat-ratio').textContent = '100.0%';
-        document.getElementById('stats-footer').style.display = '';
-
-        lastEncodedText = decodeResult.decoded_text || '';
-        lastPayloadWords = decodeResult.payload_words || [];
-        lastIsImageOutput = false;
-        lastImageDialect = '';
-        return;
-      } catch (e) {
-        errEl.textContent = 'Image decode error: ' + (e.message || String(e));
-        errEl.classList.remove('hidden');
-        return;
-      }
-    }
-  }
-
-  try {
-    const result = JSON.parse(wasmTranscode(input, instruction, BigInt(seed)));
-
-    if (result.error) {
-      errEl.textContent = result.error;
-      errEl.classList.remove('hidden');
-      const outEl = document.getElementById('output-area');
-      outEl.innerHTML = 'Output will appear here';
-      outEl.classList.add('empty');
-      outEl.dataset.plainText = '';
-      document.getElementById('copy-btn').style.display = 'none';
-      document.getElementById('save-btn').style.display = 'none';
-      document.getElementById('stats-footer').style.display = 'none';
-      document.getElementById('input-stats-footer').style.display = 'none';
-      return;
-    }
-
-    // Update panel labels from pipeline source/target
-    const inputLabel = document.getElementById('input-dialect-label');
-    const outputLabel = document.getElementById('output-dialect-label');
-    inputLabel.textContent = 'Input: ' + friendlySourceName(result.resolved_source || result.source || 'auto');
-    outputLabel.textContent = 'Output: ' + (result.target || 'auto');
-
-    // Store result for cover word toggle — convert newlines to <br> for HTML rendering
-    lastEncodedText = (result.output || '').replace(/\n/g, ' <br> ');
-    lastPayloadWords = result.payload_words || [];
-    lastStats = result.stats || {};
-    lastDataMode = result.data_mode || null;
-    lastSource = result.source || null;
-    lastTarget = result.target || null;
-    lastResolvedSource = result.resolved_source || null;
-
-    // Detect image output from target endpoint (e.g. "image/plasma/voronoi")
-    const target = result.target || '';
-    if (target.startsWith('image/') || target === 'image') {
-      lastIsImageOutput = true;
-      const parts = target.split('/');
-      lastImageDialect = parts.length >= 3 ? parts[2] : (parts[1] || 'voronoi');
-      const detectedPalette = parts.length >= 3 ? parts[1] : 'default';
-      // Sync button highlights
-      if (detectedPalette !== 'default') {
-        imagePalette = detectedPalette;
-        document.querySelectorAll('.image-palette-btn').forEach(b => b.classList.toggle('active', b.dataset.palette === imagePalette));
-      }
-      imageLayout = lastImageDialect;
-      document.querySelectorAll('.image-layout-btn').forEach(b => b.classList.toggle('active', b.dataset.layout === imageLayout));
-    } else {
-      lastIsImageOutput = false;
-      lastImageDialect = '';
-    }
-
-    // Update output display
-    const outEl = document.getElementById('output-area');
-    outEl.classList.remove('empty');
-    document.getElementById('copy-btn').style.display = lastIsImageOutput ? 'none' : '';
-    document.getElementById('save-btn').style.display = lastIsImageOutput ? '' : 'none';
-
-    if (lastStats.payload_count !== undefined) {
-      document.getElementById('stats-footer').style.display = '';
-    }
-
-    updateOutputDisplay();
-    updateBitCounts();
-  } catch (e) {
-    errEl.textContent = e.message || String(e);
-    errEl.classList.remove('hidden');
-  }
-}
-
-// ─── Output display (cover word toggle) ──────────────────────────────
-
-function updateOutputDisplay() {
-  if (!lastEncodedText) return;
-
-  const outEl = document.getElementById('output-area');
-
-  // ── Image SVG rendering ──────────────────────────────────────────
-  if (lastIsImageOutput) {
-    const textNotation = lastEncodedText.replace(/ <br> /g, '\n').replace(/<br>/g, '\n');
-    const seed = parseInt(document.getElementById('seed').value) || 42;
-    let svgHtml = '';
-    try {
-      const svgResult = wasmRenderImageSvg(textNotation, lastImageDialect, 400, 400, BigInt(seed), imageShape === 'disk');
-      if (svgResult.startsWith('<')) {
-        svgHtml = svgResult;
-      } else {
-        const parsed = JSON.parse(svgResult);
-        svgHtml = '<div class="error-msg">' + escapeHtml(parsed.error || 'SVG render failed') + '</div>';
-      }
-    } catch (e) {
-      svgHtml = '<div class="error-msg">SVG render error: ' + escapeHtml(e.message || String(e)) + '</div>';
-    }
-    outEl.innerHTML = svgHtml;
-    outEl.dataset.plainText = textNotation;
-
-    // Show image-specific stats: color count and bits/color
-    if (lastStats.payload_count !== undefined) {
-      const nColors = lastStats.payload_count || 0;
-      document.getElementById('stat-payload').textContent = nColors + ' colors';
-      document.getElementById('stat-cover').textContent = '';
-      document.getElementById('stat-total').textContent = '';
-      // Compute bits per color from target wordlist
-      let bpc = 0;
-      try {
-        const target = lastTarget || '';
-        const parts = target.split('/');
-        if (parts.length >= 2) {
-          const bpcResult = JSON.parse(wasmGetBitsPerWord('image', parts[1]));
-          if (bpcResult.bits_per_word) bpc = bpcResult.bits_per_word;
-        }
-      } catch (e) { /* ignore */ }
-      const totalBits = Math.floor(nColors * bpc);
-      document.getElementById('stat-ratio').textContent = bpc.toFixed(1) + ' bits/color = ' + totalBits + ' bits';
-      document.getElementById('stats-footer').style.display = '';
-    }
-    return;
-  }
-
-  if (lastPayloadWords.length > 0 && lastStats.payload_count !== undefined) {
-    if (showCoverWords) {
-      const payloadSet = new Set(lastPayloadWords.map(w => w.toLowerCase()));
-      const words = lastEncodedText.split(/\s+/);
-      const html = words.map(w => {
-        if (w === '<br>') return '<br>';
-        const clean = w.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-        if (payloadSet.has(clean)) {
-          return '<mark>' + escapeHtml(w) + '</mark>';
-        }
-        return escapeHtml(w);
-      }).join(' ');
-      outEl.innerHTML = html;
-      outEl.dataset.plainText = lastEncodedText.replace(/<br>/g, '\n');
-    } else {
-      const payloadOnly = lastPayloadWords.join(' ');
-      const html = lastPayloadWords.map(w => '<mark>' + escapeHtml(w) + '</mark>').join(' ');
-      outEl.innerHTML = html;
-      outEl.dataset.plainText = payloadOnly;
-    }
-
-    document.getElementById('stat-payload').textContent = lastStats.payload_count || 0;
-    document.getElementById('stat-cover').textContent = showCoverWords ? (lastStats.cover_count || 0) : 0;
-    document.getElementById('stat-total').textContent = showCoverWords ? (lastStats.total_words || 0) : (lastStats.payload_count || 0);
-    const ratio = showCoverWords
-      ? (lastStats.ratio || 0)
-      : 1.0;
-    document.getElementById('stat-ratio').textContent = (ratio * 100).toFixed(1) + '%';
-    document.getElementById('stats-footer').style.display = '';
-  } else {
-    outEl.innerHTML = escapeHtml(lastEncodedText || '(empty)').replace(/&lt;br&gt;/g, '<br>');
-    outEl.dataset.plainText = lastEncodedText.replace(/ <br> /g, '\n');
-
-    if (lastPayloadWords.length > 0) {
-      document.getElementById('stat-payload').textContent = lastPayloadWords.length;
-      document.getElementById('stat-cover').textContent = '-';
-      document.getElementById('stat-total').textContent = '-';
-      document.getElementById('stat-ratio').textContent = '-';
-      document.getElementById('stats-footer').style.display = '';
-    } else {
-      document.getElementById('stats-footer').style.display = 'none';
-    }
-  }
-}
-
-// ─── Bit count display ───────────────────────────────────────────────
-
-function updateBitCounts() {
-  const inputBitsEl = document.getElementById('input-bits-info');
-  const outputBitsEl = document.getElementById('output-bits-info');
-  const inputStatsFooter = document.getElementById('input-stats-footer');
-  if (!inputBitsEl || !outputBitsEl) return;
-
-  const input = document.getElementById('input-area').value.trim();
-
-  if (input) {
-    let inputBits = 0;
-    let inputBytes = 0;
-    let inputWords = input.split(/\s+/).filter(w => w.length > 0).length;
-    let formatLabel = lastDataMode || 'text';
-
-    // First, check if input matches a known wordlist
-    let detected = null;
-    try {
-      const matches = JSON.parse(wasmDetectDialect(input));
-      if (matches.length > 0 && matches[0].hit_rate > 0.5) {
-        detected = matches[0];
-      }
-    } catch (e) { /* ignore detection errors */ }
-
-    if (detected) {
-      formatLabel = detected.language + '/' + detected.wordlist;
-      let bitsPerWord = 11;
-      try {
-        const bpw = JSON.parse(wasmGetBitsPerWord(detected.language, detected.wordlist));
-        if (typeof bpw === 'number') bitsPerWord = bpw;
-      } catch (e) { /* fallback to 11 */ }
-      inputBits = Math.floor(detected.hits * bitsPerWord);
-      inputBytes = Math.ceil(inputBits / 8);
-    } else if (lastDataMode === 'hex') {
-      inputBytes = Math.floor(input.replace(/\s+/g, '').length / 2);
-      inputBits = inputBytes * 8;
-      formatLabel = 'hex';
-    } else if (lastDataMode === 'base64') {
-      inputBytes = Math.floor(input.replace(/\s+/g, '').length / 4) * 3;
-      inputBits = inputBytes * 8;
-      formatLabel = 'base64';
-    } else if (lastDataMode === 'ascii7') {
-      inputBytes = input.length;
-      inputBits = input.length * 7;
-      formatLabel = 'ascii7';
-    } else if (lastDataMode === 'bytes8') {
-      inputBytes = new TextEncoder().encode(input).length;
-      inputBits = inputBytes * 8;
-      formatLabel = 'bytes';
-    }
-
-    document.getElementById('stat-input-format').textContent = formatLabel;
-    document.getElementById('stat-input-words').textContent = inputWords;
-    document.getElementById('stat-input-bytes').textContent = inputBytes;
-    inputBitsEl.textContent = inputBits > 0 ? inputBits + ' bits' : '';
-    if (inputStatsFooter) inputStatsFooter.style.display = '';
-  } else {
-    inputBitsEl.textContent = '';
-    if (inputStatsFooter) inputStatsFooter.style.display = 'none';
-  }
-
-  if (lastPayloadWords.length > 0 && lastStats.payload_count !== undefined) {
-    // Derive bits per word from the target endpoint (e.g. "english/bip39/body")
-    let bitsPerWord = 11;
-    let unitLabel = 'bits/word';
-    if (lastTarget) {
-      const tParts = lastTarget.split('/');
-      if (tParts.length >= 2) {
-        try {
-          const bpw = JSON.parse(wasmGetBitsPerWord(tParts[0], tParts[1]));
-          if (bpw && typeof bpw.bits_per_word === 'number') bitsPerWord = bpw.bits_per_word;
-        } catch (e) { /* keep default */ }
-      }
-      // For image output, label as bits/color
-      if (lastIsImageOutput) unitLabel = 'bits/color';
-    }
-    const outputBits = Math.floor(lastPayloadWords.length * bitsPerWord);
-    outputBitsEl.textContent = lastPayloadWords.length + ' x '
-      + bitsPerWord.toFixed(2) + ' ' + unitLabel + ' = ~' + outputBits + ' bits';
-  } else {
-    outputBitsEl.textContent = '';
-  }
-}
-
-// ─── Debounced auto-run ──────────────────────────────────────────────
-
-let autoRunTimer = null;
-
-function autoRun(delay = 300) {
-  clearTimeout(autoRunTimer);
-  autoRunTimer = setTimeout(() => {
-    if (!ready) return;
-    doTranscode();
-  }, delay);
-}
-
-function autoRunNow() { autoRun(0); }
-
-// ─── Event listeners ─────────────────────────────────────────────────
-
-document.getElementById('input-area')?.addEventListener('input', () => autoRun(300));
-document.getElementById('seed')?.addEventListener('input', () => autoRun());
-document.getElementById('meta-input')?.addEventListener('input', () => autoRun(300));
-
-// Preset buttons
-document.querySelectorAll('.preset-btn').forEach(btn => {
-  btn.addEventListener('click', () => {
-    const meta = btn.dataset.meta;
-    document.getElementById('meta-input').value = meta;
-    autoRunNow();
-  });
-});
-
-// ─── SVG color extraction for image decode ────────────────────────
-
-function extractColorsFromSvg(svgEl) {
-  // Extract fill colors from SVG elements with data-idx attributes.
-  // data-idx preserves the original payload order regardless of spatial permutation.
-  const entries = [];
-  const elements = svgEl.querySelectorAll('[data-idx][fill]');
-  for (const el of elements) {
-    const fill = el.getAttribute('fill');
-    const idx = parseInt(el.getAttribute('data-idx'), 10);
-    if (fill && fill.startsWith('#') && fill.length === 7 && !isNaN(idx)) {
-      entries.push({ idx, fill });
-    }
-  }
-  // Sort by original payload index to recover encode order
-  entries.sort((a, b) => a.idx - b.idx);
-  return entries.map(e => e.fill);
-}
-
-// ─── Image layout/palette buttons ─────────────────────────────────
-
-let imageLayout = 'voronoi';
-let imagePalette = 'viridis';
-let imageShape = 'rect';
-
-function buildImageMeta() {
-  return 'encode into image ' + imagePalette + ' ' + imageLayout;
-}
-
-document.querySelectorAll('.image-layout-btn').forEach(btn => {
-  btn.addEventListener('click', () => {
-    imageLayout = btn.dataset.layout;
-    document.querySelectorAll('.image-layout-btn').forEach(b => b.classList.toggle('active', b.dataset.layout === imageLayout));
-    document.getElementById('meta-input').value = buildImageMeta();
-    autoRunNow();
-  });
-});
-
-document.querySelectorAll('.image-palette-btn').forEach(btn => {
-  btn.addEventListener('click', () => {
-    imagePalette = btn.dataset.palette;
-    document.querySelectorAll('.image-palette-btn').forEach(b => b.classList.toggle('active', b.dataset.palette === imagePalette));
-    document.getElementById('meta-input').value = buildImageMeta();
-    autoRunNow();
-  });
-});
-
-document.querySelectorAll('.image-shape-btn').forEach(btn => {
-  btn.addEventListener('click', () => {
-    imageShape = btn.dataset.shape;
-    document.querySelectorAll('.image-shape-btn').forEach(b => b.classList.toggle('active', b.dataset.shape === imageShape));
-    // Shape only affects rendering, not encoding — just re-render
-    if (lastIsImageOutput && lastEncodedText) updateOutputDisplay();
-  });
-});
-
-// Cover word toggle
-document.getElementById('cover-toggle')?.addEventListener('click', (e) => {
-  e.preventDefault();
-  showCoverWords = !showCoverWords;
-  const btn = document.getElementById('cover-toggle');
-  if (showCoverWords) {
-    btn.classList.remove('off');
-    btn.innerHTML = '&#9745; Cover';
-  } else {
-    btn.classList.add('off');
-    btn.innerHTML = '&#9744; Cover';
-  }
-  updateOutputDisplay();
-});
-
-// Swap button
-document.getElementById('swap-btn').addEventListener('click', () => {
-  const inputArea = document.getElementById('input-area');
-  const outputArea = document.getElementById('output-area');
-  const metaInput = document.getElementById('meta-input');
-  const preview = document.getElementById('input-image-preview');
-
-  const instruction = metaInput.value.trim();
-  // If the encode step auto-detected a structured source (e.g. BIP39 mnemonic
-  // as english/bip39/raw, or a bc1q address as crypto/btc/bip173), construct a
-  // transcode back to the original format instead of a plain decode.
-  // When swapping back from such a transcode, restore the "encode into" form.
-  let reversed;
-  const lower = instruction.toLowerCase().trim();
-  const isResolvedLanguage = lastResolvedSource && lastResolvedSource.includes('/');
-  if (isResolvedLanguage && lower.startsWith('encode into ')) {
-    const targetLang = instruction.substring('encode into '.length);
-    reversed = 'translate from ' + targetLang + ' into ' + lastResolvedSource;
-  } else if (lower.match(/^translate\s+from\s+(.+?)\s+into\s+(\S+\/\S+)$/)) {
-    // Reverse of a resolved-source transcode: restore "encode into <source-lang>"
-    const m = lower.match(/^translate\s+from\s+(.+?)\s+into\s+(\S+\/\S+)$/);
-    if (m) {
-      reversed = 'encode into ' + m[1];
-    } else {
-      reversed = reverseMetaInstruction(instruction);
-    }
-  } else {
-    reversed = reverseMetaInstruction(instruction);
-  }
-  metaInput.value = reversed;
-
-  // For image output, move the SVG into the left panel preview and extract colors for decode
-  if (lastIsImageOutput) {
-    const svgEl = outputArea.querySelector('svg');
-    if (svgEl) {
-      // Extract fill colors from SVG payload elements (not background rects)
-      const hexColors = extractColorsFromSvg(svgEl);
-      preview.innerHTML = svgEl.outerHTML;
-      preview.classList.remove('hidden');
-      inputArea.style.display = 'none';
-      // Store hex colors as JSON on the preview element for decode
-      preview.dataset.hexColors = JSON.stringify(hexColors);
-      preview.dataset.palette = imagePalette;
-    }
-    // Keep text notation in textarea as fallback
-    inputArea.value = outputArea.dataset.plainText || '';
-  } else {
-    const currentOutput = outputArea.dataset.plainText || outputArea.textContent.trim();
-    inputArea.value = currentOutput;
-    preview.innerHTML = '';
-    preview.classList.add('hidden');
-    inputArea.style.display = '';
-  }
-
-  outputArea.innerHTML = 'Output will appear here';
-  outputArea.classList.add('empty');
-  outputArea.dataset.plainText = '';
-  document.getElementById('copy-btn').style.display = 'none';
-  document.getElementById('stats-footer').style.display = 'none';
-  document.getElementById('input-stats-footer').style.display = 'none';
-  document.getElementById('input-error').classList.add('hidden');
-  document.getElementById('input-bits-info').textContent = '';
-  document.getElementById('output-bits-info').textContent = '';
-
-  lastEncodedText = '';
-  lastPayloadWords = [];
-  lastStats = {};
-  lastDataMode = null;
-  lastSource = null;
-  lastTarget = null;
-  lastResolvedSource = null;
-  lastIsImageOutput = false;
-  lastImageDialect = '';
-
-  autoRunNow();
-});
-
-function friendlySourceName(source) {
-  if (!source || source === 'auto') return 'auto';
-  const map = {
-    'crypto/btc/bech32/bip173': 'btc address (bc1q)',
-    'crypto/btc/bech32/bip173-test': 'btc testnet (tb1q)',
-    'crypto/btc/bech32/bip350': 'btc taproot (bc1p)',
-    'crypto/btc/bech32/bip350-test': 'btc taproot testnet (tb1p)',
-    'crypto/nostr/bech32/pub': 'nostr pubkey (npub)',
-    'crypto/nostr/bech32/sec': 'nostr secret (nsec)',
-    'crypto/nostr/bech32/note': 'nostr note',
-    'crypto/ln/bech32/main': 'lightning invoice',
-    'crypto/ln/bech32/test': 'lightning testnet',
-    'crypto/cashu/base64url/a': 'cashu token',
-    'crypto/cashu/base64url/b': 'cashu token v2',
-  };
-  if (map[source]) return map[source];
-  // english/bip39/raw → "bip39 mnemonic"
-  if (source.endsWith('/raw')) {
-    const parts = source.split('/');
-    return parts[1] + ' mnemonic';
-  }
-  return source;
-}
-
-function reverseMetaInstruction(instruction) {
-  const lower = instruction.toLowerCase().trim();
-  if (lower.startsWith('encode into ')) {
-    return 'decode from ' + instruction.substring('encode into '.length);
-  }
-  if (lower.startsWith('decode from ')) {
-    return 'encode into ' + instruction.substring('decode from '.length);
-  }
-  const translateMatch = lower.match(/^translate\s+from\s+(.+?)\s+into\s+(.+)$/);
-  if (translateMatch) {
-    return 'translate from ' + translateMatch[2] + ' into ' + translateMatch[1];
-  }
-  return instruction
-    .replace(/\binto\b/gi, '__INTO__')
-    .replace(/\bfrom\b/gi, 'into')
-    .replace(/__INTO__/g, 'from');
-}
-
-// ─── Random input generators ─────────────────────────────────────────
-
-function parseTargetLanguage() {
-  const instruction = document.getElementById('meta-input').value.trim().toLowerCase();
-  const match = instruction.match(/(?:into|as|to)\s+(english|latin|czech)/);
-  if (match) return match[1];
-  if (instruction.includes('english')) return 'english';
-  if (instruction.includes('latin')) return 'latin';
-  if (instruction.includes('czech')) return 'czech';
-  return 'english';
-}
-
-function targetWordlist() {
-  const lang = parseTargetLanguage();
-  // Languages whose default payload lives in payload.yaml (not payload_bip39.yaml)
-  if (lang === 'latin' || lang === 'czech') return 'default';
-  return 'bip39';
-}
-
-window.randomWords = function(count) {
-  if (!ready) return;
-  // BIP39 always uses the English BIP39 wordlist regardless of selected dialect
-  const lang = 'english';
-  const wl = 'bip39';
-  const seed = Date.now();
-  const errEl = document.getElementById('input-error');
-  errEl.classList.add('hidden');
-  try {
-    const words = JSON.parse(wasmRandomWords(count, lang, wl, BigInt(seed)));
-    if (words.error) {
-      errEl.textContent = words.error;
-      errEl.classList.remove('hidden');
-      return;
-    }
-    document.getElementById('input-area').value = words.join(' ');
-    // A BIP39 seed is itself English/bip39 words, so default to the
-    // word-preserving "english bip39" dialect (base-N): the user sees their
-    // exact seed words woven into prose, not re-chunked by bitpack. From here
-    // they can click "Latin BIP39" to see the same seed in fewer Latin words.
-    document.getElementById('meta-input').value = 'encode into english bip39';
-    autoRunNow();
-  } catch (e) {
-    errEl.textContent = e.message || String(e);
-    errEl.classList.remove('hidden');
-  }
-};
-
-window.randomApiKey = function() {
-  // A realistic "sk-"-style secret token: the headline last-mile scenario —
-  // turn an opaque key into readable prose you can dictate or paste, then
-  // decode it back byte-for-byte.
-  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  const length = 48;
-  const randomValues = crypto.getRandomValues(new Uint8Array(length));
-  const chars = Array.from(randomValues)
-    .map(v => alphabet[v % alphabet.length])
-    .join('');
-  document.getElementById('input-area').value = 'sk-' + chars;
-  autoRunNow();
-};
-
-window.randomHex = function() {
-  const bytes = 32;
-  const hex = Array.from(crypto.getRandomValues(new Uint8Array(bytes)))
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('');
-  document.getElementById('input-area').value = hex.toUpperCase();
-  autoRunNow();
-};
-
-window.randomBase64 = function() {
-  const bytes = 32;
-  const randomBytes = crypto.getRandomValues(new Uint8Array(bytes));
-  const base64 = btoa(String.fromCharCode(...randomBytes));
-  document.getElementById('input-area').value = base64;
-  autoRunNow();
-};
-
-window.randomBitcoinKey = function() {
-  const bech32Alphabet = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
-  const length = 39;
-  const randomValues = crypto.getRandomValues(new Uint8Array(length));
-  const chars = Array.from(randomValues)
-    .map(v => bech32Alphabet[v % bech32Alphabet.length])
-    .join('');
-  document.getElementById('input-area').value = 'bc1' + chars;
-  autoRunNow();
-};
-
-window.randomNostrKey = function() {
-  const bech32Alphabet = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
-  const length = 59;
-  const randomValues = crypto.getRandomValues(new Uint8Array(length));
-  const chars = Array.from(randomValues)
-    .map(v => bech32Alphabet[v % bech32Alphabet.length])
-    .join('');
-  document.getElementById('input-area').value = 'npub' + chars;
-  autoRunNow();
-};
-
-// ─── Utilities ───────────────────────────────────────────────────────
-
-window.copyOutput = function() {
-  const el = document.getElementById('output-area');
-  const text = el.dataset.plainText || el.textContent;
-  navigator.clipboard.writeText(text).catch(() => {});
-};
-
-window.saveImage = function() {
-  const svgEl = document.getElementById('output-area').querySelector('svg');
-  if (!svgEl) return;
-  const svgData = new XMLSerializer().serializeToString(svgEl);
-  const blob = new Blob([svgData], { type: 'image/svg+xml' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'glossia.svg';
-  a.click();
-  URL.revokeObjectURL(url);
-};
+let mode = 'encode';            // 'encode' (seed -> prose) or 'decode' (prose -> seed)
+let currentLang = 'english';
+let inputTimer = null;
+const SEED = 42n;               // fixed seed -> deterministic prose
+
+// Languages offered for the BIP39 panel. Each has a word-preserving base_n
+// "bip39" dialect, so the seed round-trips byte-for-byte. English shares the
+// payload wordlist with BIP39, so the seed words appear verbatim in the prose;
+// Latin/Czech re-express the same entropy in their own (more compact) wordlists.
+const LANGS = [
+  { id: 'english', label: 'English', encodeMeta: 'encode into english bip39', source: 'english/bip39/bip39' },
+  { id: 'latin',   label: 'Latin',   encodeMeta: 'encode into latin bip39',   source: 'latin/default/bip39' },
+  { id: 'czech',   label: 'Czech',   encodeMeta: 'encode into czech bip39',   source: 'czech/default/bip39' },
+];
+
+function langById(id) { return LANGS.find(l => l.id === id) || LANGS[0]; }
 
 function escapeHtml(s) {
-  const div = document.createElement('div');
-  div.textContent = s;
-  return div.innerHTML;
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
 }
 
-// Theme toggle
-const toggleBtn = document.getElementById('theme-toggle');
-function updateToggleIcon() {
-  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-  toggleBtn.innerHTML = isDark ? '&#9790;' : '&#9728;';
+function showError(msg) {
+  const e = document.getElementById('demo-error');
+  e.textContent = msg;
+  e.classList.remove('hidden');
 }
-toggleBtn.addEventListener('click', () => {
-  const current = document.documentElement.getAttribute('data-theme');
-  const next = current === 'dark' ? 'light' : 'dark';
-  document.documentElement.setAttribute('data-theme', next);
-  localStorage.setItem('glossia-theme', next);
-  updateToggleIcon();
-});
-updateToggleIcon();
+function clearError() {
+  document.getElementById('demo-error').classList.add('hidden');
+}
 
-// Smooth scroll for anchor links
-document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-  anchor.addEventListener('click', function (e) {
-    e.preventDefault();
-    const target = document.querySelector(this.getAttribute('href'));
-    if (target) {
-      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+function setOutput(text) {
+  const el = document.getElementById('right-box');
+  if (!text) {
+    el.classList.add('empty');
+    el.textContent = 'Output will appear here';
+    el.dataset.plainText = '';
+    return;
+  }
+  el.classList.remove('empty');
+  el.innerHTML = escapeHtml(text).replace(/\n/g, '<br>');
+  el.dataset.plainText = text;
+}
+
+// ─── Language buttons ────────────────────────────────────────────────
+
+function buildLangButtons() {
+  for (const rowId of ['left-langs', 'right-langs']) {
+    const row = document.getElementById(rowId);
+    row.innerHTML = '';
+    for (const l of LANGS) {
+      const b = document.createElement('button');
+      b.className = 'btn-sm lang-btn';
+      b.dataset.lang = l.id;
+      b.textContent = l.label;
+      b.title = l.label + ' prose';
+      b.addEventListener('click', () => selectLang(l.id));
+      row.appendChild(b);
     }
+  }
+}
+
+function updateLangHighlights() {
+  document.querySelectorAll('.lang-btn').forEach(b => {
+    b.classList.toggle('active', b.dataset.lang === currentLang);
   });
-});
+}
+
+function selectLang(id) {
+  currentLang = id;
+  updateChrome();
+  run();
+}
+
+// ─── Chrome (labels, which language row is shown) ─────────────────────
+
+function updateChrome() {
+  const lang = langById(currentLang);
+  const leftLangs = document.getElementById('left-langs');
+  const rightLangs = document.getElementById('right-langs');
+  const genBtn = document.getElementById('gen-btn');
+  const hint = document.getElementById('demo-hint');
+
+  if (mode === 'encode') {
+    // seed (left) -> prose (right); language sits above the prose (right).
+    document.getElementById('left-label').textContent = 'BIP39 seed';
+    document.getElementById('right-label').textContent = lang.label + ' sentences';
+    leftLangs.classList.add('hidden');
+    rightLangs.classList.remove('hidden');
+    genBtn.classList.remove('hidden');
+    hint.textContent = 'Generates a 12-word seed and weaves it into ' + lang.label +
+      ' prose. Pick a language above the sentence; press ⇄ to decode a sentence back into the seed.';
+  } else {
+    // prose (left) -> seed (right); language sits above the prose (left).
+    document.getElementById('left-label').textContent = lang.label + ' sentences';
+    document.getElementById('right-label').textContent = 'BIP39 seed';
+    leftLangs.classList.remove('hidden');
+    rightLangs.classList.add('hidden');
+    genBtn.classList.add('hidden');
+    hint.textContent = 'Decoding ' + lang.label + ' prose back into the BIP39 seed. ' +
+      'Edit the sentence on the left, or press ⇄ to go back to encoding.';
+  }
+  updateLangHighlights();
+}
+
+// ─── Core encode / decode ────────────────────────────────────────────
+
+function run() {
+  if (!ready) return;
+  clearError();
+  const text = document.getElementById('left-box').value.trim();
+  if (!text) { setOutput(''); return; }
+
+  const lang = langById(currentLang);
+  const meta = (mode === 'encode')
+    ? lang.encodeMeta
+    : 'transcode from ' + lang.source + ' into english/bip39/raw';
+
+  try {
+    const result = JSON.parse(wasmTranscode(text, meta, SEED));
+    if (result.error) { showError(result.error); setOutput(''); return; }
+    setOutput((result.output || '').trim());
+  } catch (e) {
+    showError(e.message || String(e));
+    setOutput('');
+  }
+}
+
+// ─── Actions (called from inline onclick) ─────────────────────────────
+
+window.generateSeed = function() {
+  if (!ready) return;
+  if (mode !== 'encode') { mode = 'encode'; updateChrome(); }
+  clearError();
+  try {
+    const words = JSON.parse(wasmRandomWords(12, 'english', 'bip39', BigInt(Date.now())));
+    if (words.error) { showError(words.error); return; }
+    document.getElementById('left-box').value = words.join(' ');
+    run();
+  } catch (e) {
+    showError(e.message || String(e));
+  }
+};
+
+window.toggleMode = function() {
+  // Move the current output into the input box, then flip direction.
+  const out = document.getElementById('right-box').dataset.plainText || '';
+  mode = (mode === 'encode') ? 'decode' : 'encode';
+  document.getElementById('left-box').value = out;
+  updateChrome();
+  run();
+};
+
+window.copyOutput = function() {
+  const el = document.getElementById('right-box');
+  navigator.clipboard.writeText(el.dataset.plainText || '').catch(() => {});
+};
 
 // ─── Startup ─────────────────────────────────────────────────────────
 
@@ -1813,9 +1034,13 @@ async function startup() {
     document.getElementById('loading').classList.add('hidden');
     document.getElementById('app').classList.remove('hidden');
 
-    // Initialize dynamic content
-    buildDialectCatalog();
-    autoRunNow();
+    buildLangButtons();
+    document.getElementById('left-box').addEventListener('input', () => {
+      clearTimeout(inputTimer);
+      inputTimer = setTimeout(run, 250);
+    });
+    updateChrome();
+    generateSeed();
   } catch (e) {
     console.error('Failed to load WASM:', e);
     document.getElementById('loading').innerHTML =


### PR DESCRIPTION
Addresses the cluster of detect→decode pipeline issues surfaced by the nostr-mail integration. Four focused commits, each with regression tests; full lib suite is green (369 passed).

## #26 — length-decaying `hit_rate` in dialect detection
`detect_dialect_with` scored `hit_rate` as *distinct matched words ÷ total tokens (with duplicates)*, so confidence decayed ~1/length and long-but-valid encoded bodies sank below downstream thresholds. Now counts matched words **with multiplicity** over the total token count, making `hit_rate` length- and entropy-invariant. This also makes the issue **#14** `min_hit_rate` filter a trustworthy signal rather than a length-sensitive one.

## #23 — bare payload words fail transcode with "data_bits not byte-aligned"
A raw BIP39-style mnemonic (not Glossia-encoded prose) has no bitpack padding header, so `decode_bitpack` misread the first word as a padding count and the remaining bits were rarely byte-aligned. The decoder now detects **unframed input** (every input token is a payload word → no cover words, no header) and decodes as base-N instead of bitpack — matching the existing `raw` path. Framed prose is unaffected. Verified byte-lossless: `english → latin` and `english → czech` on bare words now succeed and round-trip.

## Raw encode/decode codec asymmetry
The `raw` dialect used different codecs per side: raw-**encode** used bitpack (prepending a padding word) while raw-**decode** used base-N, so bytes didn't round-trip (hex `cafe` → `absorb slab useless` → `01b2bf80`). Raw-encode now uses base-N on both `do_encode` and `do_encode_rich`; raw output is genuinely bare (`cafe` → `add garlic` → `cafe`).

## `do_decode_rich` raw gap
`do_decode_rich` had no `raw` branch, so a rich raw decode fell through to the prose decoder (latent — not reachable via auto-detection today, since rich transcode routes through the non-rich `do_decode`). Factored a shared `decode_raw_words` helper used by both paths so they can't drift; the rich path reports all-payload stats (`cover_count: 0`, `ratio: 1.0`), mirroring raw encode.

## Tests
- `test_detect_dialect_hit_rate_length_invariant`
- `test_decode_codec_for_input_detects_bare_vs_framed`, `test_transcode_bare_mnemonic_english_to_latin`
- `test_raw_encode_decode_round_trip`
- `test_raw_decode_rich_returns_stats`

## Not included
- **#14** is already implemented on `master` (the `DialectFilter` / `min_hit_rate` machinery); #26 repairs the metric it relies on.
- **#25** (demo/docs "last mile" story) is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018zy27ZkwWSy4Ya8GasVeb3)_