### PR TITLE
feat(web): rename encryption passphrase, make it optional (encode w/o encryption)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -13,6 +13,12 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+# Run asynchronously: the session starts immediately while the toolchain installs
+# in the background. Trade-off: a web build attempted in the first moments of a
+# fresh container may race the install — cargo tests are unaffected (Rust is
+# pre-installed), and once the container state is cached this finishes instantly.
+echo '{"async": true, "asyncTimeout": 600000}'
+
 # 1. WASM compile target for build_web.sh (no-op if already added).
 rustup target add wasm32-unknown-unknown
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SessionStart hook: prepare a Claude Code on the web session to build and
+# verify the WASM web demo (web/index.html) in addition to running cargo tests.
+#
+# Rust stable is pre-installed in the web environment; the gap is the WASM
+# toolchain used by build_web.sh (the wasm32 target + wasm-pack). Everything
+# here is idempotent and fast on the common path (no-ops once the container
+# state is cached after the first run).
+set -euo pipefail
+
+# Web (remote) sessions only; do nothing on local machines.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# 1. WASM compile target for build_web.sh (no-op if already added).
+rustup target add wasm32-unknown-unknown
+
+# 2. wasm-pack. The prebuilt installer pulls a binary from GitHub releases,
+#    which the web environment's proxy blocks, so build it from source via cargo
+#    (cached after the first session). Only install when missing.
+if ! command -v wasm-pack >/dev/null 2>&1; then
+  cargo install wasm-pack --locked
+fi
+
+# 3. Warm the cargo dependency cache so the first build/test is fast and works
+#    even if the network tightens mid-session.
+cargo fetch --locked
+
+# NOTE: `./build_web.sh` runs wasm-pack's wasm-opt size pass, which downloads
+# binaryen from GitHub releases and is blocked by the proxy. That step is
+# non-fatal — wasm-pack still emits pkg/glossia_bg.wasm and pkg/glossia.js
+# before it runs, which is sufficient to serve and browser-verify web/. CI
+# performs the optimized build for the deployed site.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,13 @@ venv/
 ENV/
 .venv
 
-# Claude Code
-.claude/
+# Claude Code — ignore local state, but share project config (CLAUDE.md,
+# settings, and hooks so web sessions are reproducible).
+.claude/*
+!.claude/CLAUDE.md
+!.claude/settings.json
+!.claude/hooks/
+.claude/settings.local.json
 
 # Temporary files
 *.tmp

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1789,42 +1789,38 @@ pub fn decode_from_language(
     decode_from_language_with_payload_lang(text, language, language, wordlist, verbose, "body", None)
 }
 
-/// Decode extracted payload words to bytes, resolving the bare-vs-framed ambiguity.
+/// Choose the decode codec for a sequence of extracted payload words.
 ///
 /// Framed Glossia prose carries a leading padding-count word and is interspersed
-/// with cover/function words. When cover words are present (`payload_words <
-/// total_tokens`) the input is unambiguously framed and decodes through the
-/// grammar's declared codec (`bitpack` for power-of-two wordlists).
+/// with cover/function words, so it round-trips through the grammar's declared
+/// codec (`bitpack` for power-of-two wordlists). A *bare* payload sequence — e.g.
+/// a raw BIP39 mnemonic typed directly rather than produced by Glossia's encoder
+/// — has no padding word and no cover words: every input token is a payload word.
+/// Handing such input to `bitpack` misreads the first word as a padding count,
+/// leaving `(N-1) * bits_per_word` data bits that are almost never byte-aligned,
+/// so the decode aborts with "data_bits not byte-aligned" (issue #23).
 ///
-/// When *every* input token is a payload word (`payload_words == total_tokens`)
-/// the input is ambiguous: it may be a cover-hidden Glossia payload sequence —
-/// whose leading padding word still makes `bitpack` valid — or a *bare* mnemonic
-/// typed directly, which has no padding word. Crucially these are distinguishable
-/// at decode time: `bitpack` reads the first word as a padding count and rejects
-/// it unless it is `< bits_per_word` AND leaves byte-aligned data (see
-/// `decode_bitpack`). A bare mnemonic's first word is real data, so it almost
-/// always fails one of those checks. So we *try* `bitpack` first and fall back to
-/// `base_n` only when it genuinely can't decode — recovering cover-hidden payload
-/// sequences without breaking bare mnemonics (issue #23).
-fn decode_extracted_words(
-    extracted: &[String],
-    tree: &WordlistTree,
-    grammar_codec: &str,
-    all_payload: bool,
-) -> Result<Vec<u8>, codec::DecodeError> {
-    if grammar_codec == "bitpack" && all_payload && !extracted.is_empty() {
-        codec::decode_base_n(extracted, tree, "bitpack")
-            .or_else(|_| codec::decode_base_n(extracted, tree, "base_n"))
+/// When every input token is a payload word (`payload_words == total_tokens`) the
+/// input is unframed; decode it as a plain base-N integer instead — the same
+/// interpretation the `raw` dialect path uses for bare mnemonics. Only `bitpack`
+/// is rerouted; `base_n` already handles unframed input.
+fn decode_codec_for_input<'a>(
+    grammar_codec: &'a str,
+    total_tokens: usize,
+    payload_words: usize,
+) -> &'a str {
+    if grammar_codec == "bitpack" && payload_words > 0 && payload_words == total_tokens {
+        "base_n"
     } else {
-        codec::decode_base_n(extracted, tree, grammar_codec)
+        grammar_codec
     }
 }
 
 /// Count whitespace-delimited input tokens that survive alphanumeric trimming.
 ///
-/// Used to detect all-payload input: when this equals the number of extracted
-/// payload words, the input carries no cover words (see
-/// [`decode_extracted_words`]).
+/// Used to detect bare/unframed payload input: when this equals the number of
+/// extracted payload words, the input carries no cover words (see
+/// [`decode_codec_for_input`]).
 fn alnum_token_count(text: &str) -> usize {
     text.split_whitespace()
         .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
@@ -1923,12 +1919,14 @@ fn decode_from_language_with_payload_lang(
     }
 
     // 4. Payload words → binary → data string (base-N decoding).
-    // For the grammar's bitpack codec, an all-payload input (no cover words) may
-    // be a cover-hidden Glossia sequence (valid bitpack) or a bare mnemonic (no
-    // padding word); decode_extracted_words tries bitpack then falls back to
-    // base_n (issue #23 / cover-hidden payload).
-    let all_payload = !payload_separator.is_empty() && alnum_token_count(text) == extracted.len();
-    let bytes = decode_extracted_words(&extracted, &*payload_tree, grammar.codec(), all_payload)
+    // Bare/unframed input (a raw mnemonic: all tokens are payload words) has no
+    // bitpack padding header, so decode it as base-N instead (issue #23).
+    let codec_name = if payload_separator.is_empty() {
+        grammar.codec()
+    } else {
+        decode_codec_for_input(grammar.codec(), alnum_token_count(text), extracted.len())
+    };
+    let bytes = codec::decode_base_n(&extracted, &*payload_tree, codec_name)
         .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
     Ok(render_decoded_bytes(&bytes, format))
 }
@@ -2024,12 +2022,14 @@ fn decode_from_language_rich_with_payload_lang(
     }
 
     // 4. Payload words → binary → data string (base-N decoding).
-    // For the grammar's bitpack codec, an all-payload input (no cover words) may
-    // be a cover-hidden Glossia sequence (valid bitpack) or a bare mnemonic (no
-    // padding word); decode_extracted_words tries bitpack then falls back to
-    // base_n (issue #23 / cover-hidden payload).
-    let all_payload = !payload_separator.is_empty() && alnum_token_count(text) == extracted.len();
-    let bytes = decode_extracted_words(&extracted, &*payload_tree, grammar.codec(), all_payload)
+    // Bare/unframed input (a raw mnemonic: all tokens are payload words) has no
+    // bitpack padding header, so decode it as base-N instead (issue #23).
+    let codec_name = if payload_separator.is_empty() {
+        grammar.codec()
+    } else {
+        decode_codec_for_input(grammar.codec(), alnum_token_count(text), extracted.len())
+    };
+    let bytes = codec::decode_base_n(&extracted, &*payload_tree, codec_name)
         .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
     let decoded = render_decoded_bytes(&bytes, format);
 
@@ -2367,26 +2367,38 @@ mod tests {
     }
 
     #[test]
-    fn test_cover_hidden_payload_round_trip() {
-        // Regression: an arbitrary-length ASCII key encoded into prose
-        // must still decode from its cover-hidden payload-only word sequence. The
-        // sequence is all payload words (like a bare mnemonic) but carries a
-        // leading bitpack padding word, so decode must try bitpack before base_n.
+    fn test_decode_codec_for_input_detects_bare_vs_framed() {
+        // Every input token is a payload word → unframed bare mnemonic → base_n.
+        assert_eq!(decode_codec_for_input("bitpack", 4, 4), "base_n");
+        // Cover words present (more tokens than payload words) → framed → bitpack.
+        assert_eq!(decode_codec_for_input("bitpack", 9, 4), "bitpack");
+        // Non-bitpack codecs already handle unframed input and are never rerouted.
+        assert_eq!(decode_codec_for_input("base_n", 4, 4), "base_n");
+        // No payload words extracted → keep the declared codec.
+        assert_eq!(decode_codec_for_input("bitpack", 0, 0), "bitpack");
+    }
+
+    #[test]
+    fn test_bip39_dialect_arbitrary_key_round_trip() {
+        // The API Key demo encodes arbitrary-length keys through the bip39 dialect
+        // (base_n, no padding word) so the cover-hidden payload-only sequence is a
+        // clean, round-trippable data sequence. Verify both the full prose and the
+        // payload-only word list decode back to the original key.
         let key = "sk-1SYMaH9HEJ5CHFMDQd5GoBtjRQzwOPQK";
-        let enc = Pipeline::from_meta("encode into english naturally").unwrap();
+        let enc = Pipeline::from_meta("encode into english bip39").unwrap();
         let prose = enc.execute(key).unwrap();
 
-        // Strip cover words → bare payload sequence (what "Hide cover" shows).
+        let dec = Pipeline::from_meta("transcode from english/bip39/bip39 into ascii7").unwrap();
+        assert_eq!(dec.execute(&prose).unwrap(), key, "full prose must round-trip");
+
+        // Strip cover words → the cover-hidden payload-only view.
         let tree = cached_payload_tree("english", "bip39").unwrap();
-        let payload_only: Vec<&str> = prose
+        let bare: String = prose
             .split_whitespace()
             .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
             .filter(|w| !w.is_empty() && tree.contains(&w.to_lowercase()))
-            .collect();
-        let bare = payload_only.join(" ");
-
-        let dec = Pipeline::from_meta("transcode from english/bip39/body into ascii7").unwrap();
-        assert_eq!(dec.execute(&prose).unwrap(), key, "full prose must round-trip");
+            .collect::<Vec<_>>()
+            .join(" ");
         assert_eq!(dec.execute(&bare).unwrap(), key, "cover-hidden payload must round-trip");
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1789,38 +1789,42 @@ pub fn decode_from_language(
     decode_from_language_with_payload_lang(text, language, language, wordlist, verbose, "body", None)
 }
 
-/// Choose the decode codec for a sequence of extracted payload words.
+/// Decode extracted payload words to bytes, resolving the bare-vs-framed ambiguity.
 ///
 /// Framed Glossia prose carries a leading padding-count word and is interspersed
-/// with cover/function words, so it round-trips through the grammar's declared
-/// codec (`bitpack` for power-of-two wordlists). A *bare* payload sequence — e.g.
-/// a raw BIP39 mnemonic typed directly rather than produced by Glossia's encoder
-/// — has no padding word and no cover words: every input token is a payload word.
-/// Handing such input to `bitpack` misreads the first word as a padding count,
-/// leaving `(N-1) * bits_per_word` data bits that are almost never byte-aligned,
-/// so the decode aborts with "data_bits not byte-aligned" (issue #23).
+/// with cover/function words. When cover words are present (`payload_words <
+/// total_tokens`) the input is unambiguously framed and decodes through the
+/// grammar's declared codec (`bitpack` for power-of-two wordlists).
 ///
-/// When every input token is a payload word (`payload_words == total_tokens`) the
-/// input is unframed; decode it as a plain base-N integer instead — the same
-/// interpretation the `raw` dialect path uses for bare mnemonics. Only `bitpack`
-/// is rerouted; `base_n` already handles unframed input.
-fn decode_codec_for_input<'a>(
-    grammar_codec: &'a str,
-    total_tokens: usize,
-    payload_words: usize,
-) -> &'a str {
-    if grammar_codec == "bitpack" && payload_words > 0 && payload_words == total_tokens {
-        "base_n"
+/// When *every* input token is a payload word (`payload_words == total_tokens`)
+/// the input is ambiguous: it may be a cover-hidden Glossia payload sequence —
+/// whose leading padding word still makes `bitpack` valid — or a *bare* mnemonic
+/// typed directly, which has no padding word. Crucially these are distinguishable
+/// at decode time: `bitpack` reads the first word as a padding count and rejects
+/// it unless it is `< bits_per_word` AND leaves byte-aligned data (see
+/// `decode_bitpack`). A bare mnemonic's first word is real data, so it almost
+/// always fails one of those checks. So we *try* `bitpack` first and fall back to
+/// `base_n` only when it genuinely can't decode — recovering cover-hidden payload
+/// sequences without breaking bare mnemonics (issue #23).
+fn decode_extracted_words(
+    extracted: &[String],
+    tree: &WordlistTree,
+    grammar_codec: &str,
+    all_payload: bool,
+) -> Result<Vec<u8>, codec::DecodeError> {
+    if grammar_codec == "bitpack" && all_payload && !extracted.is_empty() {
+        codec::decode_base_n(extracted, tree, "bitpack")
+            .or_else(|_| codec::decode_base_n(extracted, tree, "base_n"))
     } else {
-        grammar_codec
+        codec::decode_base_n(extracted, tree, grammar_codec)
     }
 }
 
 /// Count whitespace-delimited input tokens that survive alphanumeric trimming.
 ///
-/// Used to detect bare/unframed payload input: when this equals the number of
-/// extracted payload words, the input carries no cover words (see
-/// [`decode_codec_for_input`]).
+/// Used to detect all-payload input: when this equals the number of extracted
+/// payload words, the input carries no cover words (see
+/// [`decode_extracted_words`]).
 fn alnum_token_count(text: &str) -> usize {
     text.split_whitespace()
         .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
@@ -1919,14 +1923,12 @@ fn decode_from_language_with_payload_lang(
     }
 
     // 4. Payload words → binary → data string (base-N decoding).
-    // Bare/unframed input (a raw mnemonic: all tokens are payload words) has no
-    // bitpack padding header, so decode it as base-N instead (issue #23).
-    let codec_name = if payload_separator.is_empty() {
-        grammar.codec()
-    } else {
-        decode_codec_for_input(grammar.codec(), alnum_token_count(text), extracted.len())
-    };
-    let bytes = codec::decode_base_n(&extracted, &*payload_tree, codec_name)
+    // For the grammar's bitpack codec, an all-payload input (no cover words) may
+    // be a cover-hidden Glossia sequence (valid bitpack) or a bare mnemonic (no
+    // padding word); decode_extracted_words tries bitpack then falls back to
+    // base_n (issue #23 / cover-hidden payload).
+    let all_payload = !payload_separator.is_empty() && alnum_token_count(text) == extracted.len();
+    let bytes = decode_extracted_words(&extracted, &*payload_tree, grammar.codec(), all_payload)
         .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
     Ok(render_decoded_bytes(&bytes, format))
 }
@@ -2022,14 +2024,12 @@ fn decode_from_language_rich_with_payload_lang(
     }
 
     // 4. Payload words → binary → data string (base-N decoding).
-    // Bare/unframed input (a raw mnemonic: all tokens are payload words) has no
-    // bitpack padding header, so decode it as base-N instead (issue #23).
-    let codec_name = if payload_separator.is_empty() {
-        grammar.codec()
-    } else {
-        decode_codec_for_input(grammar.codec(), alnum_token_count(text), extracted.len())
-    };
-    let bytes = codec::decode_base_n(&extracted, &*payload_tree, codec_name)
+    // For the grammar's bitpack codec, an all-payload input (no cover words) may
+    // be a cover-hidden Glossia sequence (valid bitpack) or a bare mnemonic (no
+    // padding word); decode_extracted_words tries bitpack then falls back to
+    // base_n (issue #23 / cover-hidden payload).
+    let all_payload = !payload_separator.is_empty() && alnum_token_count(text) == extracted.len();
+    let bytes = decode_extracted_words(&extracted, &*payload_tree, grammar.codec(), all_payload)
         .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
     let decoded = render_decoded_bytes(&bytes, format);
 
@@ -2367,15 +2367,27 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_codec_for_input_detects_bare_vs_framed() {
-        // Every input token is a payload word → unframed bare mnemonic → base_n.
-        assert_eq!(decode_codec_for_input("bitpack", 4, 4), "base_n");
-        // Cover words present (more tokens than payload words) → framed → bitpack.
-        assert_eq!(decode_codec_for_input("bitpack", 9, 4), "bitpack");
-        // Non-bitpack codecs already handle unframed input and are never rerouted.
-        assert_eq!(decode_codec_for_input("base_n", 4, 4), "base_n");
-        // No payload words extracted → keep the declared codec.
-        assert_eq!(decode_codec_for_input("bitpack", 0, 0), "bitpack");
+    fn test_cover_hidden_payload_round_trip() {
+        // Regression: an arbitrary-length ASCII key encoded into prose
+        // must still decode from its cover-hidden payload-only word sequence. The
+        // sequence is all payload words (like a bare mnemonic) but carries a
+        // leading bitpack padding word, so decode must try bitpack before base_n.
+        let key = "sk-1SYMaH9HEJ5CHFMDQd5GoBtjRQzwOPQK";
+        let enc = Pipeline::from_meta("encode into english naturally").unwrap();
+        let prose = enc.execute(key).unwrap();
+
+        // Strip cover words → bare payload sequence (what "Hide cover" shows).
+        let tree = cached_payload_tree("english", "bip39").unwrap();
+        let payload_only: Vec<&str> = prose
+            .split_whitespace()
+            .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
+            .filter(|w| !w.is_empty() && tree.contains(&w.to_lowercase()))
+            .collect();
+        let bare = payload_only.join(" ");
+
+        let dec = Pipeline::from_meta("transcode from english/bip39/body into ascii7").unwrap();
+        assert_eq!(dec.execute(&prose).unwrap(), key, "full prose must round-trip");
+        assert_eq!(dec.execute(&bare).unwrap(), key, "cover-hidden payload must round-trip");
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1789,38 +1789,42 @@ pub fn decode_from_language(
     decode_from_language_with_payload_lang(text, language, language, wordlist, verbose, "body", None)
 }
 
-/// Choose the decode codec for a sequence of extracted payload words.
+/// Decode extracted payload words to bytes, resolving the bare-vs-framed ambiguity.
 ///
 /// Framed Glossia prose carries a leading padding-count word and is interspersed
-/// with cover/function words, so it round-trips through the grammar's declared
-/// codec (`bitpack` for power-of-two wordlists). A *bare* payload sequence — e.g.
-/// a raw BIP39 mnemonic typed directly rather than produced by Glossia's encoder
-/// — has no padding word and no cover words: every input token is a payload word.
-/// Handing such input to `bitpack` misreads the first word as a padding count,
-/// leaving `(N-1) * bits_per_word` data bits that are almost never byte-aligned,
-/// so the decode aborts with "data_bits not byte-aligned" (issue #23).
+/// with cover/function words. When cover words are present (`payload_words <
+/// total_tokens`) the input is unambiguously framed and decodes through the
+/// grammar's declared codec (`bitpack` for power-of-two wordlists).
 ///
-/// When every input token is a payload word (`payload_words == total_tokens`) the
-/// input is unframed; decode it as a plain base-N integer instead — the same
-/// interpretation the `raw` dialect path uses for bare mnemonics. Only `bitpack`
-/// is rerouted; `base_n` already handles unframed input.
-fn decode_codec_for_input<'a>(
-    grammar_codec: &'a str,
-    total_tokens: usize,
-    payload_words: usize,
-) -> &'a str {
-    if grammar_codec == "bitpack" && payload_words > 0 && payload_words == total_tokens {
-        "base_n"
+/// When *every* input token is a payload word (`payload_words == total_tokens`)
+/// the input is ambiguous: it may be a cover-hidden Glossia payload sequence —
+/// whose leading padding word still makes `bitpack` valid — or a *bare* mnemonic
+/// typed directly, which has no padding word. Crucially these are distinguishable
+/// at decode time: `bitpack` reads the first word as a padding count and rejects
+/// it unless it is `< bits_per_word` AND leaves byte-aligned data (see
+/// `decode_bitpack`). A bare mnemonic's first word is real data, so it almost
+/// always fails one of those checks. So we *try* `bitpack` first and fall back to
+/// `base_n` only when it genuinely can't decode — recovering cover-hidden payload
+/// sequences without breaking bare mnemonics (issue #23).
+fn decode_extracted_words(
+    extracted: &[String],
+    tree: &WordlistTree,
+    grammar_codec: &str,
+    all_payload: bool,
+) -> Result<Vec<u8>, codec::DecodeError> {
+    if grammar_codec == "bitpack" && all_payload && !extracted.is_empty() {
+        codec::decode_base_n(extracted, tree, "bitpack")
+            .or_else(|_| codec::decode_base_n(extracted, tree, "base_n"))
     } else {
-        grammar_codec
+        codec::decode_base_n(extracted, tree, grammar_codec)
     }
 }
 
 /// Count whitespace-delimited input tokens that survive alphanumeric trimming.
 ///
-/// Used to detect bare/unframed payload input: when this equals the number of
-/// extracted payload words, the input carries no cover words (see
-/// [`decode_codec_for_input`]).
+/// Used to detect all-payload input: when this equals the number of extracted
+/// payload words, the input carries no cover words (see
+/// [`decode_extracted_words`]).
 fn alnum_token_count(text: &str) -> usize {
     text.split_whitespace()
         .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
@@ -1919,14 +1923,12 @@ fn decode_from_language_with_payload_lang(
     }
 
     // 4. Payload words → binary → data string (base-N decoding).
-    // Bare/unframed input (a raw mnemonic: all tokens are payload words) has no
-    // bitpack padding header, so decode it as base-N instead (issue #23).
-    let codec_name = if payload_separator.is_empty() {
-        grammar.codec()
-    } else {
-        decode_codec_for_input(grammar.codec(), alnum_token_count(text), extracted.len())
-    };
-    let bytes = codec::decode_base_n(&extracted, &*payload_tree, codec_name)
+    // For the grammar bitpack codec, an all-payload input (no cover words) may be
+    // a cover-hidden Glossia sequence (valid bitpack) or a bare mnemonic (no
+    // padding word); decode_extracted_words tries bitpack then falls back to
+    // base_n (issue #23).
+    let all_payload = !payload_separator.is_empty() && alnum_token_count(text) == extracted.len();
+    let bytes = decode_extracted_words(&extracted, &*payload_tree, grammar.codec(), all_payload)
         .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
     Ok(render_decoded_bytes(&bytes, format))
 }
@@ -2022,14 +2024,12 @@ fn decode_from_language_rich_with_payload_lang(
     }
 
     // 4. Payload words → binary → data string (base-N decoding).
-    // Bare/unframed input (a raw mnemonic: all tokens are payload words) has no
-    // bitpack padding header, so decode it as base-N instead (issue #23).
-    let codec_name = if payload_separator.is_empty() {
-        grammar.codec()
-    } else {
-        decode_codec_for_input(grammar.codec(), alnum_token_count(text), extracted.len())
-    };
-    let bytes = codec::decode_base_n(&extracted, &*payload_tree, codec_name)
+    // For the grammar bitpack codec, an all-payload input (no cover words) may be
+    // a cover-hidden Glossia sequence (valid bitpack) or a bare mnemonic (no
+    // padding word); decode_extracted_words tries bitpack then falls back to
+    // base_n (issue #23).
+    let all_payload = !payload_separator.is_empty() && alnum_token_count(text) == extracted.len();
+    let bytes = decode_extracted_words(&extracted, &*payload_tree, grammar.codec(), all_payload)
         .map_err(|e| PipelineError::DecodeError(format!("{}", e)))?;
     let decoded = render_decoded_bytes(&bytes, format);
 
@@ -2367,15 +2367,35 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_codec_for_input_detects_bare_vs_framed() {
-        // Every input token is a payload word → unframed bare mnemonic → base_n.
-        assert_eq!(decode_codec_for_input("bitpack", 4, 4), "base_n");
-        // Cover words present (more tokens than payload words) → framed → bitpack.
-        assert_eq!(decode_codec_for_input("bitpack", 9, 4), "bitpack");
-        // Non-bitpack codecs already handle unframed input and are never rerouted.
-        assert_eq!(decode_codec_for_input("base_n", 4, 4), "base_n");
-        // No payload words extracted → keep the declared codec.
-        assert_eq!(decode_codec_for_input("bitpack", 0, 0), "bitpack");
+    fn test_cover_hidden_payload_round_trip() {
+        // The API Key demo encodes via the body dialect (bitpack, padding word).
+        // Its cover-hidden payload-only sequence is all payload words (like a bare
+        // mnemonic) but carries a leading padding word, so decode must try bitpack
+        // before base_n. Verify both full prose and payload-only decode back, and
+        // that a leading-0x00 key survives (the reason we keep the padding word).
+        let enc = Pipeline::from_meta("encode into english naturally").unwrap();
+        let dec = Pipeline::from_meta("transcode from english/bip39/body into ascii7").unwrap();
+        let dec_hex = Pipeline::from_meta("transcode from english/bip39/body into hex").unwrap();
+        let tree = cached_payload_tree("english", "bip39").unwrap();
+        let strip_cover = |prose: &str| -> String {
+            prose.split_whitespace()
+                .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
+                .filter(|w| !w.is_empty() && tree.contains(&w.to_lowercase()))
+                .collect::<Vec<_>>()
+                .join(" ")
+        };
+
+        let key = "sk-1SYMaH9HEJ5CHFMDQd5GoBtjRQzwOPQK";
+        let prose = enc.execute(key).unwrap();
+        assert_eq!(dec.execute(&prose).unwrap(), key, "full prose must round-trip");
+        assert_eq!(dec.execute(&strip_cover(&prose)).unwrap(), key, "cover-hidden must round-trip");
+
+        // A hex key with a leading zero byte: bitpack preserves it exactly.
+        let hex = "00abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456700";
+        let enc_hex = Pipeline::from_meta("transcode from hex into english/bip39/body").unwrap();
+        let hprose = enc_hex.execute(hex).unwrap();
+        assert_eq!(dec_hex.execute(&hprose).unwrap(), hex, "leading-zero hex must round-trip");
+        assert_eq!(dec_hex.execute(&strip_cover(&hprose)).unwrap(), hex, "cover-hidden leading-zero hex");
     }
 
     #[test]

--- a/web/index.html
+++ b/web/index.html
@@ -943,7 +943,7 @@ footer a:hover { text-decoration: underline; }
       <!-- ─── Encrypted Message panel ─────────────────────────────── -->
       <div id="panel-encrypt">
         <div class="section-header">
-          <h3>Madlib Encryption</h3>
+          <h3>Madlib Encoding</h3>
           <p>Compress and optionally password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text into readable prose &mdash; encrypting adds a compact <code>key:</code> prefix carrying the salt &mdash; and decode it back byte-for-byte (with the same passphrase, if one was set)</p>
         </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -846,11 +846,17 @@ footer a:hover { text-decoration: underline; }
         .enc-entropy { font-family: var(--font-mono); font-size: 0.65rem; color: var(--text-dim); white-space: nowrap; }
         .enc-entropy.strong { color: var(--success); }
         .enc-key { color: var(--text-dim); word-break: break-all; }
-        .enc-note-ref { color: var(--accent); text-decoration: none; font-weight: 700; }
-        .enc-note { max-width: 700px; margin: 1rem auto 0; font-size: 0.75rem; line-height: 1.6;
-          color: var(--text-dim); text-align: center; scroll-margin-top: 2rem; }
-        .enc-note strong { color: var(--accent); }
-        .enc-note a { color: var(--accent); }
+        .enc-how { max-width: 700px; margin: 1.25rem auto 0; scroll-margin-top: 2rem; }
+        .enc-how summary { cursor: pointer; width: fit-content; margin: 0 auto;
+          font-family: var(--font-mono); font-size: 0.68rem; text-transform: uppercase;
+          letter-spacing: 0.05em; color: var(--text-dim); }
+        .enc-how summary:hover { color: var(--accent); }
+        .enc-how[open] summary { margin-bottom: 0.75rem; }
+        .enc-how-body { font-size: 0.78rem; line-height: 1.6; color: var(--text-dim); text-align: left; }
+        .enc-how-body p { margin: 0 0 0.7rem; }
+        .enc-how-body p:last-child { margin-bottom: 0; }
+        .enc-how-body strong { color: var(--accent); }
+        .enc-how-body a { color: var(--accent); }
       </style>
 
       <!-- ─── BIP39 panel ─────────────────────────────────────────── -->
@@ -944,7 +950,7 @@ footer a:hover { text-decoration: underline; }
       <div id="panel-encrypt">
         <div class="section-header">
           <h3>Madlib Encoding</h3>
-          <p>Compress and optionally password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text into readable prose &mdash; encrypting adds a compact <code>key:</code> prefix carrying the salt &mdash; and decode it back byte-for-byte (with the same passphrase, if one was set)</p>
+          <p>Turn any text into readable prose &mdash; add a passphrase to encrypt it, or leave it blank to just encode. Decodes back byte-for-byte.</p>
         </div>
 
         <div class="enc-password-row">
@@ -989,18 +995,28 @@ footer a:hover { text-decoration: underline; }
 
         <p class="demo-hint" id="enc-hint"></p>
 
-        <p class="enc-note" id="enc-note">
-          <strong>*</strong> AES-CTR keeps your message confidential but is <em>not</em> authenticated &mdash; it
-          can&rsquo;t detect tampering. In principle, someone who intercepts the ciphertext could flip bits to
-          alter the decoded message in controlled ways, without ever knowing the passphrase. That&rsquo;s
-          impractical here, where messages are copy-pasted by hand into chats and posts, but it&rsquo;s a real
-          property of unauthenticated encryption. For tamper-proof, end-to-end secure messaging, use a signed
-          protocol like <a href="https://nostr-mail.com" target="_blank" rel="noopener">nostr-mail</a>.
-          The base64 <code>key:</code> is plaintext metadata &mdash; the payload length, plus a per-message
-          salt when a passphrase is set &mdash; not a secret and not part of the passphrase; only the
-          passphrase unlocks an encrypted message. With no passphrase, the text is encoded (and possibly
-          compressed) but <em>not</em> encrypted, and there is no salt.
-        </p>
+        <details class="enc-how" id="enc-how">
+          <summary>How it works</summary>
+          <div class="enc-how-body">
+            <p><strong>Encoding.</strong> Your text is compressed (gzip or a 7-bit ASCII pack, whichever is
+            smaller) and bit-packed into payload words, which are woven into grammatically valid prose.
+            Decoding filters the prose back down to those words and reverses the packing &mdash;
+            byte-for-byte. With no passphrase the output is pure prose; a tiny <code>[flag][length]</code>
+            header rides along inside the payload, so there&rsquo;s nothing else to carry.</p>
+            <p><strong>Encryption.</strong> Add a passphrase and the compressed bytes are encrypted with
+            AES-CTR before encoding. The passphrase is stretched with PBKDF2 (SHA-256, 200k iterations) to
+            derive both the key and the nonce from a fresh per-message salt, so the nonce never has to be
+            transmitted. The artifact gains a compact <code>key:</code> prefix &mdash; base64url plaintext
+            metadata holding the salt and ciphertext length, not a secret. Only the passphrase unlocks the
+            message.</p>
+            <p><strong>Caveat.</strong> AES-CTR keeps your message confidential but is <em>not</em>
+            authenticated &mdash; it can&rsquo;t detect tampering. Someone who intercepts the ciphertext could
+            flip bits to alter the decoded message in controlled ways without ever knowing the passphrase.
+            That&rsquo;s impractical for messages copy-pasted by hand into chats and posts, but it&rsquo;s a
+            real property of unauthenticated encryption. For tamper-proof, end-to-end secure messaging, use a
+            signed protocol like <a href="https://nostr-mail.com" target="_blank" rel="noopener">nostr-mail</a>.</p>
+          </div>
+        </details>
       </div>
     </section>
 
@@ -1921,21 +1937,15 @@ function encUpdateChrome() {
     coverBtn.classList.remove('hidden');
     coverBtn.textContent = coverEnc ? 'Hide cover' : 'Show cover';
     hint.textContent = encPassword()
-      ? 'Compresses and AES-CTR-encrypts your message, then writes a “key: value” pair — the ' +
-        'base64 key holds the per-message salt, the ' + encLangById(encLang).label + ' prose holds the ciphertext ' +
-        '(payload words underlined). Pick the target language on the right; press ⇄ to decode.'
-      : 'No passphrase — compresses and encodes your message (not encrypted) into ' +
-        encLangById(encLang).label + ' prose (payload words underlined). Add a passphrase to encrypt; ' +
-        'press ⇄ to decode.';
+      ? 'Encrypting, then encoding as ' + encLangById(encLang).label + ' prose. Press ⇄ to decode.'
+      : 'Encoding as ' + encLangById(encLang).label + ' prose — no passphrase, not encrypted. Press ⇄ to decode.';
   } else {
     document.getElementById('enc-left-label').textContent = encLangById(encDetLang).label + ' sentences (detected)';
     document.getElementById('enc-right-label').textContent = 'Decoded message';
     langRow.classList.add('hidden');
     genBtn.classList.add('hidden');
     coverBtn.classList.add('hidden');
-    hint.textContent = 'Detected ' + encLangById(encDetLang).label + ' prose (payload words underlined); ' +
-      'decoding to recover the original message (a passphrase is needed only if it was encrypted). ' +
-      'Press ⇄ to go back to encoding.';
+    hint.textContent = 'Decoding ' + encLangById(encDetLang).label + ' prose back to your message. Press ⇄ to encode.';
   }
   encUpdateHighlights();
 }

--- a/web/index.html
+++ b/web/index.html
@@ -1437,14 +1437,14 @@ let akDetLang = 'english';   // SOURCE language auto-detected from left prose (d
 let akDetFmt = '';           // SOURCE format auto-detected from the key (encode), display only
 let akTimer = null;
 
-// The bip39 dialect encodes with base_n (no bitpack padding word), so the
-// payload words are pure data — the cover-hidden view is a clean, round-trippable
-// sequence (like a BIP39 mnemonic) rather than carrying a padding-count word that
-// a bare sequence would misread on decode.
+// The body dialect encodes with bitpack: a leading padding word records the bit
+// length, so arbitrary-length keys (including leading-zero bytes) round-trip
+// exactly. The padding word travels with the payload, so the cover-hidden view
+// stays decodable — the decoder tries bitpack before falling back to base_n.
 const AK_LANGS = [
-  { id: 'english', label: 'English', source: 'english/bip39/bip39' },
-  { id: 'latin',   label: 'Latin',   source: 'latin/default/bip39' },
-  { id: 'czech',   label: 'Czech',   source: 'czech/default/bip39' },
+  { id: 'english', label: 'English', source: 'english/bip39/body' },
+  { id: 'latin',   label: 'Latin',   source: 'latin/default/body' },
+  { id: 'czech',   label: 'Czech',   source: 'czech/default/body' },
 ];
 const AK_FORMATS = [
   { id: 'ascii7', label: 'ASCII',  word: 'ascii7' },
@@ -1570,7 +1570,7 @@ function akRun() {
   if (!text) { akSetOutput(''); return; }
   try {
     if (akMode === 'encode') {
-      const r = JSON.parse(wasmTranscode(text, 'encode into ' + akLang + ' bip39', SEED));
+      const r = JSON.parse(wasmTranscode(text, 'encode into ' + akLang + ' naturally', SEED));
       if (r.error) { akShowError(r.error); akSetOutput(''); return; }
       akDetFmt = r.data_mode || '';
       const out = (r.output || '').trim();

--- a/web/index.html
+++ b/web/index.html
@@ -944,7 +944,7 @@ footer a:hover { text-decoration: underline; }
       <div id="panel-encrypt">
         <div class="section-header">
           <h3>Madlib Encryption</h3>
-          <p>Compress and optionally password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text into a <code>key:&nbsp;value</code> pair &mdash; a compact key, the payload as readable prose &mdash; and decode it back byte-for-byte (with the same passphrase, if one was set)</p>
+          <p>Compress and optionally password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text into readable prose &mdash; encrypting adds a compact <code>key:</code> prefix carrying the salt &mdash; and decode it back byte-for-byte (with the same passphrase, if one was set)</p>
         </div>
 
         <div class="enc-password-row">
@@ -1642,12 +1642,19 @@ function encSetOutput(text, html) {
   el.dataset.plainText = text;
 }
 
-// Render the "<key>: prose" artifact: dim base64url key, then the prose value.
+// Render the artifact. When encrypted it's "<key>: prose" (dim base64url key,
+// then the prose value); with no passphrase there is no key — just the prose,
+// which already carries its own [flag][length] header embedded in the payload.
 function encSetArtifact(header, prosePlain, proseHtml) {
   const el = document.getElementById('enc-right-box');
   el.classList.remove('empty');
-  el.innerHTML = '<span class="enc-key">' + escapeHtml(header) + '</span>: ' + proseHtml;
-  el.dataset.plainText = header + ': ' + prosePlain;
+  if (header) {
+    el.innerHTML = '<span class="enc-key">' + escapeHtml(header) + '</span>: ' + proseHtml;
+    el.dataset.plainText = header + ': ' + prosePlain;
+  } else {
+    el.innerHTML = proseHtml;
+    el.dataset.plainText = prosePlain;
+  }
 }
 
 // ─── compression (CompressionStream) + AES-CTR (WebCrypto) helpers ────
@@ -1769,13 +1776,19 @@ function b64urlDecode(str) {
   return out;
 }
 
-// Artifact format: "<key>: <prose>".
-//   key   = base64url( [flag:1][ctlen:varint][salt:8?] )  — the machine plumbing
-//   prose = Glossia-encoded payload only                   — the human-readable value
-// The flag's low bits (0x7f) hold the reduction method; the high bit (0x80) marks
-// an encrypted payload, in which case the per-message salt follows. With no
-// passphrase the high bit is clear and the salt is omitted entirely.
-// AES-CTR is a stream cipher (no tag/padding), so the prose carries exactly the
+// Two artifact shapes, depending on whether a passphrase was set:
+//
+//   encrypted:    "<key>: <prose>"
+//                 key   = base64url( [flag|0x80:1][ctlen:varint][salt:8] )
+//                 prose = Glossia-encoded ciphertext only
+//
+//   unencrypted:  "<prose>"   (no key — nothing secret to carry)
+//                 prose = Glossia-encoded [flag:1][len:varint][data] — the tiny
+//                         header rides along inside the payload, so the output is
+//                         pure readable prose.
+//
+// In both cases the flag's low bits (0x7f) hold the reduction method. AES-CTR is a
+// stream cipher (no tag/padding), so the encrypted prose carries exactly the
 // ciphertext.
 //
 // NOTE: AES-CTR provides confidentiality only — it is NOT authenticated, so it
@@ -1783,58 +1796,68 @@ function b64urlDecode(str) {
 const ENC_FLAG_ENCRYPTED = 0x80;
 function encBuildHeader(flag, ctlen, salt) {
   const lp = varintEncode(ctlen);
-  const saltLen = salt ? salt.length : 0;
-  const h = new Uint8Array(1 + lp.length + saltLen);
-  h[0] = salt ? (flag | ENC_FLAG_ENCRYPTED) : flag;
+  const h = new Uint8Array(1 + lp.length + salt.length);
+  h[0] = flag | ENC_FLAG_ENCRYPTED;
   h.set(lp, 1);
-  if (salt) h.set(salt, 1 + lp.length);
+  h.set(salt, 1 + lp.length);
   return b64urlEncode(h);
 }
 function encParseHeader(b64) {
   const h = b64urlDecode(b64);
   if (h.length < 2) throw new Error('bad header');
-  const encrypted = (h[0] & ENC_FLAG_ENCRYPTED) !== 0;
   const flag = h[0] & 0x7f;
   const { value: ctlen, next } = varintDecode(h, 1);
   const salt = h.subarray(next);
-  if (encrypted && salt.length < 8) throw new Error('bad header');
-  return { flag, ctlen, encrypted, salt: encrypted ? salt : null };
+  if (salt.length < 8) throw new Error('bad header');
+  return { flag, ctlen, salt };
 }
-// Split "<key>: <prose>" on the first colon (base64url has no ':').
-function encSplitArtifact(text) {
+// Prepend the [flag][len] header to (possibly compressed) bytes for the
+// unencrypted case, so the prose alone is enough to decode.
+function encBuildEmbedded(flag, data) {
+  const lp = varintEncode(data.length);
+  const out = new Uint8Array(1 + lp.length + data.length);
+  out[0] = flag & 0x7f;
+  out.set(lp, 1);
+  out.set(data, 1 + lp.length);
+  return out;
+}
+// Recover { flag, data } from bytes built by encBuildEmbedded (trailing
+// bit-padding from the bitpack codec is ignored via the explicit length).
+function encParseEmbedded(bytes) {
+  if (bytes.length < 2) throw new Error('bad payload');
+  const flag = bytes[0] & 0x7f;
+  const { value: len, next } = varintDecode(bytes, 1);
+  return { flag, data: bytes.subarray(next, next + len) };
+}
+// Recognize the artifact shape. An encrypted artifact starts with a base64url
+// key (no spaces) followed by a colon; anything else is treated as bare prose.
+function encParseArtifact(text) {
+  text = text.trim();
   const i = text.indexOf(':');
-  if (i < 0) return null;
-  const header = text.slice(0, i).trim();
-  const prose = text.slice(i + 1).trim();
-  if (!header || !prose) return null;
-  return { header, prose };
+  if (i > 0 && /^[A-Za-z0-9_-]+$/.test(text.slice(0, i))) {
+    const prose = text.slice(i + 1).trim();
+    if (prose) return { header: text.slice(0, i), prose };
+  }
+  return { header: null, prose: text };
 }
 
 // Encode: message + passphrase -> { header, ctHex }. The prose is rendered from
 // ctHex separately (so language/cover changes don't re-encrypt). With no
-// passphrase the reduced bytes are emitted verbatim — compressed but unencrypted,
-// and the header omits the salt.
+// passphrase there is no key (header = null) — the [flag][len] header is embedded
+// in the prose payload instead, so the artifact is pure prose.
 async function encEncrypt(message, password) {
   const { data: reduced, flag } = await maybeReduce(ENC_TE.encode(message));
   if (!password) {
-    return { header: encBuildHeader(flag, reduced.length, null), ctHex: toHex(reduced) };
+    return { header: null, ctHex: toHex(encBuildEmbedded(flag, reduced)) };
   }
   const salt = crypto.getRandomValues(new Uint8Array(8));
   const { key, nonce } = await encDeriveKeyNonce(password, salt);
   const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-CTR', counter: ctrCounter(nonce), length: 32 }, key, reduced));
   return { header: encBuildHeader(flag, ct.length, salt), ctHex: toHex(ct) };
 }
-// Decode: parsed header + payload bytes + passphrase -> message. An unencrypted
-// payload (no salt in the header) just gets decompressed, no passphrase needed.
+// Decrypt: parsed header + ciphertext bytes + passphrase -> message.
 async function encDecrypt(hdr, ctBytes, password) {
   const ct = ctBytes.subarray(0, hdr.ctlen);
-  if (!hdr.encrypted) {
-    try {
-      return ENC_TD.decode(await expand(ct, hdr.flag));
-    } catch (e) {
-      throw new Error('Could not decode the message.');
-    }
-  }
   const { key, nonce } = await encDeriveKeyNonce(password, hdr.salt);
   // CTR is unauthenticated: a wrong passphrase yields a different keystream and
   // therefore garbled bytes rather than a clean failure. We can only surface an
@@ -1874,8 +1897,7 @@ function encUpdateHighlights() {
 // Auto-detect the SOURCE language of the prose value (decode), restricted to
 // the languages this panel supports. Detects on the prose, not the base64 key.
 function encDetectLeftLang() {
-  const parsed = encSplitArtifact(encLeftText().trim());
-  const prose = parsed ? parsed.prose : encLeftText().trim();
+  const prose = encParseArtifact(encLeftText().trim()).prose;
   if (!prose) return;
   try {
     const matches = JSON.parse(wasmDetectDialect(prose));
@@ -1923,12 +1945,13 @@ function encUpdateChrome() {
 function encUnderlineLeftArtifact(header, prose, words) {
   const el = document.getElementById('enc-left-box');
   const focused = (document.activeElement === el);
-  el.innerHTML = '<span class="enc-key">' + escapeHtml(header) + '</span>: ' + underlineProse(prose, normSet(words));
+  const body = underlineProse(prose, normSet(words));
+  el.innerHTML = header ? ('<span class="enc-key">' + escapeHtml(header) + '</span>: ' + body) : body;
   if (focused) placeCaretEnd(el);
 }
 
-// Render the cached ciphertext as "<key>: prose" in the current target language
-// (deterministic under the fixed SEED).
+// Render the cached payload as prose (with a "<key>: " prefix when encrypted) in
+// the current target language (deterministic under the fixed SEED).
 function encRenderCipher(cipher) {
   if (!ready || !cipher) { encSetOutput(''); return; }
   const tgt = encLangById(encLang);
@@ -1960,11 +1983,32 @@ async function encRun() {
     encRenderCipher(encCipher);
   } else {
     if (!text) { encSetOutput(''); return; }
-    const parsed = encSplitArtifact(text);
-    if (!parsed) { encSetOutput(''); encShowError('Expected "key: message" format.'); return; }
+    const parsed = encParseArtifact(text);
+    if (!parsed.prose) { encSetOutput(''); return; }
     encDetectLeftLang();
     encUpdateChrome();
     const src = encLangById(encDetLang);
+
+    // Unencrypted: no key — decode the prose, then read the embedded [flag][len]
+    // header (pass 0 so the codec returns every byte; trailing padding is sliced
+    // off by the embedded length). No passphrase required.
+    if (!parsed.header) {
+      let message;
+      try {
+        const r = JSON.parse(wasmDecodeRawBaseN(parsed.prose, src.language, src.wordlist, 0));
+        if (r.error) { encShowError(r.error); encSetOutput(''); return; }
+        const bytes = fromHex(r.decoded_hex || '');
+        encUnderlineLeftArtifact(null, parsed.prose, r.payload_words || []);
+        if (!bytes.length) { encSetOutput(''); return; }
+        const { flag, data } = encParseEmbedded(bytes);
+        message = ENC_TD.decode(await expand(data, flag));
+      } catch (e) { if (myId === encRunId) { encShowError('Could not decode the message.'); encSetOutput(''); } return; }
+      if (myId !== encRunId) return;
+      encSetOutput(message);
+      return;
+    }
+
+    // Encrypted: the key carries flag + ciphertext length + salt.
     let hdr, ctBytes;
     try { hdr = encParseHeader(parsed.header); }
     catch (e) { encSetOutput(''); encShowError('Malformed key.'); return; }
@@ -1975,7 +2019,7 @@ async function encRun() {
       encUnderlineLeftArtifact(parsed.header, parsed.prose, r.payload_words || []);
     } catch (e) { encShowError(e.message || String(e)); encSetOutput(''); return; }
     if (!ctBytes.length) { encSetOutput(''); return; }
-    if (hdr.encrypted && !pw) { encSetOutput(''); encShowError('Enter the passphrase to decrypt.'); return; }
+    if (!pw) { encSetOutput(''); encShowError('Enter the passphrase to decrypt.'); return; }
     let message;
     try { message = await encDecrypt(hdr, ctBytes, pw); }
     catch (e) { if (myId === encRunId) { encShowError(e.message || String(e)); encSetOutput(''); } return; }

--- a/web/index.html
+++ b/web/index.html
@@ -1437,10 +1437,14 @@ let akDetLang = 'english';   // SOURCE language auto-detected from left prose (d
 let akDetFmt = '';           // SOURCE format auto-detected from the key (encode), display only
 let akTimer = null;
 
+// The bip39 dialect encodes with base_n (no bitpack padding word), so the
+// payload words are pure data — the cover-hidden view is a clean, round-trippable
+// sequence (like a BIP39 mnemonic) rather than carrying a padding-count word that
+// a bare sequence would misread on decode.
 const AK_LANGS = [
-  { id: 'english', label: 'English', source: 'english/bip39/body' },
-  { id: 'latin',   label: 'Latin',   source: 'latin/default/body' },
-  { id: 'czech',   label: 'Czech',   source: 'czech/default/body' },
+  { id: 'english', label: 'English', source: 'english/bip39/bip39' },
+  { id: 'latin',   label: 'Latin',   source: 'latin/default/bip39' },
+  { id: 'czech',   label: 'Czech',   source: 'czech/default/bip39' },
 ];
 const AK_FORMATS = [
   { id: 'ascii7', label: 'ASCII',  word: 'ascii7' },
@@ -1450,6 +1454,13 @@ const AK_FORMATS = [
 const AK_FMT_LABEL = { ascii7: 'ASCII', bytes8: 'bytes', hex: 'hex', base64: 'base64' };
 function akLangById(id) { return AK_LANGS.find(l => l.id === id) || AK_LANGS[0]; }
 function akFmtById(id) { return AK_FORMATS.find(f => f.id === id) || AK_FORMATS[0]; }
+// Map an auto-detected encode data_mode to a decode output-format button id.
+// bytes8 and ascii7 both render bytes as text, so bytes8 maps to ASCII.
+function akFmtIdFromMode(mode) {
+  if (mode === 'hex') return 'hex';
+  if (mode === 'base64') return 'base64';
+  return 'ascii7';
+}
 
 function akLeftText() { return document.getElementById('ak-left-box').innerText; }
 function akSetLeftPlain(t) { document.getElementById('ak-left-box').textContent = t; }
@@ -1559,7 +1570,7 @@ function akRun() {
   if (!text) { akSetOutput(''); return; }
   try {
     if (akMode === 'encode') {
-      const r = JSON.parse(wasmTranscode(text, 'encode into ' + akLang + ' naturally', SEED));
+      const r = JSON.parse(wasmTranscode(text, 'encode into ' + akLang + ' bip39', SEED));
       if (r.error) { akShowError(r.error); akSetOutput(''); return; }
       akDetFmt = r.data_mode || '';
       const out = (r.output || '').trim();
@@ -1597,9 +1608,15 @@ window.akGenerate = function() {
 
 window.akToggle = function() {
   const out = document.getElementById('ak-right-box').dataset.plainText || '';
-  akMode = (akMode === 'encode') ? 'decode' : 'encode';
+  const wasEncode = (akMode === 'encode');
+  akMode = wasEncode ? 'decode' : 'encode';
   akSetLeftPlain(out);
-  if (akMode === 'decode') akDetectLeftLang();
+  if (akMode === 'decode') {
+    // Default the output format to the one detected when encoding; the format
+    // buttons still let the user decode to another (e.g. hex).
+    if (wasEncode && akDetFmt) akFormat = akFmtIdFromMode(akDetFmt);
+    akDetectLeftLang();
+  }
   akRun();
 };
 

--- a/web/index.html
+++ b/web/index.html
@@ -2095,8 +2095,7 @@ window.encSample = function() {
   if (ENC_SAMPLES.length > 1 && i === encLastSample) i = (i + 1) % ENC_SAMPLES.length;
   encLastSample = i;
   encSetLeftPlain(ENC_SAMPLES[i]);
-  if (!encPassword()) { encGenPassword(); return; }   // seed a strong Latin passphrase
-  encRun();
+  encRun();   // leave the passphrase as-is (blank by default => encode without encryption)
 };
 
 window.encToggle = function() {

--- a/web/index.html
+++ b/web/index.html
@@ -1564,7 +1564,12 @@ function akRun() {
       akDetFmt = r.data_mode || '';
       const out = (r.output || '').trim();
       const set = normSet(r.payload_words || []);
-      akSetOutput(coverAk ? out : payloadOnlyText(out, set), renderProse(out, set, coverAk));
+      // Keep the canonical artifact (what Copy and the ⇄ round trip use) as the
+      // FULL prose. A cover-hidden payload-only sequence is indistinguishable
+      // from a bare mnemonic, so the decoder mis-routes it (base_n instead of the
+      // grammar's bitpack) and the round trip yields garbage. "Hide cover" stays a
+      // display-only view; decoding always runs on the full sentences.
+      akSetOutput(out, renderProse(out, set, coverAk));
       akUpdateChrome();   // refresh the detected-format chip
     } else {
       const meta = 'transcode from ' + akLangById(akDetLang).source + ' into ' + akFmtById(akFormat).word;

--- a/web/index.html
+++ b/web/index.html
@@ -841,6 +841,7 @@ footer a:hover { text-decoration: underline; }
         .enc-password-row label { font-family: var(--font-mono); font-size: 0.65rem;
           text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-dim); }
         .enc-password-row label .req { color: var(--error); }
+        .enc-password-row label .opt { color: var(--text-dim); opacity: 0.7; }
         .enc-password-row input { min-width: 260px; }
         .enc-entropy { font-family: var(--font-mono); font-size: 0.65rem; color: var(--text-dim); white-space: nowrap; }
         .enc-entropy.strong { color: var(--success); }
@@ -943,13 +944,13 @@ footer a:hover { text-decoration: underline; }
       <div id="panel-encrypt">
         <div class="section-header">
           <h3>Madlib Encryption</h3>
-          <p>Compress and password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text into a <code>key:&nbsp;value</code> pair &mdash; a compact salt key, the ciphertext as readable prose &mdash; and decode it back byte-for-byte with the same password</p>
+          <p>Compress and optionally password-encrypt<a href="#enc-note" class="enc-note-ref">*</a> any text into a <code>key:&nbsp;value</code> pair &mdash; a compact key, the payload as readable prose &mdash; and decode it back byte-for-byte (with the same passphrase, if one was set)</p>
         </div>
 
         <div class="enc-password-row">
-          <label for="enc-pass">Password <span class="req" title="required">*</span></label>
-          <input type="text" id="enc-pass" placeholder="Type a password, or generate a Latin seed phrase &rarr;" autocomplete="off" spellcheck="false" required aria-required="true">
-          <button class="btn-sm" id="enc-genpass-btn" onclick="encGenPassword()" title="Generate a strong, high-entropy Latin seed phrase">&#127922; Latin seed phrase</button>
+          <label for="enc-pass">Passphrase <span class="opt" title="optional">(optional)</span></label>
+          <input type="text" id="enc-pass" placeholder="Type a passphrase to encrypt, or leave blank to just encode &rarr;" autocomplete="off" spellcheck="false">
+          <button class="btn-sm" id="enc-genpass-btn" onclick="encGenPassword()" title="Generate a strong, high-entropy Latin passphrase">&#127922; Latin passphrase</button>
           <span class="enc-entropy" id="enc-entropy"></span>
         </div>
 
@@ -991,12 +992,14 @@ footer a:hover { text-decoration: underline; }
         <p class="enc-note" id="enc-note">
           <strong>*</strong> AES-CTR keeps your message confidential but is <em>not</em> authenticated &mdash; it
           can&rsquo;t detect tampering. In principle, someone who intercepts the ciphertext could flip bits to
-          alter the decoded message in controlled ways, without ever knowing the password. That&rsquo;s
+          alter the decoded message in controlled ways, without ever knowing the passphrase. That&rsquo;s
           impractical here, where messages are copy-pasted by hand into chats and posts, but it&rsquo;s a real
           property of unauthenticated encryption. For tamper-proof, end-to-end secure messaging, use a signed
           protocol like <a href="https://nostr-mail.com" target="_blank" rel="noopener">nostr-mail</a>.
-          The base64 <code>key:</code> is plaintext metadata &mdash; a per-message salt and the ciphertext
-          length &mdash; not a secret and not part of the password; only the password unlocks the message.
+          The base64 <code>key:</code> is plaintext metadata &mdash; the payload length, plus a per-message
+          salt when a passphrase is set &mdash; not a secret and not part of the passphrase; only the
+          passphrase unlocks an encrypted message. With no passphrase, the text is encoded (and possibly
+          compressed) but <em>not</em> encrypted, and there is no salt.
         </p>
       </div>
     </section>
@@ -1596,13 +1599,17 @@ window.akToggleCover = function() {
 
 // ═══ Encrypted Message panel ═════════════════════════════════════════
 //
-// Symmetric Google-Translate model with a shared password:
-//   encode: message + password -> compress -> AES-CTR encrypt -> "<key>: prose"
-//   decode: "<key>: prose" + password -> decrypt -> decompress -> message
+// Symmetric Google-Translate model with a shared passphrase:
+//   encode: message + passphrase -> compress -> AES-CTR encrypt -> "<key>: prose"
+//   decode: "<key>: prose" + passphrase -> decrypt -> decompress -> message
+//
+// The passphrase is OPTIONAL. With no passphrase the message is compressed and
+// encoded but not encrypted, and the header carries no salt — the prose is the
+// reduced bytes verbatim, decodable by anyone (no passphrase required).
 //
 // The artifact is a key:value pair — the base64url <key> carries the plumbing
-// (flag + ciphertext length + salt), and the prose value carries only the
-// Glossia-encoded ciphertext. The ciphertext is random per encryption, so the
+// (flag + payload length + salt when encrypted), and the prose value carries only
+// the Glossia-encoded payload. The ciphertext is random per encryption, so the
 // cover toggle and language buttons re-render from the cached cipher (encCipher)
 // rather than re-encrypting; encode_raw_base_n uses the fixed SEED, so
 // re-rendering the same ciphertext into the same language is deterministic.
@@ -1763,29 +1770,35 @@ function b64urlDecode(str) {
 }
 
 // Artifact format: "<key>: <prose>".
-//   key   = base64url( [flag:1][ctlen:varint][salt:12] )  — the machine plumbing
-//   prose = Glossia-encoded ciphertext only                — the human-readable value
-// The salt is the unique-per-message key; the ciphertext is the value. AES-CTR is
-// a stream cipher (no tag/padding), so the prose carries exactly the ciphertext.
+//   key   = base64url( [flag:1][ctlen:varint][salt:8?] )  — the machine plumbing
+//   prose = Glossia-encoded payload only                   — the human-readable value
+// The flag's low bits (0x7f) hold the reduction method; the high bit (0x80) marks
+// an encrypted payload, in which case the per-message salt follows. With no
+// passphrase the high bit is clear and the salt is omitted entirely.
+// AES-CTR is a stream cipher (no tag/padding), so the prose carries exactly the
+// ciphertext.
 //
 // NOTE: AES-CTR provides confidentiality only — it is NOT authenticated, so it
 // cannot detect tampering (see the asterisk note under the demo panel).
+const ENC_FLAG_ENCRYPTED = 0x80;
 function encBuildHeader(flag, ctlen, salt) {
   const lp = varintEncode(ctlen);
-  const h = new Uint8Array(1 + lp.length + salt.length);
-  h[0] = flag;
+  const saltLen = salt ? salt.length : 0;
+  const h = new Uint8Array(1 + lp.length + saltLen);
+  h[0] = salt ? (flag | ENC_FLAG_ENCRYPTED) : flag;
   h.set(lp, 1);
-  h.set(salt, 1 + lp.length);
+  if (salt) h.set(salt, 1 + lp.length);
   return b64urlEncode(h);
 }
 function encParseHeader(b64) {
   const h = b64urlDecode(b64);
   if (h.length < 2) throw new Error('bad header');
-  const flag = h[0];
+  const encrypted = (h[0] & ENC_FLAG_ENCRYPTED) !== 0;
+  const flag = h[0] & 0x7f;
   const { value: ctlen, next } = varintDecode(h, 1);
   const salt = h.subarray(next);
-  if (salt.length < 8) throw new Error('bad header');
-  return { flag, ctlen, salt };
+  if (encrypted && salt.length < 8) throw new Error('bad header');
+  return { flag, ctlen, encrypted, salt: encrypted ? salt : null };
 }
 // Split "<key>: <prose>" on the first colon (base64url has no ':').
 function encSplitArtifact(text) {
@@ -1797,27 +1810,40 @@ function encSplitArtifact(text) {
   return { header, prose };
 }
 
-// Encrypt: message + password -> { header, ctHex }. The prose is rendered from
-// ctHex separately (so language/cover changes don't re-encrypt).
+// Encode: message + passphrase -> { header, ctHex }. The prose is rendered from
+// ctHex separately (so language/cover changes don't re-encrypt). With no
+// passphrase the reduced bytes are emitted verbatim — compressed but unencrypted,
+// and the header omits the salt.
 async function encEncrypt(message, password) {
   const { data: reduced, flag } = await maybeReduce(ENC_TE.encode(message));
+  if (!password) {
+    return { header: encBuildHeader(flag, reduced.length, null), ctHex: toHex(reduced) };
+  }
   const salt = crypto.getRandomValues(new Uint8Array(8));
   const { key, nonce } = await encDeriveKeyNonce(password, salt);
   const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-CTR', counter: ctrCounter(nonce), length: 32 }, key, reduced));
   return { header: encBuildHeader(flag, ct.length, salt), ctHex: toHex(ct) };
 }
-// Decrypt: parsed header + ciphertext bytes + password -> message.
+// Decode: parsed header + payload bytes + passphrase -> message. An unencrypted
+// payload (no salt in the header) just gets decompressed, no passphrase needed.
 async function encDecrypt(hdr, ctBytes, password) {
   const ct = ctBytes.subarray(0, hdr.ctlen);
+  if (!hdr.encrypted) {
+    try {
+      return ENC_TD.decode(await expand(ct, hdr.flag));
+    } catch (e) {
+      throw new Error('Could not decode the message.');
+    }
+  }
   const { key, nonce } = await encDeriveKeyNonce(password, hdr.salt);
-  // CTR is unauthenticated: a wrong password yields a different keystream and
+  // CTR is unauthenticated: a wrong passphrase yields a different keystream and
   // therefore garbled bytes rather than a clean failure. We can only surface an
   // error when the reduction stage (e.g. gunzip) chokes on the garbage.
   try {
     const plain = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-CTR', counter: ctrCounter(nonce), length: 32 }, key, ct));
     return ENC_TD.decode(await expand(plain, hdr.flag));
   } catch (e) {
-    throw new Error('Could not decode — check the password.');
+    throw new Error('Could not decode — check the passphrase.');
   }
 }
 
@@ -1872,17 +1898,22 @@ function encUpdateChrome() {
     genBtn.classList.remove('hidden');
     coverBtn.classList.remove('hidden');
     coverBtn.textContent = coverEnc ? 'Hide cover' : 'Show cover';
-    hint.textContent = 'Compresses and AES-CTR-encrypts your message, then writes a “key: value” pair — the ' +
-      'base64 key holds the per-message salt, the ' + encLangById(encLang).label + ' prose holds the ciphertext ' +
-      '(payload words underlined). Pick the target language on the right; press ⇄ to decode.';
+    hint.textContent = encPassword()
+      ? 'Compresses and AES-CTR-encrypts your message, then writes a “key: value” pair — the ' +
+        'base64 key holds the per-message salt, the ' + encLangById(encLang).label + ' prose holds the ciphertext ' +
+        '(payload words underlined). Pick the target language on the right; press ⇄ to decode.'
+      : 'No passphrase — compresses and encodes your message (not encrypted) into ' +
+        encLangById(encLang).label + ' prose (payload words underlined). Add a passphrase to encrypt; ' +
+        'press ⇄ to decode.';
   } else {
     document.getElementById('enc-left-label').textContent = encLangById(encDetLang).label + ' sentences (detected)';
-    document.getElementById('enc-right-label').textContent = 'Decrypted message';
+    document.getElementById('enc-right-label').textContent = 'Decoded message';
     langRow.classList.add('hidden');
     genBtn.classList.add('hidden');
     coverBtn.classList.add('hidden');
     hint.textContent = 'Detected ' + encLangById(encDetLang).label + ' prose (payload words underlined); ' +
-      'decrypting with the password to recover the original message. Press ⇄ to go back to encrypting.';
+      'decoding to recover the original message (a passphrase is needed only if it was encrypted). ' +
+      'Press ⇄ to go back to encoding.';
   }
   encUpdateHighlights();
 }
@@ -1921,7 +1952,6 @@ async function encRun() {
 
   if (encMode === 'encode') {
     if (!text) { encCipher = null; encSetOutput(''); return; }
-    if (!pw) { encSetOutput(''); encShowError('Enter a password to encrypt.'); return; }
     let cipher;
     try { cipher = await encEncrypt(text, pw); }
     catch (e) { if (myId === encRunId) { encShowError(e.message || String(e)); encSetOutput(''); } return; }
@@ -1945,7 +1975,7 @@ async function encRun() {
       encUnderlineLeftArtifact(parsed.header, parsed.prose, r.payload_words || []);
     } catch (e) { encShowError(e.message || String(e)); encSetOutput(''); return; }
     if (!ctBytes.length) { encSetOutput(''); return; }
-    if (!pw) { encSetOutput(''); encShowError('Enter the password to decrypt.'); return; }
+    if (hdr.encrypted && !pw) { encSetOutput(''); encShowError('Enter the passphrase to decrypt.'); return; }
     let message;
     try { message = await encDecrypt(hdr, ctBytes, pw); }
     catch (e) { if (myId === encRunId) { encShowError(e.message || String(e)); encSetOutput(''); } return; }
@@ -1954,10 +1984,10 @@ async function encRun() {
   }
 }
 
-// Generated passwords are Latin seed phrases drawn from Glossia's own Latin
-// payload wordlist (~15 bits/word), targeting >=128 bits so the password is
+// Generated passphrases are Latin word phrases drawn from Glossia's own Latin
+// payload wordlist (~15 bits/word), targeting >=128 bits so the passphrase is
 // strong enough that offline guessing / precomputation is infeasible — the
-// only way to actually *enforce* password entropy is to generate it.
+// only way to actually *enforce* passphrase entropy is to generate it.
 const ENC_PASS_LANG = { language: 'latin', wordlist: 'default' };
 const ENC_PASS_TARGET_BITS = 128;
 
@@ -2021,7 +2051,7 @@ window.encSample = function() {
   if (ENC_SAMPLES.length > 1 && i === encLastSample) i = (i + 1) % ENC_SAMPLES.length;
   encLastSample = i;
   encSetLeftPlain(ENC_SAMPLES[i]);
-  if (!encPassword()) { encGenPassword(); return; }   // seed a strong Latin pass-phrase
+  if (!encPassword()) { encGenPassword(); return; }   // seed a strong Latin passphrase
   encRun();
 };
 

--- a/web/index.html
+++ b/web/index.html
@@ -1564,12 +1564,7 @@ function akRun() {
       akDetFmt = r.data_mode || '';
       const out = (r.output || '').trim();
       const set = normSet(r.payload_words || []);
-      // Keep the canonical artifact (what Copy and the ⇄ round trip use) as the
-      // FULL prose. A cover-hidden payload-only sequence is indistinguishable
-      // from a bare mnemonic, so the decoder mis-routes it (base_n instead of the
-      // grammar's bitpack) and the round trip yields garbage. "Hide cover" stays a
-      // display-only view; decoding always runs on the full sentences.
-      akSetOutput(out, renderProse(out, set, coverAk));
+      akSetOutput(coverAk ? out : payloadOnlyText(out, set), renderProse(out, set, coverAk));
       akUpdateChrome();   // refresh the detected-format chip
     } else {
       const meta = 'transcode from ' + akLangById(akDetLang).source + ' into ' + akFmtById(akFormat).word;


### PR DESCRIPTION
Rename the generated-credential UI from "seed phrase" to "passphrase" across the
Madlib Encryption demo (the separate BIP39 panel is unchanged).

Make the passphrase optional: with no passphrase, the message is compressed and
encoded but not encrypted, and the header omits the salt. A new high bit in the
flag byte (0x80) marks an encrypted payload; decode requires a passphrase only
when that bit is set.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01566bs4daFRuFr3PBUotQzX