### PR TITLE
Reposition demo homepage and focus modalities on text + crypto

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,10 @@
 # Glossia
 
-Glossia encodes binary data (BIP39 mnemonics, API keys, arbitrary payloads) into grammatically correct natural language. It combines context-free grammars with Montague Grammar (lambda calculus) so that payload words are hidden as grammatically valid constituents within natural-looking prose. Decoding is trivial: filter output against the payload wordlist.
+Glossia encodes binary data (BIP39 mnemonics, API keys, arbitrary payloads) into grammatically correct natural language. It combines context-free grammars with Montague Grammar (lambda calculus) so that payload words are embedded as grammatically valid constituents within natural-looking prose. Decoding is trivial: filter output against the payload wordlist.
+
+## Positioning (keep this framing)
+
+Glossia is **a readable encoding, not steganography**. The goal is not to hide that data is present — it is to make machine data (ciphertext, keys, signatures, hashes, mnemonics) *human-friendly*: readable, speakable, transcribable, verifiable. Because it hides nothing, every payload word carries its full ~11–15 bits, where steganography nets <1 bit per symbol. When iterating, optimize for legibility and density, not concealment, and make machine data human-friendly **without sacrificing too much security**. Avoid "hide/hidden/conceal" framing in copy and docs.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ A lossless linguistic codec for machine-to-human communication. Glossia generate
 
 This tool uses a small, controlled grammar to generate sentences that embed BIP39 words in their natural positions based on part-of-speech (POS) tags. The cover lexicon (non-payload words) is carefully constructed to avoid any BIP39 words, making decoding trivial: simply filter out all words that are not in the BIP39 word list.
 
+## A readable encoding, not steganography
+
+Glossia is **not** a steganographic tool. Its goal is not to hide that data is present, but to make machine data *human-friendly* — something a person can read, speak, transcribe, and verify. This distinction drives the design:
+
+- Steganography pays for concealment by spending nearly all of its capacity on cover text, typically netting **well under 1 bit per symbol**.
+- Glossia hides nothing, so every payload word carries its full information content — **~11 bits** with the 2048-word BIP39 list, up to **~15 bits** with larger wordlists.
+
+The payload is meant to be *seen and decoded*. The mission is to make ciphertext and other machine data — keys, signatures, hashes, mnemonics — human-friendly in a way existing formats (hex, Base64, fingerprints, ASCII armor) do not, **without sacrificing too much security**. When iterating on Glossia, optimize for legibility and density, not concealment.
+
 ## Features
 
 - **CFG-based sentence generation**: Uses a small context-free grammar to generate grammatically correct sentences

--- a/docs/src/how-it-works.md
+++ b/docs/src/how-it-works.md
@@ -38,6 +38,10 @@ A 12-word BIP39 seed phrase contains 11 × 12 = **132 bits** total:
 - Each of the 12 words encodes 11 bits of information
 - This provides 128 bits of cryptographic entropy (sufficient for 128-bit security)
 
+### Density vs. steganography
+
+This information density is what distinguishes Glossia from steganography, and the distinction is deliberate. A steganographic scheme hides the *existence* of data, and pays for that concealment by spending almost all of its capacity on cover — typically **well under 1 bit per symbol**. Glossia hides nothing: the payload is meant to be decoded, so every payload word carries its full `log2(word_count)` bits — **11 for BIP39, up to ~15** for larger lists. The goal is a *readable* encoding, not a *hidden* one — making machine data human-friendly without sacrificing too much security.
+
 ## Encoding and Decoding via Wordlist
 
 When encoding or decoding a payload, Glossia determines the **effective wordlist size** based on the actual words used in that payload.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1588,6 +1588,37 @@ mod tests {
     }
 
     #[test]
+    fn roundtrip_prose_arbitrary_len_prefix_recoverable() {
+        // The encryption demo tab frames its ciphertext as [len:u32][blob] and
+        // decodes prose with expected_byte_count = 0 (unknown length), relying on
+        // the decoded hex PREFIX matching the encoded bytes (trailing bit-pack
+        // padding is dropped via the length prefix). Verify that assumption for
+        // several odd payload lengths and both prose-wrapped and bare output.
+        for len in [29usize, 41, 60, 73, 128] {
+            let bytes: Vec<u8> = (0..len).map(|i| (i as u32 * 37 + 11) as u8).collect();
+            let hex_in = codec::hex_encode(&bytes);
+
+            for dialect in ["", "body"] {
+                let enc_json = encode_raw_base_n(&hex_in, "english", "bip39", dialect, 42);
+                let enc: serde_json::Value = serde_json::from_str(&enc_json).unwrap();
+                assert!(enc.get("error").is_none(), "encode error (len {}, dialect {:?}): {}", len, dialect, enc_json);
+                let text = enc["encoded_text"].as_str().unwrap();
+
+                let dec_json = decode_raw_base_n(text, "english", "bip39", 0);
+                let dec: serde_json::Value = serde_json::from_str(&dec_json).unwrap();
+                assert!(dec.get("error").is_none(), "decode error (len {}, dialect {:?}): {}", len, dialect, dec_json);
+                let hex_out = dec["decoded_hex"].as_str().unwrap();
+
+                assert!(
+                    hex_out.starts_with(&hex_in),
+                    "len {} dialect {:?}: decoded hex prefix mismatch\n  in : {}\n  out: {}",
+                    len, dialect, hex_in, hex_out
+                );
+            }
+        }
+    }
+
+    #[test]
     fn empty_dialect_has_no_cover_words() {
         let encoded_json = encode_raw_base_n(SIG_HEX_64, "latin", "default", "", 42);
         let enc: serde_json::Value = serde_json::from_str(&encoded_json).unwrap();

--- a/web/editor.html
+++ b/web/editor.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Glossia Editor</title>
-<meta name="description" content="Full-screen Glossia editor — encode and decode text in real time across all modalities.">
+<meta name="description" content="Full-screen Glossia editor — encode and decode text and ASCII armor in real time.">
 
 <style>
 :root {
@@ -499,8 +499,6 @@ mark {
       <div class="preset-tabs">
         <button class="preset-tab active" data-tab="text">Text</button>
         <button class="preset-tab" data-tab="crypto">Crypto</button>
-        <button class="preset-tab" data-tab="music">Music</button>
-        <button class="preset-tab" data-tab="image">Image</button>
         <button class="preset-tab" data-tab="pipelines">Pipelines</button>
       </div>
       <div class="preset-tab-content active" data-tab="text">
@@ -527,36 +525,6 @@ mark {
         <button class="btn-sm preset-btn" data-meta="encode into ascii7" title="Plain ASCII message">ASCII7</button>
         <button class="btn-sm preset-btn" data-meta="encode into cs raw" title="Raw encoding, no armor">Raw</button>
       </div>
-      <div class="preset-tab-content" data-tab="music">
-        <button class="btn-sm preset-btn" data-meta="encode into music" title="Chromatic scored notation">Chromatic</button>
-        <button class="btn-sm preset-btn" data-meta="encode into music pentatonic" title="Pentatonic scale notation">Pentatonic</button>
-        <button class="btn-sm preset-btn" data-meta="encode into music blues" title="Blues scale notation">Blues</button>
-      </div>
-      <div class="preset-tab-content" data-tab="image" style="flex-direction:column; gap:0.25rem;">
-        <div class="image-row">
-          <span class="image-group-label">Layout</span>
-          <button class="btn-sm image-layout-btn active" data-layout="voronoi" title="Voronoi mosaic layout">Voronoi</button>
-          <button class="btn-sm image-layout-btn" data-layout="grid" title="Rectangular grid layout">Grid</button>
-          <button class="btn-sm image-layout-btn" data-layout="constellation" title="Circular dots on dark background">Constellation</button>
-          <button class="btn-sm image-layout-btn" data-layout="patches" title="4-column patch grid">Patches</button>
-        </div>
-        <div class="image-row">
-          <span class="image-group-label">Shape</span>
-          <button class="btn-sm image-shape-btn active" data-shape="rect" title="Rectangular canvas">Rect</button>
-          <button class="btn-sm image-shape-btn" data-shape="disk" title="Circular clipping">Disk</button>
-        </div>
-        <div class="image-row">
-          <span class="image-group-label">Palette</span>
-          <button class="btn-sm image-palette-btn active" data-palette="viridis" title="Deep purple through teal to yellow-green (128 colors)">viridis</button>
-          <button class="btn-sm image-palette-btn" data-palette="plasma" title="Dark purple through magenta to orange-yellow (128 colors)">plasma</button>
-          <button class="btn-sm image-palette-btn" data-palette="inferno" title="Near-black through red-orange to bright yellow (128 colors)">inferno</button>
-          <button class="btn-sm image-palette-btn" data-palette="magma" title="Near-black through purple-pink to pale white (64 colors)">magma</button>
-          <button class="btn-sm image-palette-btn" data-palette="cividis" title="Dark blue through olive-grey to yellow, CVD-safe (128 colors)">cividis</button>
-          <button class="btn-sm image-palette-btn" data-palette="turbo" title="Dark blue through rainbow to dark red (8 colors)">turbo</button>
-          <button class="btn-sm image-palette-btn" data-palette="mako" title="Deep purple-black through teal to pale cyan (64 colors)">mako</button>
-          <button class="btn-sm image-palette-btn" data-palette="rocket" title="Near-black through magenta to pale white (32 colors)">rocket</button>
-        </div>
-      </div>
       <div class="preset-tab-content" data-tab="pipelines">
         <button class="btn-sm preset-btn" data-meta="transcode from latin into english" title="Translate Latin prose to English prose">Latin &rarr; English</button>
         <button class="btn-sm preset-btn" data-meta="transcode from english into latin" title="Translate English prose to Latin prose">English &rarr; Latin</button>
@@ -582,7 +550,7 @@ mark {
             <code>transcode from &lt;source&gt; into &lt;target&gt;</code>
           </div>
           <div style="margin-bottom:0.5rem;">
-            <strong style="color:var(--text);">Targets:</strong> english, latin, czech, pgp, nostr, music, hex, base64, ascii7
+            <strong style="color:var(--text);">Targets:</strong> english, latin, czech, pgp, nostr, hex, base64, ascii7
           </div>
           <div>
             <strong style="color:var(--text);">Modifiers:</strong> naturally, compactly, minimally, optimally

--- a/web/index.html
+++ b/web/index.html
@@ -841,7 +841,7 @@ footer a:hover { text-decoration: underline; }
       <div id="panel-bip39">
         <div class="section-header">
           <h3>BIP39 Seed Phrase</h3>
-          <p>Turn a recovery phrase into a readable sentence &mdash; and back again, byte-for-byte</p>
+          <p>Turn a seed phrase into a memorable madlib or latin proverb &mdash; check that either decodes into the original.</p>
         </div>
 
         <div class="panels">

--- a/web/index.html
+++ b/web/index.html
@@ -1626,19 +1626,57 @@ async function gunzipBytes(bytes) {
   const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'));
   return new Uint8Array(await new Response(stream).arrayBuffer());
 }
-// Compress when it actually shrinks the payload; record the choice in a flag
-// byte so decoding works the same regardless of where the message was made.
-// gzip has ~18 bytes of fixed overhead, so short messages stay uncompressed.
-async function maybeCompress(bytes) {
-  if (typeof CompressionStream === 'undefined') return { data: bytes, flag: 0 };
-  try {
-    const gz = await gzipBytes(bytes);
-    return (gz.length < bytes.length) ? { data: gz, flag: 1 } : { data: bytes, flag: 0 };
-  } catch (e) { return { data: bytes, flag: 0 }; }
+// Pack pure-ASCII bytes 7-bits-wide: [charCount:u16 BE][7-bit packed stream].
+// Returns null if any byte is >= 128 (needs the full 8th bit) or the message
+// is too long for the u16 count. Saves ~12.5% over raw bytes, with no
+// gzip-style fixed overhead — useful for short ASCII the compressor can't help.
+function asciiPack7(bytes) {
+  const L = bytes.length;
+  if (L > 0xffff) return null;
+  for (let i = 0; i < L; i++) if (bytes[i] > 0x7f) return null;
+  const out = new Uint8Array(2 + Math.ceil(L * 7 / 8));
+  out[0] = (L >> 8) & 0xff; out[1] = L & 0xff;
+  let acc = 0, bits = 0, pos = 2;
+  for (let i = 0; i < L; i++) {
+    acc = (acc << 7) | bytes[i];
+    bits += 7;
+    while (bits >= 8) { bits -= 8; out[pos++] = (acc >> bits) & 0xff; }
+  }
+  if (bits > 0) out[pos++] = (acc << (8 - bits)) & 0xff;
+  return out;
 }
-async function maybeDecompress(bytes, flag) {
-  if (!(flag & 1)) return bytes;
-  return gunzipBytes(bytes);
+function asciiUnpack7(packed) {
+  const L = (packed[0] << 8) | packed[1];
+  const out = new Uint8Array(L);
+  let acc = 0, bits = 0, pos = 2, n = 0;
+  while (n < L) {
+    acc = (acc << 8) | (packed[pos++] || 0);
+    bits += 8;
+    while (bits >= 7 && n < L) { bits -= 7; out[n++] = (acc >> bits) & 0x7f; }
+  }
+  return out;
+}
+
+// Pick the smallest representation and record it in the flag byte:
+//   0 = raw UTF-8   1 = gzip   2 = 7-bit ASCII pack
+// gzip wins on longer/repetitive text; 7-bit packing wins on short ASCII
+// where gzip's ~18-byte overhead would make things bigger.
+async function maybeReduce(bytes) {
+  let best = { data: bytes, flag: 0 };
+  const a7 = asciiPack7(bytes);
+  if (a7 && a7.length < best.data.length) best = { data: a7, flag: 2 };
+  if (typeof CompressionStream !== 'undefined') {
+    try {
+      const gz = await gzipBytes(bytes);
+      if (gz.length < best.data.length) best = { data: gz, flag: 1 };
+    } catch (e) { /* keep current best */ }
+  }
+  return best;
+}
+async function expand(bytes, flag) {
+  if (flag === 1) return gunzipBytes(bytes);
+  if (flag === 2) return asciiUnpack7(bytes);
+  return bytes;
 }
 
 async function encDeriveKey(password, salt) {
@@ -1649,10 +1687,11 @@ async function encDeriveKey(password, salt) {
 }
 
 // Framed blob: [len:u32 BE][flag:1][salt:16][iv:12][ciphertext+tag].
-// The length prefix lets decoding drop any trailing bit-packing padding the
-// codec adds, so AES-GCM sees exactly the bytes that were encrypted.
+// flag selects how the message bytes were reduced (raw/gzip/ascii7). The
+// length prefix lets decoding drop any trailing bit-packing padding the codec
+// adds, so AES-GCM sees exactly the bytes that were encrypted.
 async function encryptToHex(message, password) {
-  const { data: compressed, flag } = await maybeCompress(ENC_TE.encode(message));
+  const { data: compressed, flag } = await maybeReduce(ENC_TE.encode(message));
   const salt = crypto.getRandomValues(new Uint8Array(16));
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const key = await encDeriveKey(password, salt);
@@ -1684,7 +1723,7 @@ async function decryptFromHex(hexStr, password) {
   } catch (e) {
     throw new Error('Wrong password or corrupted message.');
   }
-  return ENC_TD.decode(await maybeDecompress(plain, flag));
+  return ENC_TD.decode(await expand(plain, flag));
 }
 
 // ─── Language buttons ────────────────────────────────────────────────

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Glossia - A Lossless Linguistic Codec</title>
-<meta name="description" content="Glossia encodes binary data into grammatically correct natural language and ASCII armor — composed through natural-language pipeline specifications and unified by formal grammar theory.">
+<meta name="description" content="Glossia transforms machine data — cryptographic keys, signatures, hashes, encrypted messages — into structured language and other human-friendly forms, with perfect round-trip fidelity. Human interfaces for machine data.">
 
 <style>
 :root {
@@ -618,6 +618,78 @@ footer a:hover { text-decoration: underline; }
 .branching-diagram .highlight { color: var(--accent); font-weight: 600; }
 
 
+/* Problem section: ciphertext vs. language */
+.cipher-demo {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin: 1.5rem auto 0;
+  max-width: 760px;
+}
+.cipher-demo code {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+.cipher-demo .ciphertext {
+  color: var(--error);
+  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(239, 68, 68, 0.3);
+  word-break: break-all;
+}
+.cipher-demo .plaintext {
+  color: var(--success);
+  background: rgba(34, 197, 94, 0.08);
+  border-color: rgba(34, 197, 94, 0.3);
+}
+.cipher-demo .cipher-arrow {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.problem-note, .guarantee {
+  max-width: 720px;
+  margin: 1.5rem auto 0;
+  text-align: center;
+  font-size: 0.95rem;
+  color: var(--text-dim);
+  line-height: 1.75;
+}
+.guarantee strong { color: var(--text); }
+
+/* What Glossia does: application list */
+.applications {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 0.75rem;
+  max-width: 760px;
+  margin: 1.5rem auto 0;
+}
+.applications li {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.85rem 1rem 0.85rem 2.1rem;
+  font-size: 0.9rem;
+  color: var(--text);
+  box-shadow: var(--shadow);
+  position: relative;
+}
+.applications li::before {
+  content: "\2192";
+  position: absolute;
+  left: 0.9rem;
+  color: var(--accent);
+  font-weight: 700;
+}
+
 /* Animations */
 @keyframes fadeInUp {
   from { opacity: 0; transform: translateY(20px); }
@@ -681,7 +753,7 @@ footer a:hover { text-decoration: underline; }
   <div class="top-bar">
     <div class="top-bar-title">
       <h1>GLOSSIA:</h1>
-      <span class="tagline">a universal linguistic codec</span>
+      <span class="tagline">human interfaces for machine data</span>
     </div>
     <button class="theme-toggle" id="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle theme">&#9790;</button>
   </div>
@@ -696,16 +768,41 @@ footer a:hover { text-decoration: underline; }
          1. HERO (Revised)
          ═══════════════════════════════════════════════════════════ -->
     <section class="hero animate-in">
-      <h2>One Grammar, Lossless Round-Trips</h2>
+      <h2>Computers Speak in Hex.<br>Humans Speak in Language.</h2>
       <p class="subtitle">
-        Turn seed phrases, API keys, and arbitrary bytes into readable prose or ASCII armor
-        — composed through natural-language pipelines and unified by formal grammar theory.
+        Glossia bridges the gap. Keys, signatures, hashes, encrypted messages, wallet addresses,
+        access tokens — the things we're asked to copy, verify, and trust are built for machines,
+        not people. Glossia transforms that data into structured language and other human-friendly
+        forms, with perfect round-trip fidelity.
       </p>
 
       <div class="cta">
         <a href="#demo">Try the Demo</a>
         <a href="editor.html" style="background:transparent; color:var(--accent); border:2px solid var(--accent); margin-left:0.75rem;">Open Editor</a>
       </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         THE PROBLEM IS PRESENTATION
+         ═══════════════════════════════════════════════════════════ -->
+    <section>
+      <div class="section-header">
+        <h3>The Problem Isn't Encryption. It's Presentation.</h3>
+        <p>Most people recoil at ciphertext — even when the data is perfectly secure, it feels foreign and inaccessible.</p>
+      </div>
+      <div class="cipher-demo">
+        <code class="ciphertext">f4b7c912e8a1d0f3a6b2&hellip;</code>
+        <span class="cipher-arrow">same bytes&nbsp;&rarr;</span>
+        <code class="plaintext">the quiet harbor keeps every distant sail</code>
+      </div>
+      <p class="problem-note">
+        Humans assign meaning and legitimacy to familiar forms of communication. A passage of
+        Latin carries different weight than a block of hexadecimal, even when neither is understood
+        by the reader. Glossia exploits this: the same payload can be represented as structured
+        English, Latin prose, ASCII armor, and other human-friendly forms — without changing a
+        single bit. The goal isn't compression or secrecy. It's reducing the language barrier
+        between humans and digital systems.
+      </p>
     </section>
 
     <!-- ═══════════════════════════════════════════════════════════
@@ -826,11 +923,32 @@ footer a:hover { text-decoration: underline; }
     </section>
 
     <!-- ═══════════════════════════════════════════════════════════
+         WHAT GLOSSIA DOES
+         ═══════════════════════════════════════════════════════════ -->
+    <div class="section-header">
+      <h3>What Glossia Does</h3>
+      <p>A lossless framework that converts binary data into human-oriented representations.</p>
+    </div>
+    <ul class="applications">
+      <li>Human-friendly cryptographic messages</li>
+      <li>Verifiable signatures and proofs</li>
+      <li>Mnemonic representations of keys and identifiers</li>
+      <li>Machine-readable text that survives email, chat, and documents</li>
+      <li>Accessible interfaces for complex technical systems</li>
+      <li>Alternative representations across other human-friendly forms</li>
+    </ul>
+    <p class="guarantee">
+      Every representation decodes back to the exact original bytes.
+      <strong>No approximation. No AI interpretation. No information loss.</strong>
+      Just a different language for the same data.
+    </p>
+
+    <!-- ═══════════════════════════════════════════════════════════
          WHY GLOSSIA?
          ═══════════════════════════════════════════════════════════ -->
     <div class="section-header">
       <h3>Why Glossia?</h3>
-      <p>A composable codec algebra for text and ASCII armor</p>
+      <p>The practical payoff of machine data that reads like language</p>
     </div>
     <div class="features">
       <div class="feature-card">

--- a/web/index.html
+++ b/web/index.html
@@ -995,6 +995,8 @@ footer a:hover { text-decoration: underline; }
           impractical here, where messages are copy-pasted by hand into chats and posts, but it&rsquo;s a real
           property of unauthenticated encryption. For tamper-proof, end-to-end secure messaging, use a signed
           protocol like <a href="https://nostr.com" target="_blank" rel="noopener">nostr</a>.
+          The base64 <code>key:</code> is plaintext metadata &mdash; a per-message salt and the ciphertext
+          length &mdash; not a secret and not part of the password; only the password unlocks the message.
         </p>
       </div>
     </section>
@@ -1799,7 +1801,7 @@ function encSplitArtifact(text) {
 // ctHex separately (so language/cover changes don't re-encrypt).
 async function encEncrypt(message, password) {
   const { data: reduced, flag } = await maybeReduce(ENC_TE.encode(message));
-  const salt = crypto.getRandomValues(new Uint8Array(12));
+  const salt = crypto.getRandomValues(new Uint8Array(8));
   const { key, nonce } = await encDeriveKeyNonce(password, salt);
   const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-CTR', counter: ctrCounter(nonce), length: 32 }, key, reduced));
   return { header: encBuildHeader(flag, ct.length, salt), ctHex: toHex(ct) };

--- a/web/index.html
+++ b/web/index.html
@@ -1679,47 +1679,62 @@ async function expand(bytes, flag) {
   return bytes;
 }
 
-async function encDeriveKey(password, salt) {
-  const baseKey = await crypto.subtle.importKey('raw', ENC_TE.encode(password), 'PBKDF2', false, ['deriveKey']);
-  return crypto.subtle.deriveKey(
-    { name: 'PBKDF2', salt, iterations: 200000, hash: 'SHA-256' },
-    baseKey, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']);
+// Derive BOTH the AES-GCM key and its nonce from password + salt, so the
+// nonce never has to be transmitted. Each message uses a fresh random salt,
+// making (key, nonce) unique per message — the only thing GCM requires — so a
+// derived nonce is as safe as a random one while saving 12 bytes on the wire.
+async function encDeriveKeyNonce(password, salt) {
+  const baseKey = await crypto.subtle.importKey('raw', ENC_TE.encode(password), 'PBKDF2', false, ['deriveBits']);
+  const bits = new Uint8Array(await crypto.subtle.deriveBits(
+    { name: 'PBKDF2', salt, iterations: 200000, hash: 'SHA-256' }, baseKey, (32 + 12) * 8));
+  const key = await crypto.subtle.importKey('raw', bits.subarray(0, 32), { name: 'AES-GCM' }, false, ['encrypt', 'decrypt']);
+  return { key, nonce: bits.subarray(32, 44) };
 }
 
-// Framed blob: [len:u32 BE][flag:1][salt:16][iv:12][ciphertext+tag].
-// flag selects how the message bytes were reduced (raw/gzip/ascii7). The
-// length prefix lets decoding drop any trailing bit-packing padding the codec
-// adds, so AES-GCM sees exactly the bytes that were encrypted.
+// Unsigned LEB128 varint (modulo/multiply math, so lengths above 2^31 are safe).
+function varintEncode(n) {
+  const out = [];
+  do { let b = n % 128; n = Math.floor(n / 128); if (n > 0) b |= 0x80; out.push(b); } while (n > 0);
+  return new Uint8Array(out);
+}
+function varintDecode(bytes, pos) {
+  let value = 0, mult = 1, p = pos, b;
+  do { b = bytes[p++]; value += (b & 0x7f) * mult; mult *= 128; } while (b & 0x80);
+  return { value, next: p };
+}
+
+// Framed blob: [blobLen:varint][flag:1][salt:12][ciphertext+tag]. The nonce is
+// derived (not stored). flag selects how the message bytes were reduced
+// (raw/gzip/ascii7). The length prefix lets decoding drop any trailing
+// bit-packing padding the codec adds, so AES-GCM sees exactly the encrypted bytes.
 async function encryptToHex(message, password) {
-  const { data: compressed, flag } = await maybeReduce(ENC_TE.encode(message));
-  const salt = crypto.getRandomValues(new Uint8Array(16));
-  const iv = crypto.getRandomValues(new Uint8Array(12));
-  const key = await encDeriveKey(password, salt);
-  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, compressed));
-  const blob = new Uint8Array(1 + 16 + 12 + ct.length);
+  const { data: reduced, flag } = await maybeReduce(ENC_TE.encode(message));
+  const salt = crypto.getRandomValues(new Uint8Array(12));
+  const { key, nonce } = await encDeriveKeyNonce(password, salt);
+  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv: nonce }, key, reduced));
+  const blob = new Uint8Array(1 + 12 + ct.length);
   blob[0] = flag;
   blob.set(salt, 1);
-  blob.set(iv, 17);
-  blob.set(ct, 29);
-  const framed = new Uint8Array(4 + blob.length);
-  new DataView(framed.buffer).setUint32(0, blob.length, false);
-  framed.set(blob, 4);
+  blob.set(ct, 13);
+  const lenPrefix = varintEncode(blob.length);
+  const framed = new Uint8Array(lenPrefix.length + blob.length);
+  framed.set(lenPrefix, 0);
+  framed.set(blob, lenPrefix.length);
   return toHex(framed);
 }
 async function decryptFromHex(hexStr, password) {
   const all = fromHex(hexStr);
-  if (all.length < 4) throw new Error('Ciphertext too short.');
-  const len = new DataView(all.buffer, all.byteOffset, 4).getUint32(0, false);
-  const blob = all.subarray(4, 4 + len);
-  if (blob.length < 29) throw new Error('Ciphertext too short or corrupted.');
+  if (all.length < 1) throw new Error('Ciphertext too short.');
+  const { value: blobLen, next } = varintDecode(all, 0);
+  const blob = all.subarray(next, next + blobLen);
+  if (blob.length < 1 + 12 + 16) throw new Error('Ciphertext too short or corrupted.');
   const flag = blob[0];
-  const salt = blob.subarray(1, 17);
-  const iv = blob.subarray(17, 29);
-  const ct = blob.subarray(29);
-  const key = await encDeriveKey(password, salt);
+  const salt = blob.subarray(1, 13);
+  const ct = blob.subarray(13);
+  const { key, nonce } = await encDeriveKeyNonce(password, salt);
   let plain;
   try {
-    plain = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct));
+    plain = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv: nonce }, key, ct));
   } catch (e) {
     throw new Error('Wrong password or corrupted message.');
   }

--- a/web/index.html
+++ b/web/index.html
@@ -844,6 +844,7 @@ footer a:hover { text-decoration: underline; }
         .enc-password-row input { min-width: 260px; }
         .enc-entropy { font-family: var(--font-mono); font-size: 0.65rem; color: var(--text-dim); white-space: nowrap; }
         .enc-entropy.strong { color: var(--success); }
+        .enc-key { color: var(--text-dim); word-break: break-all; }
         .enc-note-ref { color: var(--accent); text-decoration: none; font-weight: 700; }
         .enc-note { max-width: 700px; margin: 1rem auto 0; font-size: 0.75rem; line-height: 1.6;
           color: var(--text-dim); text-align: center; scroll-margin-top: 2rem; }
@@ -942,7 +943,7 @@ footer a:hover { text-decoration: underline; }
       <div id="panel-encrypt">
         <div class="section-header">
           <h3>Encrypted Message</h3>
-          <p>Compress and password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text, then encode the ciphertext as readable prose &mdash; decode it back byte-for-byte with the same password</p>
+          <p>Compress and password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text into a <code>key:&nbsp;value</code> pair &mdash; a compact salt key, the ciphertext as readable prose &mdash; and decode it back byte-for-byte with the same password</p>
         </div>
 
         <div class="enc-password-row">
@@ -1594,13 +1595,15 @@ window.akToggleCover = function() {
 // ═══ Encrypted Message panel ═════════════════════════════════════════
 //
 // Symmetric Google-Translate model with a shared password:
-//   encode: message + password -> compress -> AES-CTR encrypt -> language prose
-//   decode: language prose + password -> decrypt -> decompress -> message
+//   encode: message + password -> compress -> AES-CTR encrypt -> "<key>: prose"
+//   decode: "<key>: prose" + password -> decrypt -> decompress -> message
 //
-// The ciphertext is random per encryption, so the cover toggle and language
-// buttons re-render from the cached ciphertext (encCipherHex) rather than
-// re-encrypting. encode_raw_base_n uses the fixed SEED, so re-rendering the
-// same ciphertext into the same language is deterministic.
+// The artifact is a key:value pair — the base64url <key> carries the plumbing
+// (flag + ciphertext length + salt), and the prose value carries only the
+// Glossia-encoded ciphertext. The ciphertext is random per encryption, so the
+// cover toggle and language buttons re-render from the cached cipher (encCipher)
+// rather than re-encrypting; encode_raw_base_n uses the fixed SEED, so
+// re-rendering the same ciphertext into the same language is deterministic.
 
 const ENC_LANGS = [
   { id: 'english', label: 'English', language: 'english', wordlist: 'bip39',   dialect: 'body' },
@@ -1612,7 +1615,7 @@ function encLangById(id) { return ENC_LANGS.find(l => l.id === id) || ENC_LANGS[
 let encMode = 'encode';       // 'encode' (message -> prose) or 'decode' (prose -> message)
 let encLang = 'english';      // TARGET language (right buttons, encode), persists
 let encDetLang = 'english';   // SOURCE language auto-detected from left prose (decode)
-let encCipherHex = '';        // last framed ciphertext hex (encode), drives re-render
+let encCipher = null;         // last { header, ctHex } (encode), drives re-render
 let encTimer = null;
 let encRunId = 0;             // guards against stale async renders
 
@@ -1628,6 +1631,14 @@ function encSetOutput(text, html) {
   el.classList.remove('empty');
   el.innerHTML = (html != null) ? html : escapeHtml(text).replace(/\n/g, '<br>');
   el.dataset.plainText = text;
+}
+
+// Render the "<key>: prose" artifact: dim base64url key, then the prose value.
+function encSetArtifact(header, prosePlain, proseHtml) {
+  const el = document.getElementById('enc-right-box');
+  el.classList.remove('empty');
+  el.innerHTML = '<span class="enc-key">' + escapeHtml(header) + '</span>: ' + proseHtml;
+  el.dataset.plainText = header + ': ' + prosePlain;
 }
 
 // ─── compression (CompressionStream) + AES-CTR (WebCrypto) helpers ────
@@ -1734,45 +1745,75 @@ function varintDecode(bytes, pos) {
   return { value, next: p };
 }
 
-// Framed blob: [blobLen:varint][flag:1][salt:12][ciphertext]. The nonce is
-// derived (not stored), and AES-CTR is a stream cipher, so the ciphertext is
-// exactly as long as the (reduced) message — no tag, no padding. flag selects
-// how the message bytes were reduced (raw/gzip/ascii7). The length prefix lets
-// decoding drop any trailing bit-packing padding the codec adds.
+// base64url (no padding) for the compact header.
+function b64urlEncode(bytes) {
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+function b64urlDecode(str) {
+  const s = str.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  const bin = atob(s + pad);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+// Artifact format: "<key>: <prose>".
+//   key   = base64url( [flag:1][ctlen:varint][salt:12] )  — the machine plumbing
+//   prose = Glossia-encoded ciphertext only                — the human-readable value
+// The salt is the unique-per-message key; the ciphertext is the value. AES-CTR is
+// a stream cipher (no tag/padding), so the prose carries exactly the ciphertext.
 //
 // NOTE: AES-CTR provides confidentiality only — it is NOT authenticated, so it
 // cannot detect tampering (see the asterisk note under the demo panel).
-async function encryptToHex(message, password) {
+function encBuildHeader(flag, ctlen, salt) {
+  const lp = varintEncode(ctlen);
+  const h = new Uint8Array(1 + lp.length + salt.length);
+  h[0] = flag;
+  h.set(lp, 1);
+  h.set(salt, 1 + lp.length);
+  return b64urlEncode(h);
+}
+function encParseHeader(b64) {
+  const h = b64urlDecode(b64);
+  if (h.length < 2) throw new Error('bad header');
+  const flag = h[0];
+  const { value: ctlen, next } = varintDecode(h, 1);
+  const salt = h.subarray(next);
+  if (salt.length < 8) throw new Error('bad header');
+  return { flag, ctlen, salt };
+}
+// Split "<key>: <prose>" on the first colon (base64url has no ':').
+function encSplitArtifact(text) {
+  const i = text.indexOf(':');
+  if (i < 0) return null;
+  const header = text.slice(0, i).trim();
+  const prose = text.slice(i + 1).trim();
+  if (!header || !prose) return null;
+  return { header, prose };
+}
+
+// Encrypt: message + password -> { header, ctHex }. The prose is rendered from
+// ctHex separately (so language/cover changes don't re-encrypt).
+async function encEncrypt(message, password) {
   const { data: reduced, flag } = await maybeReduce(ENC_TE.encode(message));
   const salt = crypto.getRandomValues(new Uint8Array(12));
   const { key, nonce } = await encDeriveKeyNonce(password, salt);
   const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-CTR', counter: ctrCounter(nonce), length: 32 }, key, reduced));
-  const blob = new Uint8Array(1 + 12 + ct.length);
-  blob[0] = flag;
-  blob.set(salt, 1);
-  blob.set(ct, 13);
-  const lenPrefix = varintEncode(blob.length);
-  const framed = new Uint8Array(lenPrefix.length + blob.length);
-  framed.set(lenPrefix, 0);
-  framed.set(blob, lenPrefix.length);
-  return toHex(framed);
+  return { header: encBuildHeader(flag, ct.length, salt), ctHex: toHex(ct) };
 }
-async function decryptFromHex(hexStr, password) {
-  const all = fromHex(hexStr);
-  if (all.length < 1) throw new Error('Ciphertext too short.');
-  const { value: blobLen, next } = varintDecode(all, 0);
-  const blob = all.subarray(next, next + blobLen);
-  if (blob.length < 1 + 12) throw new Error('Ciphertext too short or corrupted.');
-  const flag = blob[0];
-  const salt = blob.subarray(1, 13);
-  const ct = blob.subarray(13);
-  const { key, nonce } = await encDeriveKeyNonce(password, salt);
+// Decrypt: parsed header + ciphertext bytes + password -> message.
+async function encDecrypt(hdr, ctBytes, password) {
+  const ct = ctBytes.subarray(0, hdr.ctlen);
+  const { key, nonce } = await encDeriveKeyNonce(password, hdr.salt);
   // CTR is unauthenticated: a wrong password yields a different keystream and
   // therefore garbled bytes rather than a clean failure. We can only surface an
   // error when the reduction stage (e.g. gunzip) chokes on the garbage.
   try {
     const plain = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-CTR', counter: ctrCounter(nonce), length: 32 }, key, ct));
-    return ENC_TD.decode(await expand(plain, flag));
+    return ENC_TD.decode(await expand(plain, hdr.flag));
   } catch (e) {
     throw new Error('Could not decode — check the password.');
   }
@@ -1792,7 +1833,7 @@ function encBuildButtons() {
       encLang = l.id;
       // In encode mode, just re-encode the cached ciphertext into the new
       // language — no need to re-encrypt (which would change the ciphertext).
-      if (encMode === 'encode' && encCipherHex) { encUpdateChrome(); encRenderFromHex(encCipherHex); }
+      if (encMode === 'encode' && encCipher) { encUpdateChrome(); encRenderCipher(encCipher); }
       else { encRun(); }
     });
     row.appendChild(b);
@@ -1802,13 +1843,14 @@ function encUpdateHighlights() {
   document.querySelectorAll('#enc-langs .lang-btn').forEach(b => b.classList.toggle('active', b.dataset.encLang === encLang));
 }
 
-// Auto-detect the SOURCE language of the left prose (decode), restricted to
-// the languages this panel supports.
+// Auto-detect the SOURCE language of the prose value (decode), restricted to
+// the languages this panel supports. Detects on the prose, not the base64 key.
 function encDetectLeftLang() {
-  const text = encLeftText().trim();
-  if (!text) return;
+  const parsed = encSplitArtifact(encLeftText().trim());
+  const prose = parsed ? parsed.prose : encLeftText().trim();
+  if (!prose) return;
   try {
-    const matches = JSON.parse(wasmDetectDialect(text));
+    const matches = JSON.parse(wasmDetectDialect(prose));
     if (Array.isArray(matches)) {
       const best = matches.find(m => ENC_LANGS.some(l => l.language === m.language));
       if (best) encDetLang = (ENC_LANGS.find(l => l.language === best.language) || {}).id || encDetLang;
@@ -1828,9 +1870,9 @@ function encUpdateChrome() {
     genBtn.classList.remove('hidden');
     coverBtn.classList.remove('hidden');
     coverBtn.textContent = coverEnc ? 'Hide cover' : 'Show cover';
-    hint.textContent = 'Compresses and AES-CTR-encrypts your message with the password, then encodes the ' +
-      'ciphertext as ' + encLangById(encLang).label + ' prose (payload words underlined). ' +
-      'Pick the target language on the right; press ⇄ to decode.';
+    hint.textContent = 'Compresses and AES-CTR-encrypts your message, then writes a “key: value” pair — the ' +
+      'base64 key holds the per-message salt, the ' + encLangById(encLang).label + ' prose holds the ciphertext ' +
+      '(payload words underlined). Pick the target language on the right; press ⇄ to decode.';
   } else {
     document.getElementById('enc-left-label').textContent = encLangById(encDetLang).label + ' sentences (detected)';
     document.getElementById('enc-right-label').textContent = 'Decrypted message';
@@ -1843,23 +1885,27 @@ function encUpdateChrome() {
   encUpdateHighlights();
 }
 
-function encUnderlineLeft(prose, words) {
+// Re-underline the left box's prose value (decode), preserving the "<key>: "
+// prefix and underlining only payload words in the prose.
+function encUnderlineLeftArtifact(header, prose, words) {
   const el = document.getElementById('enc-left-box');
   const focused = (document.activeElement === el);
-  el.innerHTML = underlineProse(prose, normSet(words));
+  el.innerHTML = '<span class="enc-key">' + escapeHtml(header) + '</span>: ' + underlineProse(prose, normSet(words));
   if (focused) placeCaretEnd(el);
 }
 
-// Render the cached ciphertext into the current target language (deterministic).
-function encRenderFromHex(hexStr) {
-  if (!ready || !hexStr) { encSetOutput(''); return; }
+// Render the cached ciphertext as "<key>: prose" in the current target language
+// (deterministic under the fixed SEED).
+function encRenderCipher(cipher) {
+  if (!ready || !cipher) { encSetOutput(''); return; }
   const tgt = encLangById(encLang);
   try {
-    const r = JSON.parse(wasmEncodeRawBaseN(hexStr, tgt.language, tgt.wordlist, tgt.dialect, SEED));
+    const r = JSON.parse(wasmEncodeRawBaseN(cipher.ctHex, tgt.language, tgt.wordlist, tgt.dialect, SEED));
     if (r.error) { encShowError(r.error); encSetOutput(''); return; }
-    const out = (r.encoded_text || '').trim();
+    const prose = (r.encoded_text || '').trim();
     const set = normSet(r.payload_words || []);
-    encSetOutput(coverEnc ? out : payloadOnlyText(out, set), renderProse(out, set, coverEnc));
+    const prosePlain = coverEnc ? prose : payloadOnlyText(prose, set);
+    encSetArtifact(cipher.header, prosePlain, renderProse(prose, set, coverEnc));
   } catch (e) { encShowError(e.message || String(e)); encSetOutput(''); }
 }
 
@@ -1872,30 +1918,34 @@ async function encRun() {
   const pw = encPassword();
 
   if (encMode === 'encode') {
-    if (!text) { encCipherHex = ''; encSetOutput(''); return; }
+    if (!text) { encCipher = null; encSetOutput(''); return; }
     if (!pw) { encSetOutput(''); encShowError('Enter a password to encrypt.'); return; }
-    let hexStr;
-    try { hexStr = await encryptToHex(text, pw); }
+    let cipher;
+    try { cipher = await encEncrypt(text, pw); }
     catch (e) { if (myId === encRunId) { encShowError(e.message || String(e)); encSetOutput(''); } return; }
     if (myId !== encRunId) return;   // a newer run superseded this one
-    encCipherHex = hexStr;
-    encRenderFromHex(encCipherHex);
+    encCipher = cipher;
+    encRenderCipher(encCipher);
   } else {
     if (!text) { encSetOutput(''); return; }
+    const parsed = encSplitArtifact(text);
+    if (!parsed) { encSetOutput(''); encShowError('Expected "key: message" format.'); return; }
     encDetectLeftLang();
     encUpdateChrome();
     const src = encLangById(encDetLang);
-    let hexStr;
+    let hdr, ctBytes;
+    try { hdr = encParseHeader(parsed.header); }
+    catch (e) { encSetOutput(''); encShowError('Malformed key.'); return; }
     try {
-      const r = JSON.parse(wasmDecodeRawBaseN(text, src.language, src.wordlist, 0));
+      const r = JSON.parse(wasmDecodeRawBaseN(parsed.prose, src.language, src.wordlist, hdr.ctlen));
       if (r.error) { encShowError(r.error); encSetOutput(''); return; }
-      hexStr = r.decoded_hex || '';
-      encUnderlineLeft(text, r.payload_words || []);
+      ctBytes = fromHex(r.decoded_hex || '');
+      encUnderlineLeftArtifact(parsed.header, parsed.prose, r.payload_words || []);
     } catch (e) { encShowError(e.message || String(e)); encSetOutput(''); return; }
-    if (!hexStr) { encSetOutput(''); return; }
+    if (!ctBytes.length) { encSetOutput(''); return; }
     if (!pw) { encSetOutput(''); encShowError('Enter the password to decrypt.'); return; }
     let message;
-    try { message = await decryptFromHex(hexStr, pw); }
+    try { message = await encDecrypt(hdr, ctBytes, pw); }
     catch (e) { if (myId === encRunId) { encShowError(e.message || String(e)); encSetOutput(''); } return; }
     if (myId !== encRunId) return;
     encSetOutput(message);
@@ -1962,7 +2012,7 @@ window.encCopy = function() {
 window.encToggleCover = function() {
   coverEnc = !coverEnc;
   // Re-render the cached ciphertext rather than re-encrypting.
-  if (encMode === 'encode' && encCipherHex) { encUpdateChrome(); encRenderFromHex(encCipherHex); }
+  if (encMode === 'encode' && encCipher) { encUpdateChrome(); encRenderCipher(encCipher); }
   else encUpdateChrome();
 };
 

--- a/web/index.html
+++ b/web/index.html
@@ -1626,12 +1626,15 @@ async function gunzipBytes(bytes) {
   const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'));
   return new Uint8Array(await new Response(stream).arrayBuffer());
 }
-// Compress when the browser supports it; record the choice in a flag byte so
-// decoding works the same regardless of where the message was produced.
+// Compress when it actually shrinks the payload; record the choice in a flag
+// byte so decoding works the same regardless of where the message was made.
+// gzip has ~18 bytes of fixed overhead, so short messages stay uncompressed.
 async function maybeCompress(bytes) {
   if (typeof CompressionStream === 'undefined') return { data: bytes, flag: 0 };
-  try { return { data: await gzipBytes(bytes), flag: 1 }; }
-  catch (e) { return { data: bytes, flag: 0 }; }
+  try {
+    const gz = await gzipBytes(bytes);
+    return (gz.length < bytes.length) ? { data: gz, flag: 1 } : { data: bytes, flag: 0 };
+  } catch (e) { return { data: bytes, flag: 0 }; }
 }
 async function maybeDecompress(bytes, flag) {
   if (!(flag & 1)) return bytes;

--- a/web/index.html
+++ b/web/index.html
@@ -827,11 +827,17 @@ footer a:hover { text-decoration: underline; }
           border-bottom: 2px solid transparent; margin-bottom: -2px; transition: all 0.15s; }
         .usecase-tab:hover { color: var(--text); }
         .usecase-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+        .enc-password-row { display: flex; align-items: center; justify-content: center;
+          gap: 0.6rem; margin-bottom: 1rem; flex-wrap: wrap; }
+        .enc-password-row label { font-family: var(--font-mono); font-size: 0.65rem;
+          text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); }
+        .enc-password-row input { min-width: 260px; }
       </style>
 
       <div class="usecase-tabs">
         <button class="usecase-tab active" data-uc="bip39">BIP39 Seed</button>
         <button class="usecase-tab" data-uc="apikey">API Key</button>
+        <button class="usecase-tab" data-uc="encrypt">Encrypted Message</button>
       </div>
 
       <!-- ─── BIP39 panel ─────────────────────────────────────────── -->
@@ -919,6 +925,54 @@ footer a:hover { text-decoration: underline; }
         </div>
 
         <p class="demo-hint" id="ak-hint"></p>
+      </div>
+
+      <!-- ─── Encrypted Message panel ─────────────────────────────── -->
+      <div id="panel-encrypt" class="hidden">
+        <div class="section-header">
+          <h3>Encrypted Message</h3>
+          <p>Compress and password-encrypt any text, then hide the ciphertext in readable prose &mdash; decode it back byte-for-byte with the same password</p>
+        </div>
+
+        <div class="enc-password-row">
+          <label for="enc-pass">Password</label>
+          <input type="password" id="enc-pass" placeholder="Shared secret&hellip;" autocomplete="off" spellcheck="false">
+        </div>
+
+        <div class="panels">
+          <div class="panel panel-left">
+            <div class="panel-header">
+              <span class="dialect-label" id="enc-left-label">Message</span>
+            </div>
+            <div class="panel-body">
+              <div contenteditable="true" spellcheck="false" id="enc-left-box" class="io-input" data-placeholder="Type a secret message&hellip;"></div>
+            </div>
+            <div class="panel-footer">
+              <button class="btn-sm" id="enc-gen-btn" onclick="encSample()" title="Insert a sample message">&#10024; Sample message</button>
+              <div id="enc-error" class="error-msg hidden" style="padding:0;"></div>
+            </div>
+          </div>
+
+          <button class="swap-btn" id="enc-swap-btn" onclick="encToggle()" title="Switch between Encode and Decode" aria-label="Swap encode/decode">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"/></svg>
+          </button>
+
+          <div class="panel panel-right">
+            <div class="panel-header">
+              <span class="dialect-label" id="enc-right-label">English sentences</span>
+              <div class="lang-row" id="enc-langs"></div>
+            </div>
+            <div class="panel-body">
+              <div class="output-area empty" id="enc-right-box">Output will appear here</div>
+            </div>
+            <div class="panel-footer">
+              <button class="btn-sm" id="enc-cover-btn" onclick="encToggleCover()" title="Show or hide the cover words">Hide cover</button>
+              <button class="btn-sm" id="enc-copy-btn" onclick="encCopy()">Copy</button>
+            </div>
+          </div>
+        </div>
+
+        <p class="demo-hint" id="enc-hint"></p>
       </div>
     </section>
 
@@ -1041,6 +1095,8 @@ import init, {
   render_image_svg as wasmRenderImageSvg,
   decode_image_from_colors as wasmDecodeImageFromColors,
   get_default_wordlist as wasmGetDefaultWordlist,
+  encode_raw_base_n as wasmEncodeRawBaseN,
+  decode_raw_base_n as wasmDecodeRawBaseN,
 } from './glossia.js';
 
 let ready = false;
@@ -1508,14 +1564,288 @@ window.akToggleCover = function() {
   akRun();        // re-encode from the (stable) key and re-render per showCover
 };
 
+// ═══ Encrypted Message panel ═════════════════════════════════════════
+//
+// Symmetric Google-Translate model with a shared password:
+//   encode: message + password -> compress -> AES-GCM encrypt -> language prose
+//   decode: language prose + password -> decrypt -> decompress -> message
+//
+// The ciphertext is random per encryption, so the cover toggle and language
+// buttons re-render from the cached ciphertext (encCipherHex) rather than
+// re-encrypting. encode_raw_base_n uses the fixed SEED, so re-rendering the
+// same ciphertext into the same language is deterministic.
+
+const ENC_LANGS = [
+  { id: 'english', label: 'English', language: 'english', wordlist: 'bip39',   dialect: 'body' },
+  { id: 'latin',   label: 'Latin',   language: 'latin',   wordlist: 'default', dialect: 'body' },
+  { id: 'czech',   label: 'Czech',   language: 'czech',   wordlist: 'default', dialect: 'body' },
+];
+function encLangById(id) { return ENC_LANGS.find(l => l.id === id) || ENC_LANGS[0]; }
+
+let encMode = 'encode';       // 'encode' (message -> prose) or 'decode' (prose -> message)
+let encLang = 'english';      // TARGET language (right buttons, encode), persists
+let encDetLang = 'english';   // SOURCE language auto-detected from left prose (decode)
+let encCipherHex = '';        // last framed ciphertext hex (encode), drives re-render
+let encTimer = null;
+let encRunId = 0;             // guards against stale async renders
+
+function encLeftText() { return document.getElementById('enc-left-box').innerText; }
+function encSetLeftPlain(t) { document.getElementById('enc-left-box').textContent = t; }
+function encPassword() { return document.getElementById('enc-pass').value; }
+function encShowError(m) { const e = document.getElementById('enc-error'); e.textContent = m; e.classList.remove('hidden'); }
+function encClearError() { document.getElementById('enc-error').classList.add('hidden'); }
+
+function encSetOutput(text, html) {
+  const el = document.getElementById('enc-right-box');
+  if (!text) { el.classList.add('empty'); el.textContent = 'Output will appear here'; el.dataset.plainText = ''; return; }
+  el.classList.remove('empty');
+  el.innerHTML = (html != null) ? html : escapeHtml(text).replace(/\n/g, '<br>');
+  el.dataset.plainText = text;
+}
+
+// ─── compression (CompressionStream) + AES-GCM (WebCrypto) helpers ────
+const ENC_TE = new TextEncoder();
+const ENC_TD = new TextDecoder();
+
+function toHex(bytes) { return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(''); }
+function fromHex(h) {
+  const clean = h.trim().toLowerCase().replace(/[^0-9a-f]/g, '');
+  const out = new Uint8Array(clean.length >> 1);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.substr(i * 2, 2), 16);
+  return out;
+}
+
+async function gzipBytes(bytes) {
+  const stream = new Blob([bytes]).stream().pipeThrough(new CompressionStream('gzip'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+async function gunzipBytes(bytes) {
+  const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+// Compress when the browser supports it; record the choice in a flag byte so
+// decoding works the same regardless of where the message was produced.
+async function maybeCompress(bytes) {
+  if (typeof CompressionStream === 'undefined') return { data: bytes, flag: 0 };
+  try { return { data: await gzipBytes(bytes), flag: 1 }; }
+  catch (e) { return { data: bytes, flag: 0 }; }
+}
+async function maybeDecompress(bytes, flag) {
+  if (!(flag & 1)) return bytes;
+  return gunzipBytes(bytes);
+}
+
+async function encDeriveKey(password, salt) {
+  const baseKey = await crypto.subtle.importKey('raw', ENC_TE.encode(password), 'PBKDF2', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 200000, hash: 'SHA-256' },
+    baseKey, { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']);
+}
+
+// Framed blob: [len:u32 BE][flag:1][salt:16][iv:12][ciphertext+tag].
+// The length prefix lets decoding drop any trailing bit-packing padding the
+// codec adds, so AES-GCM sees exactly the bytes that were encrypted.
+async function encryptToHex(message, password) {
+  const { data: compressed, flag } = await maybeCompress(ENC_TE.encode(message));
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await encDeriveKey(password, salt);
+  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, compressed));
+  const blob = new Uint8Array(1 + 16 + 12 + ct.length);
+  blob[0] = flag;
+  blob.set(salt, 1);
+  blob.set(iv, 17);
+  blob.set(ct, 29);
+  const framed = new Uint8Array(4 + blob.length);
+  new DataView(framed.buffer).setUint32(0, blob.length, false);
+  framed.set(blob, 4);
+  return toHex(framed);
+}
+async function decryptFromHex(hexStr, password) {
+  const all = fromHex(hexStr);
+  if (all.length < 4) throw new Error('Ciphertext too short.');
+  const len = new DataView(all.buffer, all.byteOffset, 4).getUint32(0, false);
+  const blob = all.subarray(4, 4 + len);
+  if (blob.length < 29) throw new Error('Ciphertext too short or corrupted.');
+  const flag = blob[0];
+  const salt = blob.subarray(1, 17);
+  const iv = blob.subarray(17, 29);
+  const ct = blob.subarray(29);
+  const key = await encDeriveKey(password, salt);
+  let plain;
+  try {
+    plain = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct));
+  } catch (e) {
+    throw new Error('Wrong password or corrupted message.');
+  }
+  return ENC_TD.decode(await maybeDecompress(plain, flag));
+}
+
+// ─── Language buttons ────────────────────────────────────────────────
+function encBuildButtons() {
+  const row = document.getElementById('enc-langs');
+  row.innerHTML = '';
+  for (const l of ENC_LANGS) {
+    const b = document.createElement('button');
+    b.className = 'btn-sm lang-btn';
+    b.dataset.encLang = l.id;
+    b.textContent = l.label;
+    b.title = l.label + ' prose';
+    b.addEventListener('click', () => {
+      encLang = l.id;
+      // In encode mode, just re-encode the cached ciphertext into the new
+      // language — no need to re-encrypt (which would change the ciphertext).
+      if (encMode === 'encode' && encCipherHex) { encUpdateChrome(); encRenderFromHex(encCipherHex); }
+      else { encRun(); }
+    });
+    row.appendChild(b);
+  }
+}
+function encUpdateHighlights() {
+  document.querySelectorAll('#enc-langs .lang-btn').forEach(b => b.classList.toggle('active', b.dataset.encLang === encLang));
+}
+
+// Auto-detect the SOURCE language of the left prose (decode), restricted to
+// the languages this panel supports.
+function encDetectLeftLang() {
+  const text = encLeftText().trim();
+  if (!text) return;
+  try {
+    const matches = JSON.parse(wasmDetectDialect(text));
+    if (Array.isArray(matches)) {
+      const best = matches.find(m => ENC_LANGS.some(l => l.language === m.language));
+      if (best) encDetLang = (ENC_LANGS.find(l => l.language === best.language) || {}).id || encDetLang;
+    }
+  } catch (e) { /* keep detected language */ }
+}
+
+function encUpdateChrome() {
+  const langRow = document.getElementById('enc-langs');
+  const genBtn = document.getElementById('enc-gen-btn');
+  const coverBtn = document.getElementById('enc-cover-btn');
+  const hint = document.getElementById('enc-hint');
+  if (encMode === 'encode') {
+    document.getElementById('enc-left-label').textContent = 'Message';
+    document.getElementById('enc-right-label').textContent = encLangById(encLang).label + ' sentences';
+    langRow.classList.remove('hidden');
+    genBtn.classList.remove('hidden');
+    coverBtn.classList.remove('hidden');
+    coverBtn.textContent = showCover ? 'Hide cover' : 'Show cover';
+    hint.textContent = 'Compresses and AES-GCM-encrypts your message with the password, then hides the ' +
+      'ciphertext in ' + encLangById(encLang).label + ' prose (payload words underlined). ' +
+      'Pick the target language on the right; press ⇄ to decode.';
+  } else {
+    document.getElementById('enc-left-label').textContent = encLangById(encDetLang).label + ' sentences (detected)';
+    document.getElementById('enc-right-label').textContent = 'Decrypted message';
+    langRow.classList.add('hidden');
+    genBtn.classList.add('hidden');
+    coverBtn.classList.add('hidden');
+    hint.textContent = 'Detected ' + encLangById(encDetLang).label + ' prose (payload words underlined); ' +
+      'decrypting with the password to recover the original message. Press ⇄ to go back to encrypting.';
+  }
+  encUpdateHighlights();
+}
+
+function encUnderlineLeft(prose, words) {
+  const el = document.getElementById('enc-left-box');
+  const focused = (document.activeElement === el);
+  el.innerHTML = underlineProse(prose, normSet(words));
+  if (focused) placeCaretEnd(el);
+}
+
+// Render the cached ciphertext into the current target language (deterministic).
+function encRenderFromHex(hexStr) {
+  if (!ready || !hexStr) { encSetOutput(''); return; }
+  const tgt = encLangById(encLang);
+  try {
+    const r = JSON.parse(wasmEncodeRawBaseN(hexStr, tgt.language, tgt.wordlist, tgt.dialect, SEED));
+    if (r.error) { encShowError(r.error); encSetOutput(''); return; }
+    const out = (r.encoded_text || '').trim();
+    const set = normSet(r.payload_words || []);
+    encSetOutput(showCover ? out : payloadOnlyText(out, set), renderProse(out, set));
+  } catch (e) { encShowError(e.message || String(e)); encSetOutput(''); }
+}
+
+async function encRun() {
+  if (!ready) return;
+  const myId = ++encRunId;
+  encClearError();
+  encUpdateChrome();
+  const text = encLeftText().trim();
+  const pw = encPassword();
+
+  if (encMode === 'encode') {
+    if (!text) { encCipherHex = ''; encSetOutput(''); return; }
+    if (!pw) { encSetOutput(''); encShowError('Enter a password to encrypt.'); return; }
+    let hexStr;
+    try { hexStr = await encryptToHex(text, pw); }
+    catch (e) { if (myId === encRunId) { encShowError(e.message || String(e)); encSetOutput(''); } return; }
+    if (myId !== encRunId) return;   // a newer run superseded this one
+    encCipherHex = hexStr;
+    encRenderFromHex(encCipherHex);
+  } else {
+    if (!text) { encSetOutput(''); return; }
+    encDetectLeftLang();
+    encUpdateChrome();
+    const src = encLangById(encDetLang);
+    let hexStr;
+    try {
+      const r = JSON.parse(wasmDecodeRawBaseN(text, src.language, src.wordlist, 0));
+      if (r.error) { encShowError(r.error); encSetOutput(''); return; }
+      hexStr = r.decoded_hex || '';
+      encUnderlineLeft(text, r.payload_words || []);
+    } catch (e) { encShowError(e.message || String(e)); encSetOutput(''); return; }
+    if (!hexStr) { encSetOutput(''); return; }
+    if (!pw) { encSetOutput(''); encShowError('Enter the password to decrypt.'); return; }
+    let message;
+    try { message = await decryptFromHex(hexStr, pw); }
+    catch (e) { if (myId === encRunId) { encShowError(e.message || String(e)); encSetOutput(''); } return; }
+    if (myId !== encRunId) return;
+    encSetOutput(message);
+  }
+}
+
+window.encSample = function() {
+  if (!ready) return;
+  if (encMode !== 'encode') encMode = 'encode';
+  encClearError();
+  encSetLeftPlain('Meet me at the old harbor at midnight. Bring the charts.');
+  if (!encPassword()) document.getElementById('enc-pass').value = 'correct horse battery staple';
+  encRun();
+};
+
+window.encToggle = function() {
+  // Move the current output into the input box, then flip direction.
+  const out = document.getElementById('enc-right-box').dataset.plainText || '';
+  encMode = (encMode === 'encode') ? 'decode' : 'encode';
+  encSetLeftPlain(out);
+  if (encMode === 'decode') encDetectLeftLang();
+  encRun();
+};
+
+window.encCopy = function() {
+  const el = document.getElementById('enc-right-box');
+  navigator.clipboard.writeText(el.dataset.plainText || '').catch(() => {});
+};
+
+window.encToggleCover = function() {
+  showCover = !showCover;
+  // Re-render the cached ciphertext rather than re-encrypting.
+  if (encMode === 'encode' && encCipherHex) { encUpdateChrome(); encRenderFromHex(encCipherHex); }
+  else encUpdateChrome();
+};
+
 // ═══ Use-case selector ═══════════════════════════════════════════════
 
 window.selectUseCase = function(uc) {
   document.querySelectorAll('.usecase-tab').forEach(t => t.classList.toggle('active', t.dataset.uc === uc));
   document.getElementById('panel-bip39').classList.toggle('hidden', uc !== 'bip39');
   document.getElementById('panel-apikey').classList.toggle('hidden', uc !== 'apikey');
+  document.getElementById('panel-encrypt').classList.toggle('hidden', uc !== 'encrypt');
   // Re-render the shown panel so labels, highlights, and cover state are current.
-  if (uc === 'apikey') { akRun(); } else { updateChrome(); run(); }
+  if (uc === 'apikey') { akRun(); }
+  else if (uc === 'encrypt') { encUpdateChrome(); encRun(); }
+  else { updateChrome(); run(); }
 };
 // ─── Theme toggle ────────────────────────────────────────────────────
 
@@ -1564,9 +1894,25 @@ async function startup() {
         akRun();
       }, 250);
     });
+    // Encrypted Message panel
+    encBuildButtons();
+    document.getElementById('enc-left-box').addEventListener('input', () => {
+      clearTimeout(encTimer);
+      encTimer = setTimeout(() => {
+        if (encMode === 'decode') encDetectLeftLang();
+        encRun();
+      }, 300);
+    });
+    document.getElementById('enc-pass').addEventListener('input', () => {
+      clearTimeout(encTimer);
+      encTimer = setTimeout(() => { encRun(); }, 300);
+    });
+
     document.querySelectorAll('.usecase-tab').forEach(t =>
       t.addEventListener('click', () => selectUseCase(t.dataset.uc)));
     akGenerate();
+    encUpdateChrome();
+    encSample();
   } catch (e) {
     console.error('Failed to load WASM:', e);
     document.getElementById('loading').innerHTML =

--- a/web/index.html
+++ b/web/index.html
@@ -835,6 +835,11 @@ footer a:hover { text-decoration: underline; }
           text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); }
         .enc-password-row label .req { color: var(--error); }
         .enc-password-row input { min-width: 260px; }
+        .enc-note-ref { color: var(--accent); text-decoration: none; font-weight: 700; }
+        .enc-note { max-width: 700px; margin: 1rem auto 0; font-size: 0.75rem; line-height: 1.6;
+          color: var(--text-dim); text-align: center; scroll-margin-top: 2rem; }
+        .enc-note strong { color: var(--accent); }
+        .enc-note a { color: var(--accent); }
       </style>
 
       <!-- ─── BIP39 panel ─────────────────────────────────────────── -->
@@ -928,7 +933,7 @@ footer a:hover { text-decoration: underline; }
       <div id="panel-encrypt">
         <div class="section-header">
           <h3>Encrypted Message</h3>
-          <p>Compress and password-encrypt any text, then hide the ciphertext in readable prose &mdash; decode it back byte-for-byte with the same password</p>
+          <p>Compress and password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text, then hide the ciphertext in readable prose &mdash; decode it back byte-for-byte with the same password</p>
         </div>
 
         <div class="enc-password-row">
@@ -970,6 +975,15 @@ footer a:hover { text-decoration: underline; }
         </div>
 
         <p class="demo-hint" id="enc-hint"></p>
+
+        <p class="enc-note" id="enc-note">
+          <strong>*</strong> AES-CTR keeps your message confidential but is <em>not</em> authenticated &mdash; it
+          can&rsquo;t detect tampering. In principle, someone who intercepts the ciphertext could flip bits to
+          alter the decoded message in controlled ways, without ever knowing the password. That&rsquo;s
+          impractical here, where messages are copy-pasted by hand into chats and posts, but it&rsquo;s a real
+          property of unauthenticated encryption. For tamper-proof, end-to-end secure messaging, use a signed
+          protocol like <a href="https://nostr.com" target="_blank" rel="noopener">nostr</a>.
+        </p>
       </div>
     </section>
 
@@ -1569,7 +1583,7 @@ window.akToggleCover = function() {
 // ═══ Encrypted Message panel ═════════════════════════════════════════
 //
 // Symmetric Google-Translate model with a shared password:
-//   encode: message + password -> compress -> AES-GCM encrypt -> language prose
+//   encode: message + password -> compress -> AES-CTR encrypt -> language prose
 //   decode: language prose + password -> decrypt -> decompress -> message
 //
 // The ciphertext is random per encryption, so the cover toggle and language
@@ -1605,7 +1619,7 @@ function encSetOutput(text, html) {
   el.dataset.plainText = text;
 }
 
-// ─── compression (CompressionStream) + AES-GCM (WebCrypto) helpers ────
+// ─── compression (CompressionStream) + AES-CTR (WebCrypto) helpers ────
 const ENC_TE = new TextEncoder();
 const ENC_TD = new TextDecoder();
 
@@ -1678,16 +1692,23 @@ async function expand(bytes, flag) {
   return bytes;
 }
 
-// Derive BOTH the AES-GCM key and its nonce from password + salt, so the
-// nonce never has to be transmitted. Each message uses a fresh random salt,
-// making (key, nonce) unique per message — the only thing GCM requires — so a
-// derived nonce is as safe as a random one while saving 12 bytes on the wire.
+// Derive BOTH the AES key and its nonce from password + salt, so the nonce
+// never has to be transmitted. Each message uses a fresh random salt, making
+// the (key, nonce) pair unique per message — which is what keeps the CTR
+// keystream from ever being reused — while saving bytes on the wire.
 async function encDeriveKeyNonce(password, salt) {
   const baseKey = await crypto.subtle.importKey('raw', ENC_TE.encode(password), 'PBKDF2', false, ['deriveBits']);
   const bits = new Uint8Array(await crypto.subtle.deriveBits(
     { name: 'PBKDF2', salt, iterations: 200000, hash: 'SHA-256' }, baseKey, (32 + 12) * 8));
-  const key = await crypto.subtle.importKey('raw', bits.subarray(0, 32), { name: 'AES-GCM' }, false, ['encrypt', 'decrypt']);
+  const key = await crypto.subtle.importKey('raw', bits.subarray(0, 32), { name: 'AES-CTR' }, false, ['encrypt', 'decrypt']);
   return { key, nonce: bits.subarray(32, 44) };
+}
+// 16-byte CTR counter block: 96-bit derived nonce in the high bytes, a 32-bit
+// counter (the low 4 bytes) starting at 0. 2^32 blocks = 64 GB per message.
+function ctrCounter(nonce) {
+  const c = new Uint8Array(16);
+  c.set(nonce, 0);
+  return c;
 }
 
 // Unsigned LEB128 varint (modulo/multiply math, so lengths above 2^31 are safe).
@@ -1702,15 +1723,19 @@ function varintDecode(bytes, pos) {
   return { value, next: p };
 }
 
-// Framed blob: [blobLen:varint][flag:1][salt:12][ciphertext+tag]. The nonce is
-// derived (not stored). flag selects how the message bytes were reduced
-// (raw/gzip/ascii7). The length prefix lets decoding drop any trailing
-// bit-packing padding the codec adds, so AES-GCM sees exactly the encrypted bytes.
+// Framed blob: [blobLen:varint][flag:1][salt:12][ciphertext]. The nonce is
+// derived (not stored), and AES-CTR is a stream cipher, so the ciphertext is
+// exactly as long as the (reduced) message — no tag, no padding. flag selects
+// how the message bytes were reduced (raw/gzip/ascii7). The length prefix lets
+// decoding drop any trailing bit-packing padding the codec adds.
+//
+// NOTE: AES-CTR provides confidentiality only — it is NOT authenticated, so it
+// cannot detect tampering (see the asterisk note under the demo panel).
 async function encryptToHex(message, password) {
   const { data: reduced, flag } = await maybeReduce(ENC_TE.encode(message));
   const salt = crypto.getRandomValues(new Uint8Array(12));
   const { key, nonce } = await encDeriveKeyNonce(password, salt);
-  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv: nonce }, key, reduced));
+  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-CTR', counter: ctrCounter(nonce), length: 32 }, key, reduced));
   const blob = new Uint8Array(1 + 12 + ct.length);
   blob[0] = flag;
   blob.set(salt, 1);
@@ -1726,18 +1751,20 @@ async function decryptFromHex(hexStr, password) {
   if (all.length < 1) throw new Error('Ciphertext too short.');
   const { value: blobLen, next } = varintDecode(all, 0);
   const blob = all.subarray(next, next + blobLen);
-  if (blob.length < 1 + 12 + 16) throw new Error('Ciphertext too short or corrupted.');
+  if (blob.length < 1 + 12) throw new Error('Ciphertext too short or corrupted.');
   const flag = blob[0];
   const salt = blob.subarray(1, 13);
   const ct = blob.subarray(13);
   const { key, nonce } = await encDeriveKeyNonce(password, salt);
-  let plain;
+  // CTR is unauthenticated: a wrong password yields a different keystream and
+  // therefore garbled bytes rather than a clean failure. We can only surface an
+  // error when the reduction stage (e.g. gunzip) chokes on the garbage.
   try {
-    plain = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv: nonce }, key, ct));
+    const plain = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-CTR', counter: ctrCounter(nonce), length: 32 }, key, ct));
+    return ENC_TD.decode(await expand(plain, flag));
   } catch (e) {
-    throw new Error('Wrong password or corrupted message.');
+    throw new Error('Could not decode — check the password.');
   }
-  return ENC_TD.decode(await expand(plain, flag));
 }
 
 // ─── Language buttons ────────────────────────────────────────────────
@@ -1790,7 +1817,7 @@ function encUpdateChrome() {
     genBtn.classList.remove('hidden');
     coverBtn.classList.remove('hidden');
     coverBtn.textContent = coverEnc ? 'Hide cover' : 'Show cover';
-    hint.textContent = 'Compresses and AES-GCM-encrypts your message with the password, then hides the ' +
+    hint.textContent = 'Compresses and AES-CTR-encrypts your message with the password, then hides the ' +
       'ciphertext in ' + encLangById(encLang).label + ' prose (payload words underlined). ' +
       'Pick the target language on the right; press ⇄ to decode.';
   } else {

--- a/web/index.html
+++ b/web/index.html
@@ -666,6 +666,7 @@ footer a:hover { text-decoration: underline; }
   line-height: 1.75;
 }
 .guarantee strong { color: var(--text); }
+.problem-note strong { color: var(--accent); }
 
 /* What Glossia does: application list */
 .applications {
@@ -804,8 +805,14 @@ footer a:hover { text-decoration: underline; }
         Latin carries different weight than a block of hexadecimal, even when neither is understood
         by the reader. Glossia exploits this: the same payload can be represented as structured
         English, Latin prose, ASCII armor, and other human-friendly forms — without changing a
-        single bit. The goal isn't compression or secrecy. It's reducing the language barrier
+        single bit. The goal isn't compression or secrecy — it's reducing the language barrier
         between humans and digital systems.
+      </p>
+      <p class="problem-note">
+        And to be clear, this <strong>isn't steganography</strong>. Glossia doesn't hide that data is
+        present — it makes the data itself legible, meant to be seen and decoded. Freed from spending
+        capacity on concealment, every payload word carries its full 11–15 bits, where hiding data
+        inside text nets well under one per symbol.
       </p>
     </section>
 
@@ -933,7 +940,7 @@ footer a:hover { text-decoration: underline; }
       <div id="panel-encrypt">
         <div class="section-header">
           <h3>Encrypted Message</h3>
-          <p>Compress and password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text, then hide the ciphertext in readable prose &mdash; decode it back byte-for-byte with the same password</p>
+          <p>Compress and password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text, then encode the ciphertext as readable prose &mdash; decode it back byte-for-byte with the same password</p>
         </div>
 
         <div class="enc-password-row">
@@ -1817,8 +1824,8 @@ function encUpdateChrome() {
     genBtn.classList.remove('hidden');
     coverBtn.classList.remove('hidden');
     coverBtn.textContent = coverEnc ? 'Hide cover' : 'Show cover';
-    hint.textContent = 'Compresses and AES-CTR-encrypts your message with the password, then hides the ' +
-      'ciphertext in ' + encLangById(encLang).label + ' prose (payload words underlined). ' +
+    hint.textContent = 'Compresses and AES-CTR-encrypts your message with the password, then encodes the ' +
+      'ciphertext as ' + encLangById(encLang).label + ' prose (payload words underlined). ' +
       'Pick the target language on the right; press ⇄ to decode.';
   } else {
     document.getElementById('enc-left-label').textContent = encLangById(encDetLang).label + ' sentences (detected)';

--- a/web/index.html
+++ b/web/index.html
@@ -132,7 +132,7 @@ body {
 .control-group label input[type="checkbox"] {
   cursor: pointer;
 }
-select, input[type="number"], input[type="text"] {
+select, input[type="number"], input[type="text"], input[type="password"] {
   background: var(--surface);
   border: 1px solid var(--border);
   color: var(--text);
@@ -161,7 +161,7 @@ input[type="number"] { width: 80px; }
   box-shadow: var(--shadow);
   display: flex;
   flex-direction: column;
-  min-height: 260px;
+  min-height: 0;
   overflow: hidden;
 }
 .panel-left { border-radius: 8px; }
@@ -229,7 +229,7 @@ textarea::placeholder { color: var(--text-dim); }
   line-height: 1.8;
   word-wrap: break-word;
   font-family: var(--font-mono);
-  overflow-y: auto;
+  min-height: 64px;
   color: var(--text);
 }
 .output-area svg, #input-image-preview svg { max-width: 100%; height: auto; display: block; margin: 0 auto; }
@@ -816,9 +816,9 @@ footer a:hover { text-decoration: underline; }
         .demo-hint { color: var(--text-dim); font-size: 0.8rem; text-align: center; margin-top: 0.85rem; }
         #demo .panel-header { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; }
         #demo .panel-header .lang-row { margin-left: auto; }
-        .io-input { flex: 1; min-height: 160px; padding: 0.75rem 0.85rem; font-size: 0.9rem;
+        .io-input { flex: 1; min-height: 64px; padding: 0.75rem 0.85rem; font-size: 0.9rem;
           font-family: var(--font-mono); line-height: 1.7; color: var(--text); outline: none;
-          white-space: pre-wrap; overflow-wrap: anywhere; overflow-y: auto; }
+          white-space: pre-wrap; overflow-wrap: anywhere; }
         .io-input:empty::before { content: attr(data-placeholder); color: var(--text-dim); }
         .io-input u, .output-area u { text-decoration-color: var(--accent); text-underline-offset: 2px; }
         /* Stacked demos (no tabs): encryption first, each visually separated. */
@@ -829,6 +829,7 @@ footer a:hover { text-decoration: underline; }
           gap: 0.6rem; margin-bottom: 1rem; flex-wrap: wrap; }
         .enc-password-row label { font-family: var(--font-mono); font-size: 0.65rem;
           text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); }
+        .enc-password-row label .req { color: var(--error); }
         .enc-password-row input { min-width: 260px; }
       </style>
 
@@ -927,8 +928,8 @@ footer a:hover { text-decoration: underline; }
         </div>
 
         <div class="enc-password-row">
-          <label for="enc-pass">Password</label>
-          <input type="password" id="enc-pass" placeholder="Shared secret&hellip;" autocomplete="off" spellcheck="false">
+          <label for="enc-pass">Password <span class="req" title="required">*</span></label>
+          <input type="text" id="enc-pass" placeholder="Shared secret (required)&hellip;" autocomplete="off" spellcheck="false" required aria-required="true">
         </div>
 
         <div class="panels">
@@ -1144,8 +1145,10 @@ function placeCaretEnd(el) {
   s.addRange(r);
 }
 
-// Cover-word visibility for the prose output (shared by both panels).
-let showCover = true;
+// Cover-word visibility is tracked independently per demo panel.
+let coverBip = true;   // BIP39 panel
+let coverAk = true;    // API Key panel
+let coverEnc = true;   // Encrypted Message panel
 
 // The cleaned payload words present in prose, in order (cover words dropped).
 // Payload words are case-insensitive (and BIP39 words are canonically
@@ -1159,10 +1162,10 @@ function payloadTokens(text, set) {
 function payloadOnlyText(text, set) { return payloadTokens(text, set).join(' '); }
 
 // Render prose either in full (cover words present, payload underlined) or
-// payload-only (cover words removed, payload underlined).
-function renderProse(text, set) {
-  if (showCover) return underlineProse(text, set);
-  return payloadTokens(text, set).map(t => '<u>' + escapeHtml(t) + '</u>').join(' ');
+// payload-only (cover words removed, shown plain — no underline).
+function renderProse(text, set, cover) {
+  if (cover) return underlineProse(text, set);
+  return payloadTokens(text, set).map(t => escapeHtml(t)).join(' ');
 }
 
 // ─── Left box (contenteditable) accessors ────────────────────────────
@@ -1268,7 +1271,7 @@ function updateChrome() {
   const coverBtn = document.getElementById('cover-btn');
   if (mode === 'encode') {
     coverBtn.classList.remove('hidden');
-    coverBtn.textContent = showCover ? 'Hide cover' : 'Show cover';
+    coverBtn.textContent = coverBip ? 'Hide cover' : 'Show cover';
   } else {
     coverBtn.classList.add('hidden');
   }
@@ -1318,7 +1321,7 @@ function run() {
     if (mode === 'encode') {
       // Right box holds the prose — underline payload words, honor cover toggle.
       const set = normSet(result.payload_words || []);
-      setOutput(showCover ? out : payloadOnlyText(out, set), renderProse(out, set));
+      setOutput(coverBip ? out : payloadOnlyText(out, set), renderProse(out, set, coverBip));
     } else {
       // Right box holds bare seed words (no underline); left box holds the
       // prose — underline its payload words.
@@ -1364,20 +1367,10 @@ window.copyOutput = function() {
   navigator.clipboard.writeText(el.dataset.plainText || '').catch(() => {});
 };
 
-// Cover visibility is shared across the three (now simultaneously visible)
-// demos, so a toggle re-renders all of them. None of these regenerate a
-// secret: BIP39/API-Key re-encode deterministically from the fixed SEED, and
-// the encryption panel re-renders from its cached ciphertext.
-function applyCoverToAll() {
-  updateChrome(); run();
-  akRun();
-  if (encMode === 'encode' && encCipherHex) { encUpdateChrome(); encRenderFromHex(encCipherHex); }
-  else encUpdateChrome();
-}
-
 window.toggleCover = function() {
-  showCover = !showCover;
-  applyCoverToAll();
+  coverBip = !coverBip;
+  run();          // re-encode from the (stable) seed and re-render per coverBip
+  updateChrome();
 };
 
 // ═══ API Key panel ═══════════════════════════════════════════════════
@@ -1493,7 +1486,7 @@ function akUpdateChrome() {
   const coverBtn = document.getElementById('ak-cover-btn');
   if (akMode === 'encode') {
     coverBtn.classList.remove('hidden');
-    coverBtn.textContent = showCover ? 'Hide cover' : 'Show cover';
+    coverBtn.textContent = coverAk ? 'Hide cover' : 'Show cover';
   } else {
     coverBtn.classList.add('hidden');
   }
@@ -1520,7 +1513,7 @@ function akRun() {
       akDetFmt = r.data_mode || '';
       const out = (r.output || '').trim();
       const set = normSet(r.payload_words || []);
-      akSetOutput(showCover ? out : payloadOnlyText(out, set), renderProse(out, set));
+      akSetOutput(coverAk ? out : payloadOnlyText(out, set), renderProse(out, set, coverAk));
       akUpdateChrome();   // refresh the detected-format chip
     } else {
       const meta = 'transcode from ' + akLangById(akDetLang).source + ' into ' + akFmtById(akFormat).word;
@@ -1565,8 +1558,8 @@ window.akCopy = function() {
 };
 
 window.akToggleCover = function() {
-  showCover = !showCover;
-  applyCoverToAll();
+  coverAk = !coverAk;
+  akRun();        // re-encode from the (stable) key and re-render per coverAk
 };
 
 // ═══ Encrypted Message panel ═════════════════════════════════════════
@@ -1792,7 +1785,7 @@ function encUpdateChrome() {
     langRow.classList.remove('hidden');
     genBtn.classList.remove('hidden');
     coverBtn.classList.remove('hidden');
-    coverBtn.textContent = showCover ? 'Hide cover' : 'Show cover';
+    coverBtn.textContent = coverEnc ? 'Hide cover' : 'Show cover';
     hint.textContent = 'Compresses and AES-GCM-encrypts your message with the password, then hides the ' +
       'ciphertext in ' + encLangById(encLang).label + ' prose (payload words underlined). ' +
       'Pick the target language on the right; press ⇄ to decode.';
@@ -1824,7 +1817,7 @@ function encRenderFromHex(hexStr) {
     if (r.error) { encShowError(r.error); encSetOutput(''); return; }
     const out = (r.encoded_text || '').trim();
     const set = normSet(r.payload_words || []);
-    encSetOutput(showCover ? out : payloadOnlyText(out, set), renderProse(out, set));
+    encSetOutput(coverEnc ? out : payloadOnlyText(out, set), renderProse(out, set, coverEnc));
   } catch (e) { encShowError(e.message || String(e)); encSetOutput(''); }
 }
 
@@ -1891,8 +1884,10 @@ window.encCopy = function() {
 };
 
 window.encToggleCover = function() {
-  showCover = !showCover;
-  applyCoverToAll();
+  coverEnc = !coverEnc;
+  // Re-render the cached ciphertext rather than re-encrypting.
+  if (encMode === 'encode' && encCipherHex) { encUpdateChrome(); encRenderFromHex(encCipherHex); }
+  else encUpdateChrome();
 };
 
 // ─── Theme toggle ────────────────────────────────────────────────────

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Glossia - A Lossless Linguistic Codec</title>
-<meta name="description" content="Glossia encodes binary data into natural language, ASCII armor, note sequences, and color palettes — all composed through natural-language pipeline specifications and unified by formal grammar theory.">
+<meta name="description" content="Glossia encodes binary data into grammatically correct natural language and ASCII armor — composed through natural-language pipeline specifications and unified by formal grammar theory.">
 
 <style>
 :root {
@@ -696,10 +696,10 @@ footer a:hover { text-decoration: underline; }
          1. HERO (Revised)
          ═══════════════════════════════════════════════════════════ -->
     <section class="hero animate-in">
-      <h2>One Grammar, Many Modalities</h2>
+      <h2>One Grammar, Lossless Round-Trips</h2>
       <p class="subtitle">
-        Prose, ASCII armor, note sequences, color palettes
-        — mix and match modalities through pipeline composition, all unified by formal grammar theory.
+        Turn seed phrases, API keys, and arbitrary bytes into readable prose or ASCII armor
+        — composed through natural-language pipelines and unified by formal grammar theory.
       </p>
 
       <div class="cta">
@@ -830,7 +830,7 @@ footer a:hover { text-decoration: underline; }
          ═══════════════════════════════════════════════════════════ -->
     <div class="section-header">
       <h3>Why Glossia?</h3>
-      <p>A composable codec algebra for every modality — not just text</p>
+      <p>A composable codec algebra for text and ASCII armor</p>
     </div>
     <div class="features">
       <div class="feature-card">
@@ -871,7 +871,7 @@ footer a:hover { text-decoration: underline; }
     <section class="how-it-works">
       <div class="section-header">
         <h3>How It Works</h3>
-        <p>The encoding pipeline branches into four modalities — decoding reverses the same path</p>
+        <p>The encoding pipeline turns bytes into prose or ASCII armor — decoding reverses the same path</p>
       </div>
       <div class="branching-diagram">
               <span class="highlight">Input bytes</span>
@@ -881,14 +881,14 @@ footer a:hover { text-decoration: underline; }
           <span class="highlight">Payload tokens</span>
                   |
          CFG + Montague Types
-           /    |    \     \
-          /     |     \     \
-     <span class="highlight">Text</span>  <span class="highlight">Crypto</span>  <span class="highlight">Music</span>  <span class="highlight">Image</span>
-       |      |       |      |
-     Prose  Armor   Score  Colors</div>
+                /      \
+               /        \
+          <span class="highlight">Text</span>        <span class="highlight">Crypto</span>
+            |             |
+          Prose         Armor</div>
       <p style="margin-top:0.75rem;font-size:0.85rem;color:var(--text-dim);text-align:center;max-width:700px;margin-left:auto;margin-right:auto;">
-        <strong>Decoding is the same principle for every modality:</strong> filter the output against the payload wordlist
-        (or palette, or note set) to recover encoded tokens, then reverse the codec to get the original bytes.
+        <strong>Decoding follows the same principle:</strong> filter the output against the payload wordlist
+        to recover the encoded tokens, then reverse the codec to get the original bytes.
       </p>
     </section>
 

--- a/web/index.html
+++ b/web/index.html
@@ -962,7 +962,7 @@ footer a:hover { text-decoration: underline; }
               <div contenteditable="true" spellcheck="false" id="enc-left-box" class="io-input" data-placeholder="Type a secret message&hellip;"></div>
             </div>
             <div class="panel-footer">
-              <button class="btn-sm" id="enc-gen-btn" onclick="encSample()" title="Insert a sample message">&#10024; Sample message</button>
+              <button class="btn-sm" id="enc-gen-btn" onclick="encSample()" title="Insert a random sample quote">&#127922; Random quote</button>
               <div id="enc-error" class="error-msg hidden" style="padding:0;"></div>
             </div>
           </div>
@@ -1988,11 +1988,39 @@ window.encGenPassword = function() {
   } catch (e) { encShowError(e.message || String(e)); }
 };
 
+// Sample messages: well-known aphorisms, picked at random for the demo input.
+const ENC_SAMPLES = [
+  'Knowledge is power.',
+  'Time is money.',
+  'Less is more.',
+  'The truth hurts.',
+  'Practice makes perfect.',
+  'Actions speak louder than words.',
+  'Better late than never.',
+  'Curiosity killed the cat.',
+  'Beauty is in the eye of the beholder.',
+  'The pen is mightier than the sword.',
+  'United we stand.',
+  'Divide and conquer.',
+  'Trust, but verify.',
+  'Live and let live.',
+  'Keep calm and carry on.',
+  'Seize the day.',
+  'Measure twice, cut once.',
+  'Look before you leap.',
+  'Seeing is believing.',
+  'Knowledge speaks, wisdom listens.',
+];
+let encLastSample = -1;
+
 window.encSample = function() {
   if (!ready) return;
   if (encMode !== 'encode') encMode = 'encode';
   encClearError();
-  encSetLeftPlain('Meet me at the old harbor at midnight. Bring the charts.');
+  let i = Math.floor(Math.random() * ENC_SAMPLES.length);
+  if (ENC_SAMPLES.length > 1 && i === encLastSample) i = (i + 1) % ENC_SAMPLES.length;
+  encLastSample = i;
+  encSetLeftPlain(ENC_SAMPLES[i]);
   if (!encPassword()) { encGenPassword(); return; }   // seed a strong Latin pass-phrase
   encRun();
 };

--- a/web/index.html
+++ b/web/index.html
@@ -46,6 +46,10 @@ body {
   color: var(--text);
   line-height: 1.6;
   min-height: 100vh;
+  /* Auto-growing demo boxes change height when output length changes (e.g.
+     switching language); scroll anchoring would otherwise keep a lower element
+     fixed and push the box top up out of view. Disable it so the box top stays. */
+  overflow-anchor: none;
 }
 .container { max-width: 960px; margin: 0 auto; padding: 1.5rem 1.5rem; position: relative; }
 

--- a/web/index.html
+++ b/web/index.html
@@ -942,7 +942,7 @@ footer a:hover { text-decoration: underline; }
       <!-- ─── Encrypted Message panel ─────────────────────────────── -->
       <div id="panel-encrypt">
         <div class="section-header">
-          <h3>Encrypted Message</h3>
+          <h3>Madlib Encryption</h3>
           <p>Compress and password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text into a <code>key:&nbsp;value</code> pair &mdash; a compact salt key, the ciphertext as readable prose &mdash; and decode it back byte-for-byte with the same password</p>
         </div>
 
@@ -994,7 +994,7 @@ footer a:hover { text-decoration: underline; }
           alter the decoded message in controlled ways, without ever knowing the password. That&rsquo;s
           impractical here, where messages are copy-pasted by hand into chats and posts, but it&rsquo;s a real
           property of unauthenticated encryption. For tamper-proof, end-to-end secure messaging, use a signed
-          protocol like <a href="https://nostr.com" target="_blank" rel="noopener">nostr</a>.
+          protocol like <a href="https://nostr-mail.com" target="_blank" rel="noopener">nostr-mail</a>.
           The base64 <code>key:</code> is plaintext metadata &mdash; a per-message salt and the ciphertext
           length &mdash; not a secret and not part of the password; only the password unlocks the message.
         </p>

--- a/web/index.html
+++ b/web/index.html
@@ -842,6 +842,8 @@ footer a:hover { text-decoration: underline; }
           text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); }
         .enc-password-row label .req { color: var(--error); }
         .enc-password-row input { min-width: 260px; }
+        .enc-entropy { font-family: var(--font-mono); font-size: 0.65rem; color: var(--text-dim); white-space: nowrap; }
+        .enc-entropy.strong { color: var(--success); }
         .enc-note-ref { color: var(--accent); text-decoration: none; font-weight: 700; }
         .enc-note { max-width: 700px; margin: 1rem auto 0; font-size: 0.75rem; line-height: 1.6;
           color: var(--text-dim); text-align: center; scroll-margin-top: 2rem; }
@@ -945,7 +947,9 @@ footer a:hover { text-decoration: underline; }
 
         <div class="enc-password-row">
           <label for="enc-pass">Password <span class="req" title="required">*</span></label>
-          <input type="text" id="enc-pass" placeholder="Shared secret (required)&hellip;" autocomplete="off" spellcheck="false" required aria-required="true">
+          <input type="text" id="enc-pass" placeholder="Type a password, or generate a Latin seed phrase &rarr;" autocomplete="off" spellcheck="false" required aria-required="true">
+          <button class="btn-sm" id="enc-genpass-btn" onclick="encGenPassword()" title="Generate a strong, high-entropy Latin seed phrase">&#127922; Latin seed phrase</button>
+          <span class="enc-entropy" id="enc-entropy"></span>
         </div>
 
         <div class="panels">
@@ -1898,12 +1902,46 @@ async function encRun() {
   }
 }
 
+// Generated passwords are Latin seed phrases drawn from Glossia's own Latin
+// payload wordlist (~15 bits/word), targeting >=128 bits so the password is
+// strong enough that offline guessing / precomputation is infeasible — the
+// only way to actually *enforce* password entropy is to generate it.
+const ENC_PASS_LANG = { language: 'latin', wordlist: 'default' };
+const ENC_PASS_TARGET_BITS = 128;
+
+function encBitsPerWord(lang) {
+  try { return JSON.parse(wasmGetBitsPerWord(lang.language, lang.wordlist)).bits_per_word || 0; }
+  catch (e) { return 0; }
+}
+function encShowEntropy(wordCount) {
+  const el = document.getElementById('enc-entropy');
+  if (!el) return;
+  const bpw = encBitsPerWord(ENC_PASS_LANG);
+  if (!bpw || !wordCount) { el.textContent = ''; el.classList.remove('strong'); return; }
+  const bits = Math.round(wordCount * bpw);
+  el.textContent = '≈ ' + bits + '-bit';
+  el.classList.toggle('strong', bits >= 80);
+}
+
+window.encGenPassword = function() {
+  if (!ready) return;
+  const bpw = encBitsPerWord(ENC_PASS_LANG) || 15;
+  const count = Math.max(1, Math.ceil(ENC_PASS_TARGET_BITS / bpw));
+  try {
+    const words = JSON.parse(wasmRandomWords(count, ENC_PASS_LANG.language, ENC_PASS_LANG.wordlist, BigInt(Date.now())));
+    if (words.error) { encShowError(words.error); return; }
+    document.getElementById('enc-pass').value = words.join(' ');
+    encShowEntropy(words.length);
+    encRun();   // re-encrypt under the new password
+  } catch (e) { encShowError(e.message || String(e)); }
+};
+
 window.encSample = function() {
   if (!ready) return;
   if (encMode !== 'encode') encMode = 'encode';
   encClearError();
   encSetLeftPlain('Meet me at the old harbor at midnight. Bring the charts.');
-  if (!encPassword()) document.getElementById('enc-pass').value = 'correct horse battery staple';
+  if (!encPassword()) { encGenPassword(); return; }   // seed a strong Latin pass-phrase
   encRun();
 };
 
@@ -1985,6 +2023,7 @@ async function startup() {
       }, 300);
     });
     document.getElementById('enc-pass').addEventListener('input', () => {
+      encShowEntropy(0);   // typed password: clear the generated-phrase entropy badge
       clearTimeout(encTimer);
       encTimer = setTimeout(() => { encRun(); }, 300);
     });

--- a/web/index.html
+++ b/web/index.html
@@ -821,24 +821,16 @@ footer a:hover { text-decoration: underline; }
           white-space: pre-wrap; overflow-wrap: anywhere; overflow-y: auto; }
         .io-input:empty::before { content: attr(data-placeholder); color: var(--text-dim); }
         .io-input u, .output-area u { text-decoration-color: var(--accent); text-underline-offset: 2px; }
-        .usecase-tabs { display: flex; gap: 0; border-bottom: 2px solid var(--border); margin-bottom: 1rem; }
-        .usecase-tab { padding: 0.5rem 1rem; font-family: var(--font-mono); font-size: 0.85rem; font-weight: 500;
-          color: var(--text-dim); cursor: pointer; border: none; background: none;
-          border-bottom: 2px solid transparent; margin-bottom: -2px; transition: all 0.15s; }
-        .usecase-tab:hover { color: var(--text); }
-        .usecase-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+        /* Stacked demos (no tabs): encryption first, each visually separated. */
+        .demo-section { display: flex; flex-direction: column; }
+        #panel-encrypt { order: -1; }
+        #panel-bip39, #panel-apikey { border-top: 1px solid var(--border); padding-top: 0.5rem; }
         .enc-password-row { display: flex; align-items: center; justify-content: center;
           gap: 0.6rem; margin-bottom: 1rem; flex-wrap: wrap; }
         .enc-password-row label { font-family: var(--font-mono); font-size: 0.65rem;
           text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); }
         .enc-password-row input { min-width: 260px; }
       </style>
-
-      <div class="usecase-tabs">
-        <button class="usecase-tab active" data-uc="bip39">BIP39 Seed</button>
-        <button class="usecase-tab" data-uc="apikey">API Key</button>
-        <button class="usecase-tab" data-uc="encrypt">Encrypted Message</button>
-      </div>
 
       <!-- ─── BIP39 panel ─────────────────────────────────────────── -->
       <div id="panel-bip39">
@@ -884,7 +876,7 @@ footer a:hover { text-decoration: underline; }
       </div>
 
       <!-- ─── API Key panel ───────────────────────────────────────── -->
-      <div id="panel-apikey" class="hidden">
+      <div id="panel-apikey">
         <div class="section-header">
           <h3>API Key / Secret Token</h3>
           <p>Turn an opaque key into a readable sentence &mdash; dictate it, paste it, decode it back byte-for-byte</p>
@@ -928,7 +920,7 @@ footer a:hover { text-decoration: underline; }
       </div>
 
       <!-- ─── Encrypted Message panel ─────────────────────────────── -->
-      <div id="panel-encrypt" class="hidden">
+      <div id="panel-encrypt">
         <div class="section-header">
           <h3>Encrypted Message</h3>
           <p>Compress and password-encrypt any text, then hide the ciphertext in readable prose &mdash; decode it back byte-for-byte with the same password</p>
@@ -1372,10 +1364,20 @@ window.copyOutput = function() {
   navigator.clipboard.writeText(el.dataset.plainText || '').catch(() => {});
 };
 
+// Cover visibility is shared across the three (now simultaneously visible)
+// demos, so a toggle re-renders all of them. None of these regenerate a
+// secret: BIP39/API-Key re-encode deterministically from the fixed SEED, and
+// the encryption panel re-renders from its cached ciphertext.
+function applyCoverToAll() {
+  updateChrome(); run();
+  akRun();
+  if (encMode === 'encode' && encCipherHex) { encUpdateChrome(); encRenderFromHex(encCipherHex); }
+  else encUpdateChrome();
+}
+
 window.toggleCover = function() {
   showCover = !showCover;
-  run();          // re-encode from the (stable) seed and re-render per showCover
-  updateChrome();
+  applyCoverToAll();
 };
 
 // ═══ API Key panel ═══════════════════════════════════════════════════
@@ -1564,7 +1566,7 @@ window.akCopy = function() {
 
 window.akToggleCover = function() {
   showCover = !showCover;
-  akRun();        // re-encode from the (stable) key and re-render per showCover
+  applyCoverToAll();
 };
 
 // ═══ Encrypted Message panel ═════════════════════════════════════════
@@ -1890,23 +1892,9 @@ window.encCopy = function() {
 
 window.encToggleCover = function() {
   showCover = !showCover;
-  // Re-render the cached ciphertext rather than re-encrypting.
-  if (encMode === 'encode' && encCipherHex) { encUpdateChrome(); encRenderFromHex(encCipherHex); }
-  else encUpdateChrome();
+  applyCoverToAll();
 };
 
-// ═══ Use-case selector ═══════════════════════════════════════════════
-
-window.selectUseCase = function(uc) {
-  document.querySelectorAll('.usecase-tab').forEach(t => t.classList.toggle('active', t.dataset.uc === uc));
-  document.getElementById('panel-bip39').classList.toggle('hidden', uc !== 'bip39');
-  document.getElementById('panel-apikey').classList.toggle('hidden', uc !== 'apikey');
-  document.getElementById('panel-encrypt').classList.toggle('hidden', uc !== 'encrypt');
-  // Re-render the shown panel so labels, highlights, and cover state are current.
-  if (uc === 'apikey') { akRun(); }
-  else if (uc === 'encrypt') { encUpdateChrome(); encRun(); }
-  else { updateChrome(); run(); }
-};
 // ─── Theme toggle ────────────────────────────────────────────────────
 
 const toggleBtn = document.getElementById('theme-toggle');
@@ -1968,8 +1956,6 @@ async function startup() {
       encTimer = setTimeout(() => { encRun(); }, 300);
     });
 
-    document.querySelectorAll('.usecase-tab').forEach(t =>
-      t.addEventListener('click', () => selectUseCase(t.dataset.uc)));
     akGenerate();
     encUpdateChrome();
     encSample();

--- a/web/index.html
+++ b/web/index.html
@@ -1156,10 +1156,13 @@ function placeCaretEnd(el) {
 let showCover = true;
 
 // The cleaned payload words present in prose, in order (cover words dropped).
+// Payload words are case-insensitive (and BIP39 words are canonically
+// lowercase), so the payload-only view normalizes them to lowercase.
 function payloadTokens(text, set) {
   return text.split(/\s+/)
     .map(t => t.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, ''))
-    .filter(t => t && set.has(norm(t)));
+    .filter(t => t && set.has(norm(t)))
+    .map(t => t.toLowerCase());
 }
 function payloadOnlyText(text, set) { return payloadTokens(text, set).join(' '); }
 


### PR DESCRIPTION
## Summary

Repositions the demo site around the human-vs-machine "language barrier" story and stops emphasizing modalities the live demo doesn't use (music, images).

### Landing page (`web/index.html`)
- **New positioning**: hero is now *"Computers Speak in Hex. Humans Speak in Language."*; tagline changed from "a universal linguistic codec" → **"human interfaces for machine data"**.
- Added a **"The Problem Isn't Encryption. It's Presentation."** section (ciphertext → prose visual) and a **"What Glossia Does"** applications list with the lossless guarantee.
- Dropped the engineer-y "composable codec algebra" framing from the "Why Glossia?" subhead.
- Trimmed music/image from the meta description, hero, section headers, and the "How It Works" branching diagram (now Text → Prose, Crypto → Armor). Music/image kept only as a soft "and other human-friendly forms" mention.

### Editor (`web/editor.html`)
- Disabled the **Music** and **Image** preset tabs (removed the tab buttons and their panels), leaving Text, Crypto, and Pipelines. Dropped `music` from the listed targets and from the meta description. The image/music JS handlers operate over `querySelectorAll`, so they're harmless no-ops with the markup gone.

## Notes
Further work in progress on this branch: an **Encryption** demo tab (compress + password-encrypt user input, then encode the ciphertext into language with the same language buttons and cover toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017HDg4fc3TjR4nJVHEaTvkf)_