### PR TITLE
Fix #29: make the meta verb authoritative; add encode/transcode/decode CLI flags

### DIFF
--- a/glossia-cli/src/main.rs
+++ b/glossia-cli/src/main.rs
@@ -382,13 +382,20 @@ fn print_usage(program_name: &str) {
     eprintln!("                          Auto-detects language/wordlist if --language not specified");
     eprintln!();
     eprintln!("Pipeline mode (translate between languages):");
-    eprintln!("  --meta <instruction>    Execute a meta-language pipeline instruction");
-    eprintln!("                          e.g., \"translate from english into latin\"");
-    eprintln!("  --into <target>         Encode into target language/format");
-    eprintln!("                          e.g., english, latin, latin/default/prose, hex");
-    eprintln!("  --from <source>         Decode from source language/format");
-    eprintln!("                          e.g., english, english/bip39, hex, base64");
-    eprintln!("                          Use --from with --into to transcode between languages");
+    eprintln!("  The verb is authoritative — it decides how the input is read:");
+    eprintln!("  --encode                Input is raw data; encode it (requires --to).");
+    eprintln!("                          A bare mnemonic is encoded as text and round-trips.");
+    eprintln!("  --transcode             Input is an existing Glossia encoding; detect its");
+    eprintln!("                          source and re-encode (requires --to). With no --from");
+    eprintln!("                          the source language is auto-detected.");
+    eprintln!("  --decode                Decode an encoding back to data (with --from/--to);");
+    eprintln!("                          on its own with words, the legacy word->bytes mode.");
+    eprintln!("  --to / --into <target>  Target language/format (e.g. english, latin,");
+    eprintln!("                          latin/default/prose, hex, base64).");
+    eprintln!("  --from <source>         Source language/format (e.g. english, english/bip39,");
+    eprintln!("                          english/bip39/raw, hex). Optional under --transcode.");
+    eprintln!("  --meta <instruction>    Run a full meta-language instruction directly,");
+    eprintln!("                          e.g. \"transcode from english into latin\".");
     eprintln!("                          Input comes from --from-ascii, positional args, or stdin");
     eprintln!("  --madlib                Replace payload words with [POS] placeholders");
     eprintln!("  --seed <N>              Seed for deterministic random generation");
@@ -415,10 +422,11 @@ fn print_usage(program_name: &str) {
     eprintln!("  {} --random 5 --dialect latin-body --highlight-payload bars", program_name);
     eprintln!();
     eprintln!("Pipeline examples:");
-    eprintln!("  {} --into english --from-ascii \"Hello World\"", program_name);
-    eprintln!("  {} --from english --into latin < english_prose.txt", program_name);
-    eprintln!("  {} --from english < prose.txt   (decode to original data)", program_name);
-    eprintln!("  {} --meta \"translate from english into latin\" < prose.txt", program_name);
+    eprintln!("  {} --encode --to english --from-ascii \"Hello World\"", program_name);
+    eprintln!("  {} --transcode --from english --to latin < english_prose.txt", program_name);
+    eprintln!("  {} --transcode --to latin < seed_words.txt   (auto-detect source)", program_name);
+    eprintln!("  {} --decode --from english < prose.txt   (decode to original data)", program_name);
+    eprintln!("  {} --meta \"transcode from english into latin\" < prose.txt", program_name);
     eprintln!();
     eprintln!("Image rendering:");
     eprintln!("  -o <file.svg|file.png>      Output image file (with -l image)");
@@ -467,6 +475,11 @@ fn parse_args() -> Result<(Vec<String>, Option<usize>, Option<String>, bool, Opt
     let mut meta_instruction: Option<String> = None;
     let mut pipeline_into: Option<String> = None;
     let mut pipeline_from: Option<String> = None;
+    // Verb flags (encode/transcode/decode) drive a pipeline together with the
+    // --from/--to endpoint helpers. `--decode` doubles as the legacy word→bytes
+    // flag; it only drives a pipeline when an endpoint is also given.
+    let mut encode_flag = false;
+    let mut transcode_flag = false;
     let mut render_image: Option<String> = None;
     let mut render_output: Option<String> = None;
     let mut i = 1;
@@ -658,9 +671,17 @@ fn parse_args() -> Result<(Vec<String>, Option<usize>, Option<String>, bool, Opt
                 meta_instruction = Some(args[i + 1].clone());
                 i += 2;
             }
-            "--into" => {
+            "--encode" => {
+                encode_flag = true;
+                i += 1;
+            }
+            "--transcode" => {
+                transcode_flag = true;
+                i += 1;
+            }
+            "--into" | "--to" => {
                 if i + 1 >= args.len() {
-                    return Err("--into requires a value (target language or format)".to_string());
+                    return Err(format!("{} requires a value (target language or format)", args[i]));
                 }
                 pipeline_into = Some(args[i + 1].clone());
                 i += 2;
@@ -724,6 +745,41 @@ fn parse_args() -> Result<(Vec<String>, Option<usize>, Option<String>, bool, Opt
         }
     }
     
+    // Verb-flag pipeline: synthesize a meta instruction from --encode/--transcode/
+    // --decode plus --from/--to and run it through the meta parser (which makes the
+    // verb authoritative). `--decode` only drives a pipeline when an endpoint is
+    // given; on its own it stays the legacy word→bytes flag.
+    if encode_flag && transcode_flag {
+        return Err("Use only one of --encode or --transcode.".to_string());
+    }
+    let verb_word = if encode_flag {
+        Some("encode")
+    } else if transcode_flag {
+        Some("transcode")
+    } else if decode_mode && (pipeline_from.is_some() || pipeline_into.is_some()) {
+        Some("decode")
+    } else {
+        None
+    };
+    if let Some(vw) = verb_word {
+        if meta_instruction.is_some() {
+            return Err("Use either --meta or the --encode/--transcode/--decode flags, not both.".to_string());
+        }
+        if (encode_flag || transcode_flag) && pipeline_into.is_none() {
+            return Err(format!("--{} requires a target: add --to <language|format>.", vw));
+        }
+        let mut s = String::from(vw);
+        if let Some(ref f) = pipeline_from {
+            s.push_str(" from ");
+            s.push_str(f);
+        }
+        if let Some(ref t) = pipeline_into {
+            s.push_str(" into ");
+            s.push_str(t);
+        }
+        meta_instruction = Some(s);
+    }
+
     if random_count.is_some() && !words.is_empty() {
         return Err("Cannot use --random with explicit words. Use one or the other.".to_string());
     }


### PR DESCRIPTION
## Summary

Fixes #29 (silent data loss when encoding text whose words happen to be payload words) by making the pipeline **verb authoritative** instead of guessing intent from the input's content, and surfaces the verbs as first-class CLI flags.

## The bug (#29)

`encode into <language>` with an auto source detected a bare list of payload words as a raw seed (`hit_rate >= 0.8` over a small wordlist) and transcoded it as a mnemonic. An ordinary phrase whose words happen to be BIP39 words (e.g. `absorb absurd access`) was therefore decoded to its byte value and re-encoded, so the original text did **not** round-trip — silent data loss.

Root cause: the pipeline inferred direction purely from the endpoint *types* and ignored the verb the user typed, so an `Auto` source + `Language` target had to *guess* whether the input was data to encode or an encoding to transcode. Guessing from content is what misfired.

## The fix: the verb decides

| Command | Input read as | Behavior |
|---|---|---|
| `encode into <lang>` | **raw data**, always | Never inspected for "secretly a seed?" → #29 cannot occur. A bare mnemonic encodes as text and round-trips verbatim. |
| `transcode`/`translate into <lang>` | **existing encoding** | Detects the source dialect and re-encodes (compacts a 12-word seed → ~9 Latin words). Errors if no encoding is detected, rather than guessing. |
| `decode into <fmt>` | prose | Detects source dialect (unchanged). |

Same input, different verb, different result — but each is an explicit instruction, not a heuristic that can misfire. Naming the source explicitly always wins, and structured crypto formats (bech32, npub, …) are still recognized in both directions (unambiguous format recognition, not intent guessing).

## CLI: verbs as flags

The verb is now discoverable without writing a `--meta` string:

```
glossia --encode --to english --from-ascii "Hello World"   # raw → prose
glossia --transcode --to latin < seed.txt                  # auto-detect source, compact to Latin
glossia --transcode --from english --to latin < prose.txt  # explicit source
glossia --decode --from english < prose.txt                # decode to data
```

- `--to` is an alias for `--into`.
- `--decode` keeps its legacy word→bytes behavior on its own with positional words; it only drives a pipeline when an endpoint (`--from`/`--to`) is also given, so nothing existing breaks.
- Implemented by synthesizing a meta instruction from the verb + endpoints and running it through the existing meta parser, so there is one code path and no duplicated direction logic.
- Validation: the verb flags are mutually exclusive, `--encode`/`--transcode` require a target, and they cannot be combined with `--meta`.

## Changes

- `src/pipeline.rs`: add `Verb` (Encode/Decode/Transcode/Unspecified), parse it in `from_meta`, thread it through `Pipeline` (+ `with_verb`); verb-gated `resolve_source` with a shared `detect_source_language` helper.
- `glossia-cli/src/main.rs`: `--encode`/`--transcode` flags, `--to` alias, verb synthesis + validation, updated help/examples.
- `tests/test_vectors.json`: the bip39 mnemonic vector now asserts the encode-as-text round-trip.
- `docs/src/how-it-works.md`: document the verb-authoritative model and the explicit/crypto bypasses.

## Tests

All green: 377 lib + 5 vector + 35 CLI integration + 6 other. New regression tests cover: payload-word text and a full mnemonic round-trip under `encode`; `transcode into latin` auto-detects a seed and round-trips; `transcode` errors when no source encoding is present; verb parsing.

## Notes

- Transcode is byte-lossless (verified across multiple seeds); the verb change is about routing/detection, not the codec.
- Issues #14, #23, #26, #28 were verified already-fixed in the codebase and closed separately; this PR covers the remaining open issue, #29.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bd2j14Lepnbv4wnUo4YBCY)_