### PR TITLE
web: bulletin board compose/read redesign

### DIFF
--- a/docs/src/bulletin-board.md
+++ b/docs/src/bulletin-board.md
@@ -54,6 +54,31 @@ nothing about either.
   grants full access; the view page also accepts it to decrypt.
 - **Bring your own `nsec`** — keep posting to an existing board.
 
+## Saving and loading a board
+
+The compose page's address bar already *is* the board (the author link carries the
+`nwrite`), so bookmarking it is the quickest way to return. For a durable backup
+that survives a lost bookmark, **Save board** renders the board's signing key as a
+**Glossia seed phrase** — the private key itself, written as a readable
+paragraph of prose:
+
+```
+Save board  ─▶  32-byte signing key ‖ 4-byte checksum
+            ─▶  encode_raw_base_n  ─▶  natural-language paragraph  ("write this down")
+Load board  ─▶  paste the paragraph  ─▶  decode + verify checksum  ─▶  board restored
+```
+
+This is the project's core idea applied to a private key: the seed phrase *is* the
+key, made human-friendly — readable, speakable, transcribable. A 4-byte checksum
+(`sha256(key)[..4]`) rides with the key, so a mistyped or garbled word is caught on
+load instead of silently restoring a different board (the same safeguard BIP39
+mnemonics use). The phrase is rendered in whichever prose language the board uses;
+**Load board** auto-detects the language and the checksum confirms the decode. The
+key is generated and encoded entirely in the browser — it never leaves the device.
+
+Anyone who holds the seed phrase has the signing key, so it grants full access
+(post *and* decrypt): treat it exactly like the `nwrite`.
+
 ## How a bulletin is built
 
 The message is compressed and encrypted with authenticated **AES-256-GCM**.

--- a/web/bulletin.html
+++ b/web/bulletin.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Glossia Bulletin — read an encrypted board</title>
-<meta name="description" content="Open a Glossia bulletin board by its #npub and decrypt it with a passphrase. A static page that reads encrypted messages published as natural-language prose on nostr.">
+<meta name="description" content="Open a Glossia bulletin board by its #npub and decrypt it with a read key or passphrase. A static page that reads encrypted messages published as natural-language prose on nostr — in your choice of reading style.">
 <!-- Resolve the vendored @noble crypto (schnorr / sha256 / bech32 deps) for the
      browser's native ES module loader. These files are the audited @noble ESM
      builds, vendored under ./vendor/noble so the page stays offline-capable. -->
@@ -19,111 +19,256 @@
   }
 }
 </script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,500&family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,300;1,6..72,400&family=IBM+Plex+Mono:wght@400;500;600&family=Public+Sans:wght@400;500;600&display=swap" rel="stylesheet">
 <style>
-:root {
-  --bg: #0f1117; --surface: #1a1d27; --surface-alt: #1e2130; --border: #2a2d3a;
-  --text: #e4e4e7; --text-dim: #8b8d97; --accent: #7c6cf0; --accent-hover: #9488f5;
-  --mark-bg: rgba(14,165,233,0.15); --mark-border: rgba(14,165,233,0.4);
-  --error: #ef4444; --success: #22c55e; --orange: #f97316;
-  --font-mono: 'SF Mono','Cascadia Code','Fira Code',monospace;
-  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-}
+/* ───────────────────────── base ───────────────────────── */
 * { box-sizing: border-box; }
-body { margin: 0; font-family: var(--font-sans); background: var(--bg); color: var(--text); line-height: 1.55; }
-.container { max-width: 880px; margin: 0 auto; padding: 1.5rem; }
-a { color: var(--accent); text-decoration: none; }
-a:hover { color: var(--accent-hover); text-decoration: underline; }
-header.top { display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap; border-bottom: 1px solid var(--border); padding-bottom: 1rem; margin-bottom: 1.25rem; }
-header.top h1 { font-size: 1.4rem; margin: 0; }
-header.top .sub { color: var(--text-dim); font-size: .9rem; }
-header.top .home { margin-left: auto; font-size: .85rem; }
-.card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.1rem; margin-bottom: 1rem; }
-label { display: block; font-size: .8rem; color: var(--text-dim); margin: .6rem 0 .25rem; text-transform: uppercase; letter-spacing: .03em; }
-input[type=text], input[type=password] {
-  width: 100%; background: var(--bg); border: 1px solid var(--border); color: var(--text);
-  border-radius: 7px; padding: .55rem .65rem; font-family: var(--font-mono); font-size: .9rem;
+html, body { margin: 0; }
+body {
+  min-height: 100vh;
+  font-family: 'Public Sans', system-ui, sans-serif;
+  background: var(--page);
+  color: var(--ink);
+  transition: background .35s ease, color .35s ease;
 }
-input:focus { outline: none; border-color: var(--accent); }
-.row { display: flex; gap: .6rem; align-items: flex-end; flex-wrap: wrap; }
-.row > * { flex: 1; min-width: 0; }
-.btn { background: var(--accent); color: #fff; border: none; border-radius: 7px; padding: .55rem 1rem; font-size: .9rem; cursor: pointer; font-weight: 600; }
-.btn:hover { background: var(--accent-hover); }
-.btn:disabled { opacity: .5; cursor: not-allowed; }
-.btn.sm { padding: .4rem .7rem; font-size: .8rem; background: var(--surface-alt); color: var(--text); border: 1px solid var(--border); font-weight: 500; flex: 0 0 auto; }
-.btn.sm:hover { border-color: var(--accent); background: var(--surface); }
-.hint { font-size: .82rem; color: var(--text-dim); margin: .4rem 0; }
-.mono { font-family: var(--font-mono); }
-.prose { background: var(--bg); border: 1px dashed var(--border); border-radius: 7px; padding: .7rem; margin: .5rem 0; font-size: .95rem; line-height: 1.7; }
-mark { background: var(--mark-bg); border-bottom: 1px solid var(--mark-border); color: var(--text); padding: 0 1px; border-radius: 2px; }
-.msg { color: var(--text); background: var(--surface-alt); border-left: 3px solid var(--success); padding: .5rem .7rem; border-radius: 0 6px 6px 0; margin: .4rem 0; white-space: pre-wrap; }
-.err { color: var(--error); font-size: .85rem; min-height: 1.1rem; }
-.muted { color: var(--text-dim); }
-.bulletin { border-top: 1px solid var(--border); padding-top: .8rem; margin-top: .8rem; }
-.bulletin:first-child { border-top: none; }
-.bulletin .meta { font-size: .76rem; color: var(--text-dim); display: flex; gap: .8rem; flex-wrap: wrap; }
-.hidden { display: none !important; }
-.note { background: rgba(124,108,240,.08); border: 1px solid rgba(124,108,240,.25); border-radius: 8px; padding: .6rem .8rem; font-size: .82rem; color: var(--text-dim); margin-bottom: 1rem; }
-.note strong { color: var(--text); }
-summary { color: var(--text-dim); font-size: .82rem; cursor: pointer; }
+@keyframes reveal { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+.wrap { max-width: 620px; margin: 0 auto; padding: 56px 22px 96px; }
+
+/* ───────────────────────── theme tokens ───────────────────────── */
+body[data-style="letterpress"] {
+  --page:#d7d5cf; --card:#f6f3ec; --card-bd:#d8d2c4; --ink:#26241d; --ink-soft:#413d33;
+  --accent:#9a5b3f; --meta:#a29c88; --dim:#84806f; --rule:#e2ddce; --hair:#cbc5b5;
+  --input-bg:transparent; --input-bd:#cbc5b5; --masthead-rule:1.5px solid #26241d;
+  --radius:3px; --brand-font:'IBM Plex Mono',monospace; --brand-ls:.22em;
+}
+body[data-style="midnight"] {
+  --page:#08080a; --card:#0d0d10; --card-bd:#232228; --ink:#e8e4da; --ink-soft:#cfcabf;
+  --accent:#c9a25f; --meta:#5c5a63; --dim:#6f6d75; --rule:#1c1b21; --hair:#2a2930;
+  --input-bg:#151519; --input-bd:#2a2930; --masthead-rule:1px solid #232228;
+  --radius:6px; --brand-font:'Public Sans',sans-serif; --brand-ls:.24em;
+}
+body[data-style="terminal"] {
+  --page:#dbd8d0; --card:#f0eee8; --card-bd:#17161a; --ink:#17161a; --ink-soft:#3a382f;
+  --accent:#274bd6; --meta:#a29c8b; --dim:#6d6a5f; --rule:#ddd8c9; --hair:#17161a;
+  --input-bg:#fff; --input-bd:#17161a; --masthead-rule:1.5px solid #17161a;
+  --radius:0; --brand-font:'IBM Plex Mono',monospace; --brand-ls:.1em;
+}
+
+/* ───────────────────────── board card ───────────────────────── */
+.board {
+  background: var(--card);
+  border: 1px solid var(--card-bd);
+  border-radius: var(--radius);
+  box-shadow: 0 24px 60px -32px rgba(20,18,14,.5);
+  padding: 40px 40px 44px;
+  transition: background .35s ease, border-color .35s ease;
+}
+body[data-style="midnight"] .board { box-shadow: 0 24px 60px -30px rgba(0,0,0,.7); }
+
+/* masthead */
+.masthead { display:flex; align-items:baseline; justify-content:space-between; border-bottom:var(--masthead-rule); padding-bottom:12px; }
+.brand { font:600 12.5px/1 var(--brand-font); letter-spacing:var(--brand-ls); text-transform:uppercase; color:var(--ink); }
+.compose-link { font:500 12px/1 'IBM Plex Mono',monospace; letter-spacing:.04em; color:var(--accent); text-decoration:none; }
+.compose-link:hover { text-decoration:underline; }
+
+/* reading-style switch */
+.style-switch { display:flex; gap:6px; margin-top:8px; }
+.style-tile { flex:1; display:flex; align-items:center; justify-content:center; gap:7px; padding:9px 6px; border-radius:calc(var(--radius) + 3px); border:1.5px solid var(--rule); background:transparent; cursor:pointer; font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.06em; text-transform:uppercase; color:var(--dim); transition:border-color .2s, color .2s, background .2s; }
+.style-tile:hover { color:var(--ink); }
+.style-tile[aria-pressed="true"] { border-color:var(--accent); color:var(--ink); }
+.style-tile .swatch { width:16px; height:16px; border-radius:4px; flex:0 0 auto; border:1px solid rgba(0,0,0,.12); }
+.style-tile .swatch.letterpress { background:#f6f3ec; }
+.style-tile .swatch.midnight { background:#0d0d10; }
+.style-tile .swatch.terminal { background:#17161a; }
+
+/* key bar */
+.keybar { margin:26px 0 4px; }
+.keybar label { display:block; font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.18em; text-transform:uppercase; color:var(--accent); margin-bottom:9px; }
+.keybar input {
+  width:100%; background:var(--input-bg); color:var(--ink);
+  border:1px solid var(--input-bd); border-radius:var(--radius);
+  font:400 14px/1.5 'IBM Plex Mono',monospace; padding:11px 13px;
+}
+body[data-style="letterpress"] .keybar input { border:none; border-bottom:1.5px solid var(--input-bd); border-radius:0; background:transparent; font:400 15px/1.6 'Spectral',serif; padding:5px 0; }
+.keybar input::placeholder { color:var(--dim); opacity:.75; }
+.keybar input:focus { outline:none; border-color:var(--accent); }
+body[data-style="letterpress"] .keybar input:focus { border-bottom-color:var(--accent); }
+.keyhint { margin-top:10px; font:400 12px/1.45 'IBM Plex Mono',monospace; color:var(--accent); }
+
+/* board id (the npub) shown at the top as the board's identifier */
+.board-id { display:flex; gap:8px; align-items:center; margin-top:16px; }
+.board-id input { flex:1; min-width:0; background:var(--input-bg); color:var(--ink); border:1px solid var(--input-bd); border-radius:var(--radius); font:400 13px/1.5 'IBM Plex Mono',monospace; padding:10px 12px; }
+.board-id input:focus { outline:none; border-color:var(--accent); }
+.board-id input::placeholder { color:var(--dim); opacity:.7; }
+
+/* settings disclosure */
+.settings { margin-top:16px; border-top:1px solid var(--rule); padding-top:14px; }
+.settings > summary { list-style:none; cursor:pointer; font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.16em; text-transform:uppercase; color:var(--dim); display:flex; align-items:center; gap:7px; }
+.settings > summary::-webkit-details-marker { display:none; }
+.settings > summary:hover { color:var(--accent); }
+.settings label { display:block; font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.16em; text-transform:uppercase; color:var(--dim); margin:16px 0 7px; }
+.settings input { width:100%; background:var(--input-bg); color:var(--ink); border:1px solid var(--input-bd); border-radius:var(--radius); font:400 13px/1.5 'IBM Plex Mono',monospace; padding:9px 11px; }
+.settings input:focus { outline:none; border-color:var(--accent); }
+.settings .hl-check { display:flex; align-items:center; gap:9px; text-transform:none; letter-spacing:0; color:var(--ink); font:400 13px/1.4 'Public Sans',sans-serif; cursor:pointer; }
+.settings .hl-check input { width:auto; margin:0; }
+.mini-btn { flex:0 0 auto; background:var(--accent); color:#faf8f3; border:none; border-radius:var(--radius); padding:10px 16px; font:600 12px/1 'Public Sans',sans-serif; letter-spacing:.02em; cursor:pointer; }
+.mini-btn:hover { filter:brightness(.92); }
+.mini-btn:disabled { opacity:.5; cursor:not-allowed; }
+.status { font:400 12px/1.4 'IBM Plex Mono',monospace; color:var(--dim); margin-top:8px; }
+.status:empty { margin-top:0; }
+.err { color:#c0392b; font:400 12px/1.4 'IBM Plex Mono',monospace; min-height:1em; margin-top:6px; }
+body[data-style="midnight"] .err { color:#e07b6a; }
+
+/* ───────────────────────── bulletins ───────────────────────── */
+.bulletins { margin-top:28px; display:flex; flex-direction:column; gap:32px; }
+.bulletin { padding-top:0; }
+.bulletin + .bulletin { border-top:1px solid var(--rule); padding-top:32px; }
+.b-meta { display:flex; gap:12px; flex-wrap:wrap; align-items:baseline; font:500 10px/1.2 'IBM Plex Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--meta); margin-bottom:12px; }
+.b-subject { color:var(--accent); }
+.b-id { color:var(--meta); text-transform:none; letter-spacing:.02em; }
+body:not([data-style="terminal"]) .b-id { display:none; }
+
+.b-prose { margin:0; color:var(--ink-soft); }
+body[data-style="letterpress"] .b-prose { font:italic 300 20px/1.72 'Spectral',serif; }
+body[data-style="midnight"]    .b-prose { font:300 21px/1.7 'Newsreader',serif; }
+body[data-style="terminal"]    .b-prose { font:400 14px/1.75 'IBM Plex Mono',monospace; }
+
+/* payload words read as plain prose by default; the "highlight payload words"
+   setting (body[data-hl="on"]) emphasizes them per reading style */
+.pw { color:inherit; font:inherit; border-bottom:none; }
+body[data-hl="on"] .pw { color:var(--ink); }
+body[data-hl="on"][data-style="letterpress"] .pw { font-weight:600; font-style:normal; }
+body[data-hl="on"][data-style="midnight"]    .pw { font-weight:500; color:#f4efe4; }
+body[data-hl="on"][data-style="terminal"]    .pw { font-weight:600; border-bottom:1px dotted #9a937f; }
+
+.b-attr { color:var(--dim); }
+body[data-style="letterpress"] .b-attr { text-align:right; font:italic 400 14px/1.4 'Spectral',serif; margin-top:8px; }
+body[data-style="midnight"]    .b-attr { text-align:right; font:italic 300 15px/1.4 'Newsreader',serif; margin-top:9px; }
+body[data-style="terminal"]    .b-attr { font:400 12px/1.4 'IBM Plex Mono',monospace; margin-top:7px; }
+
+/* decoded reveal */
+.b-decoded { animation:reveal .45s ease both; margin-top:16px; }
+body[data-style="letterpress"] .b-decoded,
+body[data-style="midnight"]    .b-decoded { padding-left:16px; border-left:2px solid var(--accent); }
+body[data-style="terminal"]    .b-decoded { background:#17161a; padding:12px 14px; }
+.b-decoded-label { font:600 9px/1 'IBM Plex Mono',monospace; letter-spacing:.2em; text-transform:uppercase; color:var(--accent); margin-bottom:7px; }
+body[data-style="terminal"] .b-decoded-label { color:#7fd6a0; letter-spacing:.16em; }
+body[data-style="terminal"] .b-decoded-label::after { content:' \2713'; }
+.b-decoded-text { color:var(--ink); white-space:pre-wrap; }
+body[data-style="letterpress"] .b-decoded-text { font:400 16px/1.55 'Spectral',serif; }
+body[data-style="midnight"]    .b-decoded-text { font:400 17px/1.55 'Newsreader',serif; color:#f4efe4; }
+body[data-style="terminal"]    .b-decoded-text { font:400 13px/1.6 'IBM Plex Mono',monospace; color:#f0eee8; }
+
+/* lock affordance */
+.b-lock { margin-top:14px; color:var(--meta); background:none; border:none; padding:0; cursor:pointer; display:inline-flex; }
+.b-lock:hover { color:var(--accent); }
+/* lock/unlock toggle on decoded bulletins: is-open reveals the plaintext and
+   shows the open padlock; toggling off re-hides it and shows the closed lock */
+.b-toggle .ic-unlock { display:none; }
+.bulletin.is-open .b-toggle .ic-lock { display:none; }
+.bulletin.is-open .b-toggle .ic-unlock { display:inline-flex; }
+.bulletin:not(.is-open) .b-decoded { display:none; }
+
+.empty { font:400 14px/1.6 'Public Sans',sans-serif; color:var(--dim); }
+body[data-style="terminal"] .empty { font-family:'IBM Plex Mono',monospace; font-size:13px; }
+
+/* footer */
+.foot { margin-top:20px; font:400 12px/1.6 'Public Sans',sans-serif; color:var(--dim); text-align:center; padding:0 8px; }
+.foot b { color:var(--accent); font-weight:600; }
+.hidden { display:none !important; }
 </style>
 </head>
-<body>
-<div class="container">
-  <header class="top">
-    <h1>Glossia Bulletin</h1>
-    <span class="sub">read an encrypted board — add the passphrase to decrypt</span>
-    <span class="home"><a href="./compose.html">create a bulletin →</a> &nbsp;·&nbsp; <a href="./index.html">demo</a></span>
-  </header>
-
-  <!-- the board's bulletins render here, first, so a shared #npub link leads
-       with its content -->
-  <div class="card hidden" id="r-results-card">
-    <div id="r-results"></div>
-  </div>
-
-  <div class="card">
-    <label>Decryption key <span class="muted">(optional — read key, nsec, or passphrase)</span></label>
-    <div class="row">
-      <input type="password" id="r-pass" autocomplete="current-password" placeholder="nread1… / nsec1… / passphrase — leave empty to read the prose only" spellcheck="false">
-      <button type="button" class="btn sm" data-reveal="r-pass" title="Show / hide">👁</button>
+<body data-style="letterpress" data-hl="off">
+<div class="wrap">
+  <div class="board">
+    <!-- masthead -->
+    <div class="masthead">
+      <span class="brand">Glossia Bulletin</span>
+      <a class="compose-link" href="./compose.html">compose →</a>
     </div>
-    <details id="r-settings" style="margin-top:.7rem">
-      <summary>Board &amp; relays</summary>
-      <label>Board address (npub)</label>
-      <input type="text" id="r-npub" placeholder="npub1… (or paste a full glossia link)" spellcheck="false">
-      <label>Relays</label>
-      <input type="text" id="r-relays" autocomplete="off" spellcheck="false">
-      <div class="row" style="margin-top:.7rem">
-        <button type="button" class="btn" id="r-load" style="flex:0 0 auto" disabled>Load bulletins</button>
-        <span class="hint" id="r-status" style="flex:1"></span>
-      </div>
-    </details>
+
+    <!-- board id: the board's npub, shown at the top as its identifier -->
+    <div class="board-id">
+      <input type="text" id="r-npub" spellcheck="false" placeholder="npub1… — the board's id (or paste a glossia link)">
+      <button type="button" class="mini-btn" id="r-load" disabled>Load</button>
+    </div>
+    <div class="status" id="r-status"></div>
     <div class="err" id="r-err"></div>
+
+    <!-- key bar -->
+    <div class="keybar">
+      <label for="r-key">Decryption key</label>
+      <input type="text" id="r-key" spellcheck="false" autocomplete="off"
+             placeholder="read key, nwrite, or passphrase — leave empty to read the prose only">
+      <div class="keyhint hidden" id="r-keyhint">A decryption key is required to unlock these bulletins.</div>
+    </div>
+
+    <!-- board / relay settings -->
+    <details class="settings" id="r-settings">
+      <summary>
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+        <span>Settings</span>
+      </summary>
+
+      <label>Reading style</label>
+      <div class="style-switch" role="group" aria-label="Reading style">
+        <button type="button" class="style-tile" data-set-style="letterpress"><span class="swatch letterpress"></span>Letterpress</button>
+        <button type="button" class="style-tile" data-set-style="midnight"><span class="swatch midnight"></span>Midnight</button>
+        <button type="button" class="style-tile" data-set-style="terminal"><span class="swatch terminal"></span>Terminal</button>
+      </div>
+
+      <label class="hl-check"><input type="checkbox" id="r-hl"> Highlight payload words</label>
+
+      <label for="r-relays">Relays</label>
+      <input type="text" id="r-relays" autocomplete="off" spellcheck="false">
+    </details>
+
+    <!-- bulletins -->
+    <div class="bulletins" id="r-results"></div>
   </div>
 
-  <div class="note">
-    <strong>How it works.</strong> A board lives at an <span class="mono">npub</span>. Messages are encrypted,
-    encoded into Glossia prose, signed, and published to public nostr relays. With only the npub you can read
-    the prose; a <strong>read key</strong> (nread…), an <strong>nsec</strong>, or the board's
-    <strong>passphrase</strong> decrypts it. To post, use <a href="./compose.html">create a bulletin</a>.
+  <div class="foot">
+    Glossia is a <b>readable encoding, not steganography</b>. Encrypted bulletins use authenticated AES-256-GCM,
+    so a wrong key or tampering fails cleanly. Boards are public on nostr; a weak passphrase is offline-guessable.
+    Your reading style is saved in the link's <b>#</b> — no app, no account.
   </div>
-
-  <footer class="hint" style="text-align:center; margin-top:2rem; border-top:1px solid var(--border); padding-top:1rem">
-    Glossia is a <strong>readable encoding, not steganography</strong>. Encrypted bulletins use authenticated AES-256-GCM,
-    so a wrong passphrase or tampering fails cleanly. Boards are public on nostr; a weak passphrase is offline-guessable.
-  </footer>
 </div>
 
 <script type="module">
-import { init, decodeMessage } from './glossia-msg.js';
+import { init, decodeMessage, skimArtifact } from './glossia-msg.js';
 import { fetchBoard, isNpub, resolveContentKey, DEFAULT_RELAYS } from './glossia-nostr.js';
 
 const $ = (id) => document.getElementById(id);
 let ready = false;
 
+const STYLES = ['letterpress', 'midnight', 'terminal'];
 $('r-relays').value = DEFAULT_RELAYS.join(', ');
 function parseRelays(s) { return s.split(/[\s,]+/).map(x => x.trim()).filter(x => /^wss?:\/\//.test(x)); }
 
+// ── reading style ─────────────────────────────────────────────────────
+function currentStyle() { return document.body.dataset.style; }
+function applyStyle(style, { persist = true } = {}) {
+  if (!STYLES.includes(style)) style = 'letterpress';
+  document.body.dataset.style = style;
+  document.querySelectorAll('[data-set-style]').forEach(b =>
+    b.setAttribute('aria-pressed', String(b.dataset.setStyle === style)));
+  if (persist) writeHash();
+}
+document.querySelectorAll('[data-set-style]').forEach(b =>
+  b.addEventListener('click', () => applyStyle(b.dataset.setStyle)));
+
+// ── highlight payload words (off by default) ──────────────────────────
+// Pure CSS toggle via body[data-hl]; persisted in the URL like the reading style.
+function applyHl(on, { persist = true } = {}) {
+  document.body.dataset.hl = on ? 'on' : 'off';
+  $('r-hl').checked = on;
+  if (persist) writeHash();
+}
+$('r-hl').addEventListener('change', () => applyHl($('r-hl').checked));
+
+// ── engine load state ─────────────────────────────────────────────────
 function setEngine(state, msg) {
   $('r-load').disabled = state !== 'ready';
   if (state === 'loading') $('r-status').textContent = 'Loading Glossia engine…';
@@ -138,34 +283,52 @@ setEngine('loading');
 
 // ── helpers ───────────────────────────────────────────────────────────
 function escapeHtml(s) { return s.replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
-function renderProse(prose, words) {
+function boldPayload(text, words) {
   const set = new Set((words || []).map(w => w.toLowerCase()));
-  return escapeHtml(prose).replace(/[A-Za-zÀ-ÿ]+/g, (w) => set.has(w.toLowerCase()) ? `<mark>${w}</mark>` : w);
+  return escapeHtml(text).replace(/[A-Za-zÀ-ÿ]+/g, (w) => set.has(w.toLowerCase()) ? `<b class="pw">${w}</b>` : w);
 }
-// split out the readable quote for the locked view (hide the attribution / key)
-function safeParse(text) {
+// split "<body> — <attribution>" for display
+function splitProse(text) {
   text = (text || '').trim();
   const di = text.lastIndexOf(' — ');
-  if (di > 0) return { encrypted: true, prose: text.slice(0, di).trim() };
-  const i = text.indexOf(':');
-  if (i > 0 && /^[A-Za-z0-9_-]+$/.test(text.slice(0, i))) return { encrypted: true, prose: text.slice(i + 1).trim() };
-  return { encrypted: false, prose: text };
+  if (di > 0) return { body: text.slice(0, di).trim(), attr: text.slice(di + 3).trim() };
+  return { body: text, attr: '' };
 }
+function fmtDate(sec) {
+  const d = new Date(sec * 1000);
+  const mon = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][d.getUTCMonth()];
+  const p = (n) => String(n).padStart(2, '0');
+  return `${p(d.getUTCDate())} ${mon} ${d.getUTCFullYear()} · ${p(d.getUTCHours())}:${p(d.getUTCMinutes())}`;
+}
+const ICON_LOCK = '<svg class="ic-lock" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>';
+const ICON_UNLOCK = '<svg class="ic-unlock" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 7.5-2.1"/></svg>';
 
-// show / hide toggle for the passphrase
-document.querySelectorAll('[data-reveal]').forEach(btn => btn.addEventListener('click', () => {
-  const inp = $(btn.dataset.reveal);
-  const show = inp.type === 'password';
-  inp.type = show ? 'text' : 'password';
-  btn.textContent = show ? '🙈' : '👁';
-}));
-
-// ── URL routing: following bulletin.html#npub renders that board ──────
+// ── URL routing: bulletin.html#<npub>&style=<style> ───────────────────
+function writeHash() {
+  const npub = $('r-npub').value.trim().match(/npub1[0-9a-z]+/i);
+  const parts = [];
+  if (npub) parts.push(npub[0]);
+  parts.push('style=' + currentStyle());
+  if (document.body.dataset.hl === 'on') parts.push('hl=1');
+  // keep the decryption key in the URL so a reader can bookmark the unlocked page
+  const key = $('r-key').value.trim();
+  if (key) parts.push('key=' + encodeURIComponent(key));
+  const hash = '#' + parts.join('&');
+  if (location.hash !== hash) history.replaceState(null, '', hash);
+}
 function routeFromHash() {
-  const h = decodeURIComponent(location.hash.replace(/^#/, '')).trim();
+  const raw = location.hash.replace(/^#/, '');
+  let h = raw; try { h = decodeURIComponent(raw); } catch { /* keep raw */ }
+  h = h.trim();
+  const styleM = h.match(/style=(letterpress|midnight|terminal)/i);
+  applyStyle(styleM ? styleM[1].toLowerCase() : 'letterpress', { persist: false });
+  applyHl(/(?:^|&)hl=1(?:&|$)/i.test(raw), { persist: false });   // off unless the link says on
+  // a decryption key embedded in the link (the "reader link + key") unlocks on open
+  const keyM = raw.match(/(?:^|&)key=([^&]*)/i);
+  if (keyM && keyM[1]) { let k = keyM[1]; try { k = decodeURIComponent(k); } catch { /* keep */ } $('r-key').value = k; }
   const m = h.match(/npub1[0-9a-z]+/i);
   if (m && isNpub(m[0])) { $('r-npub').value = m[0]; loadBoard(); }
-  else { $('r-settings').open = true; }   // no board yet — show the form to enter one
+  else { $('r-npub').focus(); }   // no board yet — prompt for the id at the top
 }
 window.addEventListener('hashchange', routeFromHash);
 
@@ -173,24 +336,13 @@ window.addEventListener('hashchange', routeFromHash);
 let loadedEvents = [];
 let renderToken = 0;
 
-async function renderLoaded() {
-  if (!loadedEvents.length) return;
-  const my = ++renderToken;
-  const creds = await credCandidates();   // resolved once per render, not per bulletin
-  if (my !== renderToken) return;
-  const items = await Promise.all(loadedEvents.map(ev => renderBulletin(ev, creds)));
-  if (my !== renderToken) return;
-  $('r-results').innerHTML = items.join('');
-}
-
-// Ordered list of content credentials to try for the current input. For a
-// passphrase we try the current key-derived scheme first, then the legacy scheme
-// where the passphrase string WAS the content key — so bulletins posted before
-// content keys were derived from the signing key still decrypt.
+// Ordered list of content credentials to try. For a passphrase we try the
+// key-derived scheme first, then the legacy scheme where the passphrase string
+// WAS the content key, so older bulletins still decrypt.
 async function credCandidates() {
-  const raw = $('r-pass').value.trim();
+  const raw = $('r-key').value.trim();
   if (!raw) return [];
-  if (raw.startsWith('nsec') || raw.startsWith('nread')) {
+  if (raw.startsWith('nwrite') || raw.startsWith('nsec') || raw.startsWith('nread')) {
     try { return [await resolveContentKey(raw)]; } catch { return []; }
   }
   let K = null;
@@ -198,22 +350,80 @@ async function credCandidates() {
   return K ? [K, raw] : [raw];
 }
 
+async function renderLoaded() {
+  if (!loadedEvents.length) return;
+  const my = ++renderToken;
+  const creds = await credCandidates();
+  if (my !== renderToken) return;
+  const rendered = await Promise.all(loadedEvents.map(ev => renderBulletin(ev, creds)));
+  if (my !== renderToken) return;
+  $('r-results').innerHTML = rendered.map(r => r.html).join('');
+  wireLocks();
+}
+
+async function renderBulletin(ev, creds) {
+  const when = fmtDate(ev.created_at);
+  const subjTag = (ev.tags || []).find(t => t[0] === 'subject');
+  const subject = subjTag ? escapeHtml(subjTag[1]) : '';
+  const id = escapeHtml(ev.id.slice(0, 8)) + '…';
+
+  // Try each candidate credential; GCM rejects the wrong ones cleanly.
+  let dec = null;
+  for (const c of (creds.length ? creds : [null])) {
+    try { dec = await decodeMessage(ev.content, c); break; } catch { /* keep trying */ }
+  }
+
+  const meta = `<div class="b-meta"><span>${when}</span>${subject ? `<span class="b-subject">${subject}</span>` : ''}<span class="b-id">${id}</span></div>`;
+
+  if (dec) {
+    // Unlocked: bold the body's payload words, show the attribution, reveal the plaintext.
+    const { body, attr } = splitProse(dec.prose);
+    const proseHtml = boldPayload(body, dec.payloadWords);
+    const attrHtml = attr ? `<div class="b-attr">— ${escapeHtml(attr)}</div>` : '';
+    const decoded = `<div class="b-decoded"><div class="b-decoded-label">decoded</div><div class="b-decoded-text">${escapeHtml(dec.message)}</div></div>`;
+    // Unlocked bulletins start open (unlock icon). The toggle re-hides the
+    // plaintext in place and swaps back to the closed lock.
+    const toggle = `<button type="button" class="b-lock b-toggle" data-toggle title="Hide the decoded message">${ICON_LOCK}${ICON_UNLOCK}</button>`;
+    return { unlocked: true, encrypted: !!dec.encrypted, html: `<article class="bulletin is-open">${meta}<p class="b-prose">${proseHtml}</p>${attrHtml}${decoded}${toggle}</article>` };
+  }
+
+  // Locked: skim the prose (no key needed) so payload words still read as emphasis.
+  const skim = skimArtifact(ev.content);
+  const { body, attr } = splitProse(skim.prose);
+  const proseHtml = boldPayload(body, skim.payloadWords);
+  const attrHtml = attr ? `<div class="b-attr">— ${escapeHtml(attr)}</div>` : '';
+  const lock = `<button type="button" class="b-lock" data-lock title="Add a decryption key to unlock">${ICON_LOCK}</button>`;
+  return { unlocked: false, encrypted: !!skim.encrypted, html: `<article class="bulletin">${meta}<p class="b-prose">${proseHtml}</p>${attrHtml}${lock}</article>` };
+}
+
+// clicking a lock (no key yet) focuses the key field and explains why it's
+// locked; the toggle on an unlocked bulletin hides/reveals its decoded text
+function wireLocks() {
+  document.querySelectorAll('[data-lock]').forEach(btn => btn.addEventListener('click', () => {
+    if (!$('r-key').value.trim()) $('r-keyhint').classList.remove('hidden');
+    $('r-key').focus();
+  }));
+  document.querySelectorAll('[data-toggle]').forEach(btn => btn.addEventListener('click', () => {
+    const open = btn.closest('.bulletin').classList.toggle('is-open');
+    btn.title = open ? 'Hide the decoded message' : 'Reveal the decoded message';
+  }));
+}
+
 async function loadBoard() {
   $('r-err').textContent = ''; $('r-status').textContent = '';
   if (!ready) { $('r-err').textContent = 'Engine still loading…'; return; }
   const m = $('r-npub').value.trim().match(/npub1[0-9a-z]+/i);
-  if (!m || !isNpub(m[0])) { $('r-err').textContent = 'Enter a valid npub.'; $('r-settings').open = true; return; }
+  if (!m || !isNpub(m[0])) { $('r-err').textContent = 'Enter a valid npub.'; $('r-npub').focus(); return; }
   const npub = m[0];
   const relays = parseRelays($('r-relays').value);
   if (!relays.length) { $('r-err').textContent = 'Add at least one wss:// relay.'; return; }
   $('r-status').textContent = 'Querying ' + relays.length + ' relays…';
   $('r-load').disabled = true;
-  if (location.hash.replace(/^#/, '') !== npub) history.replaceState(null, '', '#' + npub);
+  writeHash();
   try {
     loadedEvents = await fetchBoard(npub, relays);
-    $('r-results-card').classList.remove('hidden');
     if (!loadedEvents.length) {
-      $('r-results').innerHTML = '<p class="muted">No bulletins found for this board (yet).</p>';
+      $('r-results').innerHTML = '<p class="empty">No bulletins found for this board (yet).</p>';
       $('r-status').textContent = '';
       return;
     }
@@ -225,43 +435,24 @@ async function loadBoard() {
 $('r-load').addEventListener('click', loadBoard);
 $('r-npub').addEventListener('keydown', (e) => { if (e.key === 'Enter') loadBoard(); });
 
-// typing the passphrase decrypts the already-loaded bulletins in place (no
-// re-fetch); debounced since each decrypt runs PBKDF2
-let rPassTimer = null;
-$('r-pass').addEventListener('input', () => {
-  clearTimeout(rPassTimer);
-  rPassTimer = setTimeout(() => { if (loadedEvents.length) renderLoaded(); }, 350);
+// typing the key re-decrypts the loaded bulletins in place (debounced — each
+// attempt runs PBKDF2)
+let keyTimer = null;
+$('r-key').addEventListener('input', () => {
+  if ($('r-key').value.trim()) $('r-keyhint').classList.add('hidden');
+  writeHash();   // reflect the key in the URL so the unlocked page stays bookmarkable
+  clearTimeout(keyTimer);
+  keyTimer = setTimeout(() => { if (loadedEvents.length) renderLoaded(); }, 350);
 });
-$('r-pass').addEventListener('keydown', (e) => { if (e.key === 'Enter') { clearTimeout(rPassTimer); renderLoaded(); } });
+$('r-key').addEventListener('keydown', (e) => { if (e.key === 'Enter') { clearTimeout(keyTimer); renderLoaded(); } });
 
-async function renderBulletin(ev, creds) {
-  const when = new Date(ev.created_at * 1000).toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
-  const subjTag = (ev.tags || []).find(t => t[0] === 'subject');
-  const subject = subjTag ? escapeHtml(subjTag[1]) : '';
-  // Try each candidate credential in turn; GCM rejects the wrong ones cleanly.
-  let dec = null, lastErr = null;
-  for (const c of (creds.length ? creds : [null])) {
-    try { dec = await decodeMessage(ev.content, c); break; }
-    catch (e) { lastErr = e; }
-  }
-  let body;
-  if (dec) {
-    body = `<div class="prose">${renderProse(dec.prose, dec.payloadWords)}</div>`
-         + `<div class="msg">${escapeHtml(dec.message)}</div>`;
-  } else {
-    // Locked: show the full artifact — quote AND attribution — since the
-    // attribution is meant to read as the source of the quote even undecrypted.
-    const { encrypted } = safeParse(ev.content);
-    const hint = !encrypted ? escapeHtml(lastErr?.message || 'Could not decode.')
-      : creds.length ? '🔒 Wrong key/passphrase — could not decrypt.'
-      : '🔒 Encrypted — add the read key, nsec, or passphrase to reveal.';
-    body = `<div class="prose">${escapeHtml(ev.content)}</div><div class="hint">${hint}</div>`;
-  }
-  return `<div class="bulletin">
-    <div class="meta"><span>${when}</span>${subject ? `<span>· ${subject}</span>` : ''}<span class="muted mono">${ev.id.slice(0, 12)}…</span></div>
-    ${body}
-  </div>`;
-}
+// apply the reading style from the hash immediately — even before the engine
+// loads (or if it fails), the board still reads in the shared style
+(function initStyle() {
+  const m = (location.hash || '').match(/style=(letterpress|midnight|terminal)/i);
+  applyStyle(m ? m[1].toLowerCase() : 'letterpress', { persist: false });
+  applyHl(/(?:^|&)hl=1(?:&|$)/i.test(location.hash || ''), { persist: false });
+})();
 </script>
 </body>
 </html>

--- a/web/compose.html
+++ b/web/compose.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Create a Glossia Bulletin — publish an encrypted board</title>
-<meta name="description" content="Compose an encrypted message, encode it into Glossia prose, and publish it to a nostr identity. Share the board's #npub to read the prose, the read key to decrypt, the nsec to post.">
+<meta name="description" content="Compose an encrypted message, encode it into Glossia prose, and publish it to a nostr identity. Share the board's #npub to read the prose, the read key to decrypt, the nwrite to post — in your choice of reading style.">
 <script type="importmap">
 {
   "imports": {
@@ -16,169 +16,400 @@
   }
 }
 </script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,500&family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,300;1,6..72,400&family=IBM+Plex+Mono:wght@400;500;600&family=Public+Sans:wght@400;500;600&display=swap" rel="stylesheet">
 <style>
-:root {
-  --bg: #0f1117; --surface: #1a1d27; --surface-alt: #1e2130; --border: #2a2d3a;
-  --text: #e4e4e7; --text-dim: #8b8d97; --accent: #7c6cf0; --accent-hover: #9488f5;
-  --mark-bg: rgba(14,165,233,0.15); --mark-border: rgba(14,165,233,0.4);
-  --error: #ef4444; --success: #22c55e; --orange: #f97316;
-  --font-mono: 'SF Mono','Cascadia Code','Fira Code',monospace;
-  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+/* the reading-style tiles theme the whole page (mirrors the bulletin viewer) */
+body[data-style="letterpress"] {
+  --page:#d7d5cf; --card:#faf8f3; --card-bd:#e2ddce; --ink:#26241d; --ink-soft:#3c3a33;
+  --dim:#84806f; --accent:#9a5b3f; --accent-2:#824a31; --btn-ink:#faf8f3;
+  --rule:#e2ddce; --input-bg:#fff; --input-bd:#ddd6c6; --chip-bg:#efece3;
+  --meta:#b8b2a0; --error:#c0392b; --ok:#4f7a3f;
+}
+body[data-style="midnight"] {
+  --page:#08080a; --card:#131318; --card-bd:#232228; --ink:#e8e4da; --ink-soft:#cfcabf;
+  --dim:#8a8794; --accent:#c9a25f; --accent-2:#dcb877; --btn-ink:#17140c;
+  --rule:#242229; --input-bg:#0d0d10; --input-bd:#2a2930; --chip-bg:#1c1b21;
+  --meta:#5c5a63; --error:#e07b6a; --ok:#7fb98a;
+}
+body[data-style="terminal"] {
+  --page:#dbd8d0; --card:#f0eee8; --card-bd:#cdc7b8; --ink:#17161a; --ink-soft:#3a382f;
+  --dim:#6d6a5f; --accent:#274bd6; --accent-2:#1a37a8; --btn-ink:#f0eee8;
+  --rule:#ddd8c9; --input-bg:#fff; --input-bd:#17161a; --chip-bg:#e6e3da;
+  --meta:#a29c8b; --error:#c0392b; --ok:#1f7a4d;
 }
 * { box-sizing: border-box; }
-body { margin: 0; font-family: var(--font-sans); background: var(--bg); color: var(--text); line-height: 1.55; }
-.container { max-width: 880px; margin: 0 auto; padding: 1.5rem; }
+html, body { margin: 0; }
+body { min-height: 100vh; background: var(--page); color: var(--ink); font-family: 'Public Sans', system-ui, sans-serif; line-height: 1.55; transition: background .35s ease, color .35s ease; }
+.wrap { max-width: 1040px; margin: 0 auto; padding: 48px 22px 80px; }
 a { color: var(--accent); text-decoration: none; }
-a:hover { color: var(--accent-hover); text-decoration: underline; }
-header.top { display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap; border-bottom: 1px solid var(--border); padding-bottom: 1rem; margin-bottom: 1.25rem; }
-header.top h1 { font-size: 1.4rem; margin: 0; }
-header.top .sub { color: var(--text-dim); font-size: .9rem; }
-header.top .home { margin-left: auto; font-size: .85rem; }
-.card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.1rem; margin-bottom: 1rem; }
-label { display: block; font-size: .8rem; color: var(--text-dim); margin: .6rem 0 .25rem; text-transform: uppercase; letter-spacing: .03em; }
-input[type=text], input[type=password], textarea, select {
-  width: 100%; background: var(--bg); border: 1px solid var(--border); color: var(--text);
-  border-radius: 7px; padding: .55rem .65rem; font-family: var(--font-mono); font-size: .9rem;
-}
-textarea { resize: vertical; min-height: 4.5rem; line-height: 1.5; }
-input:focus, textarea:focus, select:focus { outline: none; border-color: var(--accent); }
-.row { display: flex; gap: .6rem; align-items: flex-end; flex-wrap: wrap; }
-.row > * { flex: 1; min-width: 0; }
-.btn { background: var(--accent); color: #fff; border: none; border-radius: 7px; padding: .55rem 1rem; font-size: .9rem; cursor: pointer; font-weight: 600; }
-.btn:hover { background: var(--accent-hover); }
-.btn:disabled { opacity: .5; cursor: not-allowed; }
-.btn.sm { padding: .4rem .7rem; font-size: .8rem; background: var(--surface-alt); color: var(--text); border: 1px solid var(--border); font-weight: 500; flex: 0 0 auto; }
-.btn.sm:hover { border-color: var(--accent); background: var(--surface); }
-.hint { font-size: .82rem; color: var(--text-dim); margin: .4rem 0; }
-.mono { font-family: var(--font-mono); }
-.keyval { word-break: break-all; font-size: .8rem; font-family: var(--font-mono); }
-.keyval.pub { color: var(--orange); }
-.keyval.sec { color: var(--error); }
-.keyval.read { color: var(--success); }
-.prose { background: var(--bg); border: 1px dashed var(--border); border-radius: 7px; padding: .7rem; margin: .5rem 0; font-size: .95rem; line-height: 1.7; }
-mark { background: var(--mark-bg); border-bottom: 1px solid var(--mark-border); color: var(--text); padding: 0 1px; border-radius: 2px; }
-.entropy { font-size: .78rem; color: var(--text-dim); }
-.entropy.strong { color: var(--success); }
-.err { color: var(--error); font-size: .85rem; min-height: 1.1rem; }
-.ok { color: var(--success); }
-.muted { color: var(--text-dim); }
-.relay-line { font-size: .8rem; font-family: var(--font-mono); }
+a:hover { text-decoration: underline; }
 .hidden { display: none !important; }
-.check { display: flex; align-items: center; gap: .5rem; font-size: .85rem; color: var(--text); text-transform: none; letter-spacing: 0; margin-top: .8rem; }
-.check input { width: auto; }
-.keyrow { margin: .5rem 0; }
-.keyrow .lab { font-size: .72rem; text-transform: uppercase; letter-spacing: .03em; color: var(--text-dim); }
-.note { background: rgba(124,108,240,.08); border: 1px solid rgba(124,108,240,.25); border-radius: 8px; padding: .6rem .8rem; font-size: .82rem; color: var(--text-dim); margin-bottom: 1rem; }
-.note strong { color: var(--text); }
+.mono { font-family: 'IBM Plex Mono', monospace; }
+.muted { color: var(--dim); }
+
+/* masthead */
+.masthead { display:flex; align-items:baseline; justify-content:space-between; gap:12px; flex-wrap:wrap; margin-bottom:24px; }
+.masthead .title { font:600 13px/1 'IBM Plex Mono',monospace; letter-spacing:.22em; text-transform:uppercase; color:var(--ink); }
+.masthead .sub { font:400 13px/1.4 'Public Sans',sans-serif; color:var(--dim); }
+.masthead .home { margin-left:auto; font:500 12px/1 'IBM Plex Mono',monospace; letter-spacing:.04em; }
+
+/* two-column layout */
+.layout { display:flex; gap:32px; align-items:flex-start; flex-wrap:wrap; }
+.col-form { flex:1 1 520px; min-width:320px; }
+.col-preview { flex:0 1 380px; min-width:300px; position:sticky; top:24px; }
+#c-preview-slot:empty { display:none; }
+/* when the two columns stack, the live preview moves under the message */
+@media (max-width: 820px) {
+  .wrap { padding:32px 16px 64px; }
+  .layout { flex-direction:column; align-items:stretch; }
+  .col-form, .col-preview { flex:1 1 auto; width:100%; min-width:0; }
+  .col-preview { position:static; }
+  .board { padding:24px 20px 28px; }
+  .preview { padding:20px 18px; }
+  #c-preview-slot { margin-top:18px; }
+}
+
+/* card */
+.board { background:var(--card); color:var(--ink); border:1px solid var(--card-bd); border-radius:12px; box-shadow:0 24px 60px -32px rgba(20,18,14,.4); padding:32px 36px 36px; margin-bottom:20px; transition:background .35s ease, border-color .35s ease; }
+.board-head { display:flex; align-items:baseline; justify-content:space-between; border-bottom:1px solid var(--rule); padding-bottom:14px; margin-bottom:20px; }
+.board-head .k { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.2em; text-transform:uppercase; }
+/* the section title doubles as a "start a fresh board" button */
+.board-new { color:var(--ink); text-decoration:none; cursor:pointer; display:inline-flex; align-items:center; gap:6px; }
+.board-new:hover { color:var(--accent); text-decoration:none; }
+.board-new .plus { display:inline-flex; align-items:center; justify-content:center; width:16px; height:16px; border:1px solid currentColor; border-radius:5px; font-size:13px; line-height:1; }
+.board-head .n { font:400 11px/1 'IBM Plex Mono',monospace; color:var(--meta); }
+
+/* form controls */
+label { display:block; font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.18em; text-transform:uppercase; color:var(--accent); margin:20px 0 9px; }
+label:first-of-type { margin-top:0; }
+input[type=text], input[type=password], textarea, select {
+  width:100%; background:var(--input-bg); border:1px solid var(--input-bd); border-radius:8px; color:var(--ink);
+  font:400 14px/1.5 'Public Sans',sans-serif; padding:11px 13px;
+}
+textarea { resize:vertical; min-height:88px; line-height:1.55; font-size:15px; }
+#c-id-value, #c-relays, #c-lang, select { font-family:'IBM Plex Mono',monospace; font-size:13.5px; }
+input:focus, textarea:focus, select:focus { outline:none; border-color:var(--accent); }
+input::placeholder, textarea::placeholder { color:var(--dim); opacity:.7; }
+
+.row { display:flex; gap:12px; align-items:flex-end; flex-wrap:wrap; }
+.row > * { flex:1; min-width:0; }
+
+.btn { background:var(--accent); color:var(--btn-ink); border:none; border-radius:9px; padding:13px 18px; font:600 13px/1 'Public Sans',sans-serif; letter-spacing:.02em; cursor:pointer; }
+.btn:hover { background:var(--accent-2); }
+.btn:disabled { opacity:.5; cursor:not-allowed; }
+.btn.sm { background:var(--chip-bg); color:var(--ink); border:1px solid var(--input-bd); border-radius:7px; padding:8px 12px; font-size:12px; font-weight:500; letter-spacing:0; flex:0 0 auto; }
+.btn.sm:hover { background:var(--input-bg); border-color:var(--accent); }
+.btn.block { width:100%; padding:14px; font-size:14px; margin-top:24px; }
+
+.hint { font:400 13px/1.5 'Public Sans',sans-serif; color:var(--dim); margin:.5rem 0; }
+.entropy { font:400 12px/1 'IBM Plex Mono',monospace; color:var(--dim); margin-top:8px; }
+.entropy.strong { color:var(--ok); }
+.err { color:var(--error); font:400 12px/1.4 'IBM Plex Mono',monospace; min-height:1.1em; margin-top:8px; }
+.ok { color:var(--ok); }
+.check { display:flex; align-items:center; gap:9px; font:400 13px/1.4 'Public Sans',sans-serif; color:var(--ink); text-transform:none; letter-spacing:0; margin:22px 0 0; }
+.check input { width:auto; }
+
+/* settings disclosure */
+.settings { margin-top:22px; border-top:1px solid var(--rule); padding-top:16px; }
+.settings > summary { list-style:none; cursor:pointer; display:flex; align-items:center; gap:8px; font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.18em; text-transform:uppercase; color:var(--accent); }
+.settings > summary::-webkit-details-marker { display:none; }
+.settings > summary:hover { color:var(--accent-2); }
+.settings label:first-of-type { margin-top:16px; }
+
+/* reading-style tiles */
+.tiles { display:flex; gap:10px; }
+.tile { flex:1; display:flex; flex-direction:column; align-items:center; gap:9px; padding:12px 8px; border-radius:9px; border:2px solid var(--rule); background:transparent; cursor:pointer; font:500 12px/1 'Public Sans',sans-serif; color:var(--dim); transition:border-color .2s,color .2s,background .2s; }
+.tile:hover { color:var(--ink); }
+.tile[aria-pressed="true"] { border-color:var(--accent); background:var(--input-bg); color:var(--ink); }
+.tile .mini { width:74px; height:46px; border-radius:6px; display:flex; align-items:center; justify-content:center; }
+.mini.letterpress { background:#f6f3ec; border:1px solid #d8d2c4; font:italic 500 22px/1 'Spectral',serif; color:#26241d; }
+.mini.midnight { background:#0d0d10; border:1px solid #232228; font:400 22px/1 'Newsreader',serif; color:#e8e4da; }
+.mini.terminal { background:#f0eee8; border:1px solid #17161a; font:600 18px/1 'IBM Plex Mono',monospace; color:#17161a; }
+
+/* shareable link + outputs */
+.linkbox { display:flex; gap:8px; align-items:flex-start; }
+.linkbox .u { flex:1; min-width:0; background:var(--input-bg); border:1px solid var(--input-bd); border-radius:8px; padding:12px 13px; font:400 13px/1.5 'IBM Plex Mono',monospace; color:var(--ink-soft); word-break:break-all; }
+.prose { background:var(--input-bg); border:1px dashed var(--input-bd); border-radius:8px; padding:12px 14px; margin:8px 0; font:400 15px/1.7 'Spectral',serif; color:var(--ink); }
+mark { background:color-mix(in srgb, var(--accent) 16%, transparent); border-bottom:1px solid color-mix(in srgb, var(--accent) 42%, transparent); color:var(--ink); padding:0 1px; border-radius:2px; }
+.keyrow { margin:14px 0; }
+.keyrow .lab { display:block; font:400 12px/1.4 'Public Sans',sans-serif; color:var(--dim); margin-bottom:5px; }
+.keyval { word-break:break-all; font:400 13px/1.5 'IBM Plex Mono',monospace; background:var(--input-bg); border:1px solid var(--input-bd); border-radius:7px; padding:9px 11px; }
+.keyval.pub { color:var(--accent); } .keyval.sec { color:var(--error); } .keyval.read { color:var(--ok); }
+.relay-line { font:400 13px/1.6 'IBM Plex Mono',monospace; }
+.note { background:color-mix(in srgb, var(--accent) 7%, transparent); border:1px solid color-mix(in srgb, var(--accent) 22%, transparent); border-radius:10px; padding:14px 16px; font:400 13px/1.55 'Public Sans',sans-serif; color:var(--ink-soft); margin-top:20px; }
+.note strong { color:var(--accent); font-weight:600; }
+.foot { margin-top:20px; padding-top:16px; border-top:1px solid var(--rule); font:400 12px/1.6 'Public Sans',sans-serif; color:var(--dim); text-align:center; }
+.foot strong { color:var(--accent); font-weight:600; }
+
+/* save / load board actions (in the board-head) */
+.board-actions { display:flex; gap:8px; align-items:center; }
+.board-actions .n { margin-right:4px; }
+.board-actions .btn.sm { padding:7px 11px; }
+
+/* modal: save / load a board via its seed-phrase paragraph */
+.modal-overlay { position:fixed; inset:0; z-index:50; display:flex; align-items:flex-start; justify-content:center; padding:6vh 18px 40px; background:rgba(20,18,14,.55); backdrop-filter:blur(3px); overflow-y:auto; }
+body[data-style="midnight"] .modal-overlay { background:rgba(0,0,0,.66); }
+.modal { position:relative; width:100%; max-width:560px; background:var(--card); color:var(--ink); border:1px solid var(--card-bd); border-radius:14px; box-shadow:0 40px 90px -40px rgba(20,18,14,.7); padding:30px 32px 28px; }
+.modal-x { position:absolute; top:14px; right:16px; background:none; border:none; color:var(--dim); font-size:24px; line-height:1; cursor:pointer; padding:2px 6px; }
+.modal-x:hover { color:var(--accent); }
+.modal-title { margin:0 0 10px; font:600 18px/1.2 'Public Sans',sans-serif; color:var(--ink); }
+.modal-lead { margin:0 0 16px; font:400 14px/1.6 'Public Sans',sans-serif; color:var(--ink-soft); }
+.modal-lead strong { color:var(--accent); font-weight:600; }
+.seed-prose { background:var(--input-bg); border:1px dashed color-mix(in srgb, var(--error) 45%, var(--input-bd)); border-radius:10px; padding:16px 18px; font:400 16px/1.72 'Spectral',serif; color:var(--ink); white-space:pre-wrap; word-break:break-word; }
+.modal-actions { display:flex; align-items:center; gap:10px; margin-top:16px; flex-wrap:wrap; }
+.modal-actions .muted { margin-left:auto; font:400 12px/1.3 'IBM Plex Mono',monospace; }
+.modal-foot { margin:16px 0 0; font:400 12px/1.55 'Public Sans',sans-serif; }
+#c-seed-input { width:100%; min-height:120px; }
+
+/* live preview */
+.pv-caption { margin-top:14px; font:400 12px/1.55 'Public Sans',sans-serif; color:var(--dim); }
+.share { margin-bottom:8px; }
+.share label:first-of-type { margin-top:0; }
+.share-btn { margin-top:2px; padding:10px 16px; font-size:12.5px; display:inline-flex; align-items:center; gap:8px; }
+.share-btn svg { width:14px; height:14px; }
+.linkbox.private .u { border-color:color-mix(in srgb, var(--error) 45%, transparent); }
+.lab.warn { color:var(--error); }
+.preview { padding:26px 28px; transition:background .3s ease, border-color .3s ease; }
+.preview[data-style="letterpress"] { background:#f6f3ec; border:1px solid #d8d2c4; color:#26241d; border-radius:3px; box-shadow:0 20px 50px -30px rgba(38,36,29,.5); }
+.preview[data-style="midnight"]    { background:#0d0d10; border:1px solid #232228; color:#e8e4da; border-radius:6px; box-shadow:0 20px 50px -30px rgba(0,0,0,.7); }
+.preview[data-style="terminal"]    { background:#f0eee8; border:1px solid #17161a; color:#17161a; border-radius:0; box-shadow:0 20px 50px -34px rgba(23,22,26,.5); }
+/* subject (shown only when one is set) */
+.pv-subject { font:500 10px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-transform:uppercase; margin-bottom:14px; }
+.preview[data-style="letterpress"] .pv-subject { color:#9a5b3f; }
+.preview[data-style="midnight"]    .pv-subject { color:#c9a25f; }
+.preview[data-style="terminal"]    .pv-subject { color:#274bd6; letter-spacing:.04em; }
+
+/* realtime-generated prose (mirrors the viewer's bulletin prose) */
+.pv-prose { margin:0 0 4px; }
+.preview[data-style="letterpress"] .pv-prose { font:italic 300 17px/1.7 'Spectral',serif; color:#413d33; }
+.preview[data-style="midnight"]    .pv-prose { font:300 18px/1.65 'Newsreader',serif; color:#cfcabf; }
+.preview[data-style="terminal"]    .pv-prose { font:400 13px/1.7 'IBM Plex Mono',monospace; color:#3a382f; }
+/* payload words read as plain prose by default; the "highlight payload words"
+   setting (body[data-hl="on"]) emphasizes them per reading style */
+.pv-prose .pw { font:inherit; color:inherit; border-bottom:none; }
+body[data-hl="on"] .preview[data-style="letterpress"] .pv-prose .pw { font-weight:600; font-style:normal; color:#26241d; }
+body[data-hl="on"] .preview[data-style="midnight"]    .pv-prose .pw { font-weight:500; color:#f4efe4; }
+body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weight:600; color:#17161a; border-bottom:1px dotted #9a937f; }
+.pv-attr { margin-bottom:16px; }
+.pv-attr:empty { margin-bottom:16px; }
+.preview[data-style="letterpress"] .pv-attr { text-align:right; font:italic 400 13px/1.4 'Spectral',serif; color:#8a8573; }
+.preview[data-style="midnight"]    .pv-attr { text-align:right; font:italic 300 14px/1.4 'Newsreader',serif; color:#6f6d75; }
+.preview[data-style="terminal"]    .pv-attr { font:400 11px/1.4 'IBM Plex Mono',monospace; color:#8f8a79; }
+.pv-decoded { }
+.preview[data-style="letterpress"] .pv-decoded { padding-left:16px; border-left:2px solid #9a5b3f; }
+.preview[data-style="midnight"]    .pv-decoded { padding-left:16px; border-left:2px solid #c9a25f; }
+.preview[data-style="terminal"]    .pv-decoded { background:#17161a; padding:12px 14px; }
+.pv-dec-label { font:600 9px/1 'IBM Plex Mono',monospace; letter-spacing:.2em; text-transform:uppercase; margin-bottom:7px; }
+.preview[data-style="letterpress"] .pv-dec-label { color:#9a5b3f; }
+.preview[data-style="midnight"]    .pv-dec-label { color:#c9a25f; }
+.preview[data-style="terminal"]    .pv-dec-label { color:#7fd6a0; letter-spacing:.16em; }
+.pv-dec-text { white-space:pre-wrap; }
+.preview[data-style="letterpress"] .pv-dec-text { font:400 17px/1.55 'Spectral',serif; color:#26241d; }
+.preview[data-style="midnight"]    .pv-dec-text { font:400 18px/1.55 'Newsreader',serif; color:#f4efe4; }
+.preview[data-style="terminal"]    .pv-dec-text { font:400 13px/1.6 'IBM Plex Mono',monospace; color:#f0eee8; }
 </style>
 </head>
-<body>
-<div class="container">
-  <header class="top">
-    <h1>Create a Bulletin</h1>
+<body data-style="letterpress" data-hl="off">
+<div class="wrap">
+  <div class="masthead">
+    <span class="title">Glossia · Compose</span>
     <span class="sub">encrypt a message, encode it as prose, publish it to a board</span>
-    <span class="home"><a href="./bulletin.html">← read a board</a> &nbsp;·&nbsp; <a href="./index.html">demo</a></span>
-  </header>
-
-  <form id="c-form" autocomplete="on" onsubmit="return false;">
-  <div class="card">
-    <input type="text" id="c-username" autocomplete="username" value="glossia bulletin" class="hidden" tabindex="-1" aria-hidden="true">
-
-    <label>Message</label>
-    <textarea id="c-msg" placeholder="Your message…">The pen is mightier than the sword.</textarea>
-
-    <div class="row">
-      <div style="flex:0 0 auto">
-        <label>Prose language</label>
-        <select id="c-lang">
-          <option value="english">English</option>
-          <option value="latin">Latin</option>
-          <option value="czech">Czech</option>
-        </select>
-      </div>
-      <div style="flex:0 0 auto">
-        <label>Subject <span class="muted">(optional, public)</span></label>
-        <input type="text" id="c-subject" placeholder="label" spellcheck="false" style="width:12rem">
-      </div>
-    </div>
-
-    <label>Board identity (the signing key)</label>
-    <div class="row">
-      <select id="c-id-source" style="flex:0 0 auto; width:11rem">
-        <option value="random">Random (new board)</option>
-        <option value="passphrase">From passphrase</option>
-        <option value="nsec">Enter nsec</option>
-      </select>
-      <input type="password" id="c-id-value" autocomplete="new-password" placeholder="passphrase — or let your browser suggest one" spellcheck="false">
-      <button type="button" class="btn sm" data-reveal="c-id-value" title="Show / hide">👁</button>
-      <button type="button" class="btn sm hidden" id="c-id-gen" title="Generate a new random key">🎲</button>
-    </div>
-    <div class="entropy" id="c-entropy"></div>
-    <p class="hint" id="c-id-hint">A fresh random key — after publishing, save the <strong>nsec</strong> to post again.</p>
-
-    <label class="check"><input type="checkbox" id="c-encrypt" checked> Encrypt the message <span class="muted">(uncheck to publish a public, signed-but-unencrypted bulletin)</span></label>
-
-    <label>Relays</label>
-    <input type="text" id="c-relays" spellcheck="false">
-
-    <div class="row" style="margin-top:.8rem">
-      <button type="button" class="btn" id="c-preview" style="flex:0 0 auto" disabled>Preview</button>
-      <button type="button" class="btn" id="c-publish" style="flex:0 0 auto" disabled>Publish →</button>
-      <span class="hint" id="c-status" style="flex:1"></span>
-    </div>
-    <div class="err" id="c-err"></div>
-  </div>
-  </form>
-
-  <div class="card hidden" id="c-out-card">
-    <label>What gets published (Glossia prose)</label>
-    <div class="prose" id="c-out-prose"></div>
-
-    <label>Keys to share</label>
-    <div class="keyrow">
-      <span class="lab">Read link — anyone can open &amp; read the prose</span>
-      <div class="row" style="margin:.2rem 0">
-        <button type="button" class="btn sm" id="c-copy-link">copy read link</button>
-        <a class="btn sm" id="c-open-link" href="#" target="_blank" rel="noopener" style="text-decoration:none">open ↗</a>
-      </div>
-    </div>
-    <div class="keyrow" id="c-readkey-row">
-      <span class="lab">Read key — share with readers to <strong>decrypt</strong> (cannot post)</span>
-      <div class="keyval read" id="c-out-nread"></div>
-      <button type="button" class="btn sm" id="c-copy-nread" style="margin-top:.3rem">copy read key</button>
-    </div>
-    <div class="keyrow">
-      <span class="lab" style="color:var(--error)">nsec — <strong>keep private</strong>; grants posting AND decrypting</span>
-      <div class="keyval sec" id="c-out-nsec"></div>
-      <button type="button" class="btn sm" id="c-copy-nsec" style="margin-top:.3rem">copy nsec</button>
-    </div>
-    <div class="keyrow">
-      <span class="lab">npub — the board's public address</span>
-      <div class="keyval pub" id="c-out-npub"></div>
-    </div>
-    <div id="c-relay-results"></div>
+    <span class="home"><a href="./bulletin.html">read a board →</a> &nbsp;·&nbsp; <a href="./index.html">demo</a></span>
   </div>
 
-  <div class="note">
-    <strong>How it works.</strong> A board lives at an <span class="mono">npub</span> derived from its signing key.
-    The message is encrypted with a key derived from that same signing key, encoded into Glossia prose, signed, and
-    published to public nostr relays. <strong>nsec</strong> → post and decrypt; <strong>read key</strong> → decrypt only;
-    <strong>npub</strong> → read the prose but not decrypt. You never set a separate password.
-  </div>
+  <div class="layout">
+    <div class="col-form">
+      <form id="c-form" autocomplete="on" onsubmit="return false;">
+      <div class="board">
+        <div class="board-head">
+          <a class="k board-new" id="c-new" href="./compose.html" title="Start a fresh bulletin — a brand-new board"><span class="plus">+</span> New bulletin</a>
+          <div class="board-actions">
+            <span class="n" id="c-head-npub">not yet published</span>
+            <button type="button" class="btn sm" id="c-save" title="Show this board's private key as a Glossia seed phrase to save">💾 Save</button>
+            <button type="button" class="btn sm" id="c-load" title="Restore a board from a saved Glossia seed phrase">📂 Load</button>
+          </div>
+        </div>
+        <input type="text" id="c-username" autocomplete="username" value="glossia bulletin" class="hidden" tabindex="-1" aria-hidden="true">
 
-  <footer class="hint" style="text-align:center; margin-top:2rem; border-top:1px solid var(--border); padding-top:1rem">
-    Glossia is a <strong>readable encoding, not steganography</strong>. Encrypted bulletins use authenticated AES-256-GCM,
-    so a wrong key or tampering fails cleanly. A random board key has full entropy; a passphrase-derived board is only as
-    strong as the passphrase (generated ones target ≥128 bits).
-  </footer>
+        <label>Message</label>
+        <textarea id="c-msg" spellcheck="false" placeholder="Your message…">The pen is mightier than the sword.</textarea>
+
+        <!-- on narrow screens the live preview is moved here, directly below the message -->
+        <div id="c-preview-slot"></div>
+
+        <details class="settings" id="c-settings">
+          <summary>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+            <span>Settings</span>
+          </summary>
+
+          <label>Passphrase <span class="muted">(optional — overrides the board key)</span></label>
+          <div class="row">
+            <input type="password" id="c-id-value" autocomplete="new-password" placeholder="defaults to this board's key (hash of the nwrite) — type to override" spellcheck="false">
+            <button type="button" class="btn sm" data-reveal="c-id-value" title="Show / hide">👁</button>
+            <button type="button" class="btn sm" id="c-id-gen" title="Generate a strong passphrase">🎲</button>
+          </div>
+          <div class="entropy" id="c-entropy"></div>
+
+          <label>Prose language</label>
+          <select id="c-lang">
+            <option value="english">English</option>
+            <option value="latin">Latin</option>
+            <option value="czech">Czech</option>
+          </select>
+
+          <label>Subject <span class="muted">(optional, public)</span></label>
+          <input type="text" id="c-subject" placeholder="label" spellcheck="false">
+
+          <label>Reading style <span class="muted">(saved in the shareable link)</span></label>
+          <input type="hidden" id="c-style" value="letterpress">
+          <div class="tiles" role="group" aria-label="Reading style">
+            <button type="button" class="tile" data-set-style="letterpress"><span class="mini letterpress">Aa</span>Letterpress</button>
+            <button type="button" class="tile" data-set-style="midnight"><span class="mini midnight">Aa</span>Midnight</button>
+            <button type="button" class="tile" data-set-style="terminal"><span class="mini terminal">A&gt;</span>Terminal</button>
+          </div>
+
+          <label class="check"><input type="checkbox" id="c-hl"> Highlight payload words <span class="muted">(saved in the shareable link)</span></label>
+
+          <label>Relays</label>
+          <input type="text" id="c-relays" spellcheck="false">
+        </details>
+      </div>
+      </form>
+
+      <div class="board" id="c-share-card">
+        <!-- Keep this — for you -->
+        <div class="share keep">
+          <label>Keep this <span class="muted">· for you</span></label>
+          <p class="hint" style="margin:0 0 12px">
+            <strong>Bookmark this page.</strong> Its address is your author link — the only way back in to publish more.
+            Losing it means you can't post to this board again. For a durable backup, save the seed phrase.
+          </p>
+          <button type="button" class="btn sm" id="c-save-keep">💾 Save bulletin</button>
+        </div>
+
+        <!-- Share these — for others -->
+        <div class="share" style="margin-top:24px">
+          <label>Share these <span class="muted">· for others</span></label>
+
+          <label style="margin-top:14px">Reader link <span class="lab warn">· includes the decryption key — readers unlock instantly (avoid pasting where the link is logged)</span></label>
+          <button type="button" class="btn sm share-btn" id="c-btn-reader"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>Reader link</button>
+
+          <label>Public link <span class="muted">· read the encoded prose only (npub)</span></label>
+          <button type="button" class="btn sm share-btn" id="c-btn-public"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.6" y1="10.5" x2="15.4" y2="6.5"/><line x1="8.6" y1="13.5" x2="15.4" y2="17.5"/></svg>Share</button>
+        </div>
+
+        <div id="c-relay-results"></div>
+
+        <!-- Advanced — raw keys & the author link, for power users -->
+        <details class="settings" id="c-advanced">
+          <summary>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+            <span>Advanced — keys &amp; author link</span>
+          </summary>
+
+          <label>Author link <span class="lab warn">· includes the nwrite — full access, keep private</span></label>
+          <div class="linkbox private">
+            <div class="u" id="c-link-nsec">glossia.io/compose.html#nwrite…</div>
+            <button type="button" class="btn sm" data-copy="nsec">copy</button>
+            <a class="btn sm" id="c-open-nsec" href="#" target="_blank" rel="noopener">open ↗</a>
+          </div>
+
+          <div class="keyrow" id="c-readkey-row">
+            <span class="lab">Read key <span class="muted">— decrypt only, cannot post</span></span>
+            <div class="keyval read" id="c-out-nread"></div>
+            <button type="button" class="btn sm" id="c-copy-nread" style="margin-top:6px">copy read key</button>
+          </div>
+          <div class="keyrow hidden" id="c-pass-note">
+            <span class="lab">Readers decrypt with the <strong>passphrase</strong> you set — share it with them separately.</span>
+          </div>
+          <div class="keyrow">
+            <span class="lab" style="color:var(--error)">nwrite <span class="muted">— keep private; posting AND decrypting</span></span>
+            <div class="keyval sec" id="c-out-nsec"></div>
+            <button type="button" class="btn sm" id="c-copy-nsec" style="margin-top:6px">copy nwrite</button>
+          </div>
+          <div class="keyrow">
+            <span class="lab">npub <span class="muted">— the board's public address</span></span>
+            <div class="keyval pub" id="c-out-npub"></div>
+          </div>
+        </details>
+      </div>
+
+      <div class="note">
+        <strong>How it works.</strong> Every board has three things: a <strong>public address</strong> anyone can open,
+        an <strong>author link</strong> that lets you publish, and a <strong>read key</strong> that lets readers decrypt.
+        All three come from one secret, so there's no separate password to set. Every message is encrypted and encoded into
+        Glossia prose before it's published — share a <strong>reader link</strong> (or the read key) for read-only access,
+        and keep your author link to keep posting. Prefer a shared secret? Set a passphrase, and readers decrypt with that
+        instead of the read key.
+      </div>
+
+      <div class="foot">
+        Glossia is a <strong>readable encoding, not steganography</strong>. Encrypted bulletins use authenticated AES-256-GCM,
+        so a wrong key or tampering fails cleanly. The board's signing key has full entropy; a custom passphrase is only as
+        strong as you make it (generated ones target ≥128 bits).
+      </div>
+    </div>
+
+    <aside class="col-preview">
+      <div id="c-live-preview">
+        <div class="preview" id="c-preview-card" data-style="letterpress">
+          <div class="pv-subject hidden" id="c-pv-subject"></div>
+          <p class="pv-prose" id="c-pv-prose">Your prose will appear here as you type…</p>
+          <div class="pv-attr" id="c-pv-attr"></div>
+          <div class="pv-decoded">
+            <div class="pv-dec-label">decoded</div>
+            <div class="pv-dec-text" id="c-pv-msg">The pen is mightier than the sword.</div>
+          </div>
+        </div>
+        <button type="button" class="btn block" id="c-publish" disabled>Encode &amp; publish</button>
+        <div class="hint" id="c-status" style="margin-top:10px"></div>
+        <div class="err" id="c-err"></div>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<!-- Save / Load a board via its seed-phrase paragraph -->
+<div class="modal-overlay hidden" id="c-modal">
+  <div class="modal" role="dialog" aria-modal="true">
+    <button type="button" class="modal-x" id="c-modal-close" aria-label="Close">&times;</button>
+
+    <!-- SAVE: show the board's private key as a Glossia seed phrase -->
+    <div id="c-save-view">
+      <h2 class="modal-title">Save this board</h2>
+      <p class="modal-lead">This is your board's <strong>seed phrase</strong> — keep it secret, keep it safe! With this,
+        anyone can post updates to this board, and it's the only way back in if you lose the link.</p>
+      <div class="seed-prose" id="c-seed-prose"></div>
+      <div class="modal-actions">
+        <button type="button" class="btn sm" id="c-seed-copy">Copy</button>
+        <button type="button" class="btn sm" id="c-seed-download">Download .txt</button>
+        <span class="muted" id="c-seed-npub"></span>
+      </div>
+      <p class="modal-foot muted" id="c-seed-note">The key never leaves your device. The seed phrase carries a checksum,
+        so a mistyped word is caught when you load it back.</p>
+    </div>
+
+    <!-- LOAD: restore a board from a saved seed phrase -->
+    <div id="c-load-view" class="hidden">
+      <h2 class="modal-title">Load a saved board</h2>
+      <p class="modal-lead">Paste a Glossia seed phrase you saved earlier to restore its board. You'll be able to
+        post to and decrypt it again.</p>
+      <textarea id="c-seed-input" spellcheck="false" placeholder="Paste your seed phrase paragraph…"></textarea>
+      <div class="err" id="c-load-err"></div>
+      <div class="modal-actions">
+        <button type="button" class="btn" id="c-load-go">Restore board</button>
+      </div>
+    </div>
+  </div>
 </div>
 
 <script type="module">
-import { init, encodeMessage } from './glossia-msg.js';
-import {
-  deriveIdentity, identityFromNsec, identityFromSecHex, generateIdentity,
-  buildEvent, publishEvent, DEFAULT_RELAYS,
-} from './glossia-nostr.js';
+import { init, encodeMessage, encodeSeedPhrase, decodeSeedPhrase, detectLang } from './glossia-msg.js';
+import { generateIdentity, identityFromNsec, identityFromNwrite, buildEvent, publishEvent,
+         seedPayloadHex, identityFromSeedPayloadHex, SEED_PAYLOAD_LEN, DEFAULT_RELAYS } from './glossia-nostr.js';
 import { random_words } from './glossia.js';
 
 const $ = (id) => document.getElementById(id);
@@ -189,11 +420,105 @@ function parseRelays(s) { return s.split(/[\s,]+/).map(x => x.trim()).filter(x =
 function escapeHtml(s) { return s.replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
 function renderProse(prose, words) {
   const set = new Set((words || []).map(w => w.toLowerCase()));
-  return escapeHtml(prose).replace(/[A-Za-zÀ-ÿ]+/g, (w) => set.has(w.toLowerCase()) ? `<mark>${w}</mark>` : w);
+  return escapeHtml(prose).replace(/[A-Za-zÀ-ÿ]+/g, (w) => set.has(w.toLowerCase()) ? `<b class="pw">${w}</b>` : w);
 }
-function readLink(npub) { return location.href.replace(/[^/]*$/, '') + 'bulletin.html#' + npub; }
+function splitProse(text) {
+  text = (text || '').trim();
+  const di = text.lastIndexOf(' — ');
+  if (di > 0) return { body: text.slice(0, di).trim(), attr: text.slice(di + 3).trim() };
+  return { body: text, attr: '' };
+}
+function baseUrl() { return location.href.replace(/[^/]*$/, ''); }
+// "Highlight payload words" is a reading preference carried in the link (like the
+// reading style); off by default, so it only appears in the hash when on.
+function hlOn() { return document.body.dataset.hl === 'on'; }
+function hlParam() { return hlOn() ? '&hl=1' : ''; }
+function readLink(npub, style) {
+  const s = style || $('c-style').value || 'letterpress';
+  return baseUrl() + 'bulletin.html#' + npub + '&style=' + s + hlParam();
+}
+// Author link: carries the nwrite (the board's write key) so the same board can
+// be reused to publish more bulletins. Private — grants posting AND decrypting.
+function authorLink(nwrite, style) {
+  const s = style || $('c-style').value || 'letterpress';
+  return baseUrl() + 'compose.html#' + nwrite + '&style=' + s + hlParam();
+}
 
-const ENGINE_BTNS = ['c-preview', 'c-publish', 'c-id-gen'];
+// The board's signing identity: a fresh random key for a new board, or the write
+// key (nwrite) loaded from an author link. The message is ALWAYS encrypted — the
+// credential is the board's own key (a hash of the nwrite) by default, or a passphrase.
+let nsecIdentity = null, randomIdentity = null;
+function boardIdentity() {
+  if (nsecIdentity) return nsecIdentity;
+  if (!randomIdentity) randomIdentity = generateIdentity();
+  return randomIdentity;
+}
+// Adopt a saved/loaded board as the signing identity (from an author link or a
+// seed phrase).
+function applyLoadedIdentity(id) {
+  nsecIdentity = id;
+}
+// The passphrase field is left EMPTY by default — the placeholder explains that
+// encryption then falls back to the board's own key. Any non-empty value is a
+// custom passphrase override. (We never write the read key into the field: it is
+// the board's secret, not something to surface in an input.)
+function overridePass() {
+  return $('c-id-value').value.trim();
+}
+
+// The reader's decryption credential to embed in a key link: the board's read
+// key (nread) by default, or the custom passphrase if one is set.
+function shareCred() { return overridePass() || boardIdentity().nread; }
+function readerNpubLink() { return readLink(boardIdentity().npub); }
+function readerKeyLink() { return readLink(boardIdentity().npub) + '&key=' + encodeURIComponent(shareCred()); }
+// The author link (also the bookmarkable page URL) carries the nwrite and, when a
+// custom passphrase is set, that key too — so reopening restores the board fully.
+function shareAuthorLink() {
+  const k = overridePass();
+  return authorLink(boardIdentity().nwrite) + (k ? '&key=' + encodeURIComponent(k) : '');
+}
+const strip = (u) => u.replace(/^https?:\/\//, '');
+
+// The three shareable links live under the preview and update as the board,
+// reading style, or passphrase change.
+function updateLinks() {
+  // reader/public links are computed on click by their buttons; only the author
+  // link (in Advanced) is shown as text.
+  const authL = shareAuthorLink();
+  $('c-link-nsec').textContent = strip(authL); $('c-open-nsec').href = authL;
+  // raw keys in the Advanced disclosure, kept in sync with the current board
+  $('c-out-npub').textContent = boardIdentity().npub;
+  $('c-out-nsec').textContent = boardIdentity().nwrite;
+  $('c-out-nread').textContent = boardIdentity().nread;
+  // the read key (nread) only decrypts the default board-key form; when a
+  // passphrase is set, readers use it instead — keep this in sync live
+  const custom = !!overridePass();
+  $('c-readkey-row').classList.toggle('hidden', custom);
+  $('c-pass-note').classList.toggle('hidden', !custom);
+}
+document.querySelectorAll('[data-copy]').forEach(b => b.addEventListener('click', () => {
+  const link = b.dataset.copy === 'npub' ? readerNpubLink() : b.dataset.copy === 'key' ? readerKeyLink() : shareAuthorLink();
+  navigator.clipboard.writeText(link).catch(() => {});
+}));
+
+// "Share these" buttons compute their URL on click (no link text shown):
+// the reader button copies the key-bearing link; the public button opens the
+// native share sheet where available, else copies.
+function flashBtn(btn, msg) {
+  if (!btn.dataset.html) btn.dataset.html = btn.innerHTML;   // preserve the icon markup
+  btn.textContent = msg;
+  setTimeout(() => { btn.innerHTML = btn.dataset.html; }, 1400);
+}
+$('c-btn-reader').addEventListener('click', () => {
+  navigator.clipboard.writeText(readerKeyLink()).then(() => flashBtn($('c-btn-reader'), 'Copied ✓')).catch(() => {});
+});
+$('c-btn-public').addEventListener('click', async () => {
+  const url = readerNpubLink();
+  if (navigator.share) { try { await navigator.share({ title: 'Glossia bulletin board', url }); } catch { /* share cancelled */ } return; }
+  navigator.clipboard.writeText(url).then(() => flashBtn($('c-btn-public'), 'Copied ✓')).catch(() => {});
+});
+
+const ENGINE_BTNS = ['c-publish', 'c-id-gen'];
 function setEngine(state, msg) {
   const disabled = state !== 'ready';
   ENGINE_BTNS.forEach(id => { $(id).disabled = disabled; });
@@ -203,34 +528,93 @@ function setEngine(state, msg) {
 }
 setEngine('loading');
 (async () => {
-  try { await init(); ready = true; setEngine('ready'); }
+  try { await init(); ready = true; setEngine('ready'); schedulePreview(); }
   catch (e) { setEngine('error', 'Failed to load Glossia engine: ' + (e.message || e)); }
 })();
 
-// ── identity source ───────────────────────────────────────────────────
-let randomIdentity = null;   // cached so repeated preview/publish keep one board
-function syncIdSource() {
-  const src = $('c-id-source').value;
-  $('c-id-gen').classList.toggle('hidden', src !== 'random');
-  $('c-id-value').classList.toggle('hidden', src === 'random');
-  $('c-entropy').classList.toggle('hidden', src !== 'passphrase');
-  const val = $('c-id-value');
-  if (src === 'nsec') { val.type = 'text'; val.placeholder = 'nsec1… or 64-char hex'; val.autocomplete = 'off'; }
-  else { val.placeholder = 'passphrase — or let your browser suggest one'; val.autocomplete = 'new-password'; }
-  $('c-id-hint').innerHTML = src === 'random'
-    ? 'A fresh random key — after publishing, save the <strong>nsec</strong> to post again.'
-    : src === 'passphrase'
-      ? 'Deterministic: the same passphrase always reaches the same board. Sharing the passphrase grants full access.'
-      : 'Bring an existing nostr key to keep posting to its board.';
+// ── reading style: tiles drive a hidden input + the live preview ───────
+const STYLE_NAMES = { letterpress: 'Letterpress', midnight: 'Midnight', terminal: 'Terminal' };
+function applyStyle(style) {
+  if (!STYLE_NAMES[style]) style = 'letterpress';
+  $('c-style').value = style;
+  document.body.dataset.style = style;        // theme the whole page
+  $('c-preview-card').dataset.style = style;  // and the live-preview box
+  document.querySelectorAll('[data-set-style]').forEach(b =>
+    b.setAttribute('aria-pressed', String(b.dataset.setStyle === style)));
+  $('c-style').dispatchEvent(new Event('change'));   // refresh the open link if published
 }
-$('c-id-source').addEventListener('change', syncIdSource);
-$('c-id-gen').addEventListener('click', () => { randomIdentity = generateIdentity(); $('c-status').textContent = 'New random board key ready.'; });
 
-// passphrase generator + entropy (only for the passphrase source)
+// ── highlight payload words (off by default) ──────────────────────────
+// Pure CSS toggle: body[data-hl] gates the .pw emphasis, so no re-render is
+// needed. Persisted in the shareable link (updateLinks + writeHash).
+function applyHl(on, { persist = true } = {}) {
+  document.body.dataset.hl = on ? 'on' : 'off';
+  $('c-hl').checked = on;
+  if (persist) { updateLinks(); writeHash(); }
+}
+$('c-hl').addEventListener('change', () => applyHl($('c-hl').checked));
+document.querySelectorAll('[data-set-style]').forEach(b =>
+  b.addEventListener('click', () => applyStyle(b.dataset.setStyle)));
+
+// ── live preview: realtime prose + decoded, exactly as a reader sees it ─
+function syncMeta() {
+  $('c-pv-msg').textContent = $('c-msg').value.trim() || 'Your decrypted message appears here.';
+  const subj = $('c-subject').value.trim();   // only show the subject when one is set
+  $('c-pv-subject').textContent = subj;
+  $('c-pv-subject').classList.toggle('hidden', !subj);
+}
+// The message is always encrypted; keep the publish button label in sync.
+function updateMode() {
+  $('c-publish').textContent = 'Encode & publish';
+}
+// Encoding runs the engine (and PBKDF2 when a passphrase is set), so debounce
+// and drop stale runs. The board key is cached so retyping the message alone
+// doesn't re-derive it.
+let pvTimer = null, pvToken = 0;
+async function regenPreview() {
+  const my = ++pvToken;
+  syncMeta();
+  updateMode();
+  const msg = $('c-msg').value;
+  if (!msg.trim()) { $('c-pv-prose').textContent = 'Your prose will appear here as you type…'; $('c-pv-attr').textContent = ''; return; }
+  if (!ready) { $('c-pv-prose').textContent = 'Loading the Glossia engine…'; return; }
+  try {
+    const cred = overridePass() || boardIdentity().readKey;   // default = board key; override = passphrase
+    if (my !== pvToken) return;
+    const enc = await encodeMessage(msg, cred, $('c-lang').value);
+    if (my !== pvToken) return;
+    const { body, attr } = splitProse(enc.prose);
+    $('c-pv-prose').innerHTML = renderProse(body, enc.payloadWords);
+    $('c-pv-attr').textContent = attr ? '— ' + attr : '';
+  } catch (e) {
+    if (my !== pvToken) return;
+    $('c-pv-prose').textContent = 'Could not generate prose — ' + (e.message || e);
+    $('c-pv-attr').textContent = '';
+  }
+}
+function schedulePreview() { clearTimeout(pvTimer); pvTimer = setTimeout(regenPreview, 400); }
+$('c-msg').addEventListener('input', () => { syncMeta(); schedulePreview(); });
+$('c-subject').addEventListener('input', syncMeta);
+$('c-lang').addEventListener('change', schedulePreview);
+
+// ── board passphrase ──────────────────────────────────────────────────
+// The board's signing key is derived from this passphrase, so the same
+// passphrase always reaches the same board. The 🎲 fills a strong one.
 function genPassphrase() {
   try { const w = JSON.parse(random_words(9, 'latin', 'default', BigInt(Date.now()))); return Array.isArray(w) ? w.join(' ') : ''; }
   catch { return ''; }
 }
+$('c-id-gen').addEventListener('click', () => {
+  const p = genPassphrase();
+  if (!p) { $('c-status').textContent = 'Could not generate a passphrase — is the engine ready?'; return; }
+  $('c-id-value').value = p;
+  showEntropy(p);
+  updateMode();
+  updateLinks();
+  writeHash();
+  schedulePreview();
+  $('c-status').textContent = 'Strong passphrase generated — save it to post again.';
+});
 function estimateBits(p) {
   p = p.trim(); if (!p) return 0;
   const words = p.split(/\s+/);
@@ -240,12 +624,12 @@ function estimateBits(p) {
   return Math.round(p.length * Math.log2(Math.max(cs, 2)));
 }
 function showEntropy(p) {
-  const bits = $('c-id-source').value === 'passphrase' ? estimateBits(p) : 0;
+  const bits = estimateBits(p);
   const el = $('c-entropy');
   el.textContent = bits ? `≈ ${bits}-bit passphrase` : '';
   el.classList.toggle('strong', bits >= 80);
 }
-$('c-id-value').addEventListener('input', (e) => showEntropy(e.target.value));
+$('c-id-value').addEventListener('input', (e) => { showEntropy(e.target.value); updateMode(); updateLinks(); writeHash(); schedulePreview(); });
 
 document.querySelectorAll('[data-reveal]').forEach(btn => btn.addEventListener('click', () => {
   const inp = $(btn.dataset.reveal);
@@ -255,62 +639,24 @@ document.querySelectorAll('[data-reveal]').forEach(btn => btn.addEventListener('
 }));
 
 // ── build / preview / publish ─────────────────────────────────────────
-async function resolveIdentity() {
-  const src = $('c-id-source').value;
-  if (src === 'random') {
-    if (!randomIdentity) randomIdentity = generateIdentity();
-    return randomIdentity;
-  }
-  const v = $('c-id-value').value.trim();
-  if (src === 'passphrase') {
-    if (!v) throw new Error('Enter a passphrase.');
-    if (v.split(/\s+/).length < 2 && estimateBits(v) < 60) { /* weak but allowed */ }
-    return await deriveIdentity(v);
-  }
-  if (!v) throw new Error('Enter an nsec.');
-  return v.startsWith('nsec') ? identityFromNsec(v) : identityFromSecHex(v);
-}
-
 async function buildBulletin() {
   const msg = $('c-msg').value;
   if (!msg.trim()) throw new Error('Write a message first.');
-  const identity = await resolveIdentity();
-  const cred = $('c-encrypt').checked ? identity.readKey : null;   // key-derived encryption
+  const identity = boardIdentity();
+  const cred = overridePass() || identity.readKey;   // default = board key (hash of nwrite); override = passphrase
   const enc = await encodeMessage(msg, cred, $('c-lang').value);
   const ev = buildEvent(identity, enc.artifact, { subject: $('c-subject').value.trim() || undefined });
   return { identity, enc, ev };
 }
 
-function showBoard(identity, enc) {
-  const c = $('c-out-card');
-  c.classList.remove('hidden');
-  $('c-out-prose').innerHTML = renderProse(enc.prose, enc.payloadWords);
-  $('c-out-npub').textContent = identity.npub;
-  $('c-out-nsec').textContent = identity.nsec;
-  $('c-out-nread').textContent = identity.nread;
-  $('c-readkey-row').classList.toggle('hidden', !enc.encrypted);   // read key only matters when encrypted
-  $('c-open-link').href = readLink(identity.npub);
-  c.dataset.npub = identity.npub; c.dataset.nsec = identity.nsec; c.dataset.nread = identity.nread;
-}
-
-$('c-preview').addEventListener('click', async () => {
-  $('c-err').textContent = ''; $('c-status').textContent = '';
-  if (!ready) return;
-  try {
-    const { identity, enc } = await buildBulletin();
-    showBoard(identity, enc);
-    $('c-relay-results').innerHTML = '';
-    $('c-status').textContent = 'Preview ready — review, then Publish.';
-  } catch (e) { $('c-err').textContent = e.message || String(e); }
-});
+function shortNpub(v) { return v && v.length > 18 ? v.slice(0, 10) + '…' + v.slice(-6) : (v || ''); }
 
 $('c-publish').addEventListener('click', async () => {
   $('c-err').textContent = ''; $('c-status').textContent = '';
   if (!ready) return;
-  let identity, enc, ev;
-  try { ({ identity, enc, ev } = await buildBulletin()); }
+  let ev;
+  try { ({ ev } = await buildBulletin()); }
   catch (e) { $('c-err').textContent = e.message || String(e); return; }
-  showBoard(identity, enc);
   const relays = parseRelays($('c-relays').value);
   if (!relays.length) { $('c-err').textContent = 'Add at least one wss:// relay.'; return; }
   $('c-status').textContent = 'Publishing to ' + relays.length + ' relays…';
@@ -328,12 +674,156 @@ $('c-publish').addEventListener('click', async () => {
   finally { $('c-publish').disabled = false; }
 });
 
-function copy(id) { navigator.clipboard.writeText($('c-out-card').dataset[id] || '').catch(() => {}); }
-$('c-copy-link').addEventListener('click', () => navigator.clipboard.writeText(readLink($('c-out-card').dataset.npub || '')).catch(() => {}));
-$('c-copy-nread').addEventListener('click', () => copy('nread'));
-$('c-copy-nsec').addEventListener('click', () => copy('nsec'));
+$('c-copy-nread').addEventListener('click', () => navigator.clipboard.writeText(boardIdentity().nread).catch(() => {}));
+$('c-copy-nsec').addEventListener('click', () => navigator.clipboard.writeText(boardIdentity().nwrite).catch(() => {}));
 
-syncIdSource();
+// ── save / load a board via its seed-phrase paragraph ─────────────────
+// A board's private key (its signing key / nwrite) is rendered as readable
+// Glossia prose so it can be written down and later re-entered to restore the
+// board — the project's core idea applied to a private key.
+function showModal(view) {
+  $('c-save-view').classList.toggle('hidden', view !== 'save');
+  $('c-load-view').classList.toggle('hidden', view !== 'load');
+  $('c-modal').classList.remove('hidden');
+}
+function closeModal() { $('c-modal').classList.add('hidden'); }
+$('c-modal-close').addEventListener('click', closeModal);
+$('c-modal').addEventListener('click', (e) => { if (e.target === $('c-modal')) closeModal(); });
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !$('c-modal').classList.contains('hidden')) closeModal(); });
+
+// "+ New bulletin" resets to a fresh, unsaved board: drop the board from the URL
+// and reload, so init generates a brand-new random signing key. (The href on the
+// element is the no-JS fallback.)
+$('c-new').addEventListener('click', (e) => {
+  e.preventDefault();
+  history.replaceState(null, '', baseUrl() + 'compose.html');
+  location.reload();
+});
+
+let currentSeed = '';   // the seed phrase currently shown in the save dialog
+function openSaveDialog() {
+  if (!ready) { $('c-status').textContent = 'Engine still loading — try again in a moment.'; return; }
+  const id = boardIdentity();
+  try {
+    currentSeed = encodeSeedPhrase(seedPayloadHex(id), $('c-lang').value).prose;
+    $('c-seed-prose').textContent = currentSeed;
+  } catch (e) {
+    currentSeed = '';
+    $('c-seed-prose').textContent = 'Could not render the seed phrase — ' + (e.message || e);
+  }
+  $('c-seed-npub').textContent = shortNpub(id.npub);
+  // when a custom passphrase is set, note that it's separate from the signing key
+  $('c-seed-note').textContent = overridePass()
+    ? 'This restores the board’s signing key. Your custom passphrase is separate — keep it too, or readers can’t decrypt.'
+    : 'The key never leaves your device. The seed phrase carries a checksum, so a mistyped word is caught when you load it back.';
+  showModal('save');
+}
+$('c-save').addEventListener('click', openSaveDialog);
+$('c-save-keep').addEventListener('click', openSaveDialog);
+$('c-seed-copy').addEventListener('click', () => { if (currentSeed) navigator.clipboard.writeText(currentSeed).catch(() => {}); });
+$('c-seed-download').addEventListener('click', () => {
+  if (!currentSeed) return;
+  const blob = new Blob([currentSeed + '\n'], { type: 'text/plain' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = 'glossia-board-seed.txt';
+  a.click();
+  URL.revokeObjectURL(a.href);
+});
+
+$('c-load').addEventListener('click', () => { $('c-load-err').textContent = ''; $('c-seed-input').value = ''; showModal('load'); });
+// Decode a pasted seed phrase back into a board identity. The language is
+// unknown, so try the detected one first, then each supported language; the
+// checksum rejects a wrong-language decode, so the first that verifies wins.
+function identityFromSeed(prose) {
+  const seen = new Set();
+  for (const lang of [detectLang(prose), 'english', 'latin', 'czech']) {
+    if (seen.has(lang)) continue;
+    seen.add(lang);
+    try {
+      const { hex } = decodeSeedPhrase(prose, SEED_PAYLOAD_LEN, lang);
+      return identityFromSeedPayloadHex(hex);
+    } catch { /* try the next language */ }
+  }
+  throw new Error('Could not read that seed phrase — check the words and try again.');
+}
+$('c-load-go').addEventListener('click', () => {
+  $('c-load-err').textContent = '';
+  const text = $('c-seed-input').value.trim();
+  if (!text) { $('c-load-err').textContent = 'Paste a seed phrase first.'; return; }
+  if (!ready) { $('c-load-err').textContent = 'Engine still loading — try again in a moment.'; return; }
+  let id;
+  try { id = identityFromSeed(text); }
+  catch (e) { $('c-load-err').textContent = e.message || String(e); return; }
+  restoreBoard(id);
+  closeModal();
+  $('c-status').textContent = 'Board restored from its seed phrase — you can publish to it again.';
+});
+
+// Switch the whole page over to a restored board: adopt its identity, reset the
+// credential to that board's default, and refresh links, address bar, preview.
+function restoreBoard(id) {
+  applyLoadedIdentity(id);
+  hashKey = '';                                 // a seed carries only the signing key
+  $('c-id-value').value = '';                   // no custom passphrase → use the board key
+  showEntropy('');
+  $('c-relay-results').innerHTML = '';          // old board's publish results no longer apply
+  $('c-head-npub').textContent = shortNpub(boardIdentity().npub);
+  updateMode(); updateLinks(); writeHash(); schedulePreview();
+}
+
+// keep the share links + address bar in sync when the reading style changes
+$('c-style').addEventListener('change', () => { updateLinks(); writeHash(); });
+
+// ── the address bar IS the board: compose.html#nwrite…&style=… ─────────
+// Writing the board into the hash makes the page bookmarkable — reopening the
+// bookmark restores the same board so you can keep publishing to it. The hash
+// fragment is never sent to the server.
+function writeHash() {
+  const k = overridePass();
+  const hash = '#' + boardIdentity().nwrite + '&style=' + ($('c-style').value || 'letterpress')
+    + (k ? '&key=' + encodeURIComponent(k) : '') + hlParam();
+  if (location.hash !== hash) history.replaceState(null, '', hash);
+}
+let hashKey = '';   // a custom passphrase carried in the opened author link, if any
+function loadFromHash() {
+  const raw = location.hash.replace(/^#/, '');
+  const styleM = raw.match(/style=(letterpress|midnight|terminal)/i);
+  if (styleM) applyStyle(styleM[1].toLowerCase());
+  applyHl(/(?:^|&)hl=1(?:&|$)/i.test(raw), { persist: false });   // off unless the link says on
+  // Prefer an nwrite write key; fall back to nsec so older author links still open.
+  const wm = raw.match(/nwrite1[0-9a-z]+/i);
+  const nm = raw.match(/nsec1[0-9a-z]+/i);
+  try {
+    if (wm) applyLoadedIdentity(identityFromNwrite(wm[0]));
+    else if (nm) applyLoadedIdentity(identityFromNsec(nm[0]));
+  } catch { /* malformed write key — ignore, start a fresh board */ }
+  const keyM = raw.match(/(?:^|&)key=([^&]*)/i);
+  if (keyM && keyM[1]) { try { hashKey = decodeURIComponent(keyM[1]); } catch { hashKey = keyM[1]; } }
+}
+
+// keep the live preview under the message when the columns stack (mobile),
+// and back in the right-hand column on wider screens
+const mqStack = window.matchMedia('(max-width: 820px)');
+function placePreview() {
+  const live = $('c-live-preview');
+  if (mqStack.matches) $('c-preview-slot').appendChild(live);
+  else document.querySelector('.col-preview').appendChild(live);   // aside holds only the preview now
+}
+mqStack.addEventListener('change', placePreview);
+placePreview();
+
+loadFromHash();
+// prefill the passphrase only with a custom key carried in an author link;
+// otherwise leave it empty so encryption defaults to the board's own key
+$('c-id-value').value = hashKey || '';
+$('c-head-npub').textContent = shortNpub(boardIdentity().npub);   // show the board id up front
+syncMeta();
+updateMode();
+updateLinks();
+applyStyle($('c-style').value);   // mark the default reading-style tile selected
+writeHash();                      // pin the board in the address bar so it's bookmarkable
+schedulePreview();
 </script>
 </body>
 </html>

--- a/web/glossia-msg.js
+++ b/web/glossia-msg.js
@@ -245,6 +245,33 @@ export function detectLang(prose) {
   return 'english';
 }
 
+// ─── seed-phrase paragraph: a raw key ⇆ readable Glossia prose ────────
+// A "seed phrase" is a raw key rendered as natural-language prose whose payload
+// words carry the key's bytes — the project's core idea applied to a private
+// key. It uses the same word-preserving base-n codec as the demo's BIP39 panel,
+// so the bytes round-trip exactly (decoding filters the prose back against the
+// wordlist). Callers append a checksum to the key before encoding (see
+// glossia-nostr.js) so a mistyped word is caught on load.
+
+// hex string (any byte length) -> { prose, payloadWords, langId }.
+export function encodeSeedPhrase(hex, langId = 'english') {
+  const lang = msgLangById(langId);
+  const r = JSON.parse(wasmEncodeRawBaseN(hex, lang.language, lang.wordlist, lang.dialect, SEED));
+  if (r.error) throw new Error(r.error);
+  return { prose: (r.encoded_text || '').trim(), payloadWords: r.payload_words || [], langId: lang.id };
+}
+
+// prose paragraph + known byte length -> { hex, payloadWords, langId }. Decodes
+// in the given language, or the one auto-detected from the prose.
+export function decodeSeedPhrase(prose, byteCount, langId) {
+  const text = (prose || '').trim();
+  if (!text) throw new Error('empty seed phrase');
+  const lang = msgLangById(langId || detectLang(text));
+  const r = JSON.parse(wasmDecodeRawBaseN(text, lang.language, lang.wordlist, byteCount));
+  if (r.error) throw new Error(r.error);
+  return { hex: r.decoded_hex || '', payloadWords: r.payload_words || [], langId: lang.id };
+}
+
 // artifact string + credential -> { message, prose, payloadWords, langId,
 // encrypted, authenticated }. Throws on malformed input; for the authenticated
 // form a wrong credential or tampering throws cleanly.
@@ -265,6 +292,42 @@ export async function decodeMessage(artifact, cred) {
   const { flag, data } = parseEmbedded(bytes);
   const message = TD.decode(await expand(data, flag));
   return { message, prose: text, header: null, payloadWords: r.payload_words || [], langId: lang.id, encrypted: false };
+}
+
+// Skim an artifact WITHOUT a credential: recover the prose's payload words (and
+// split the body from its attribution trailer) so a locked bulletin can still be
+// rendered with its payload words highlighted. The prose→word mapping is
+// deterministic from the wordlist and the public trailer, so no key is needed —
+// only the final AES-GCM step (in decodeMessage) requires the credential.
+// Returns { prose, body, trailer, payloadWords, encrypted }. Never throws.
+export function skimArtifact(artifact) {
+  const text = (artifact || '').trim();
+  if (!text) return { prose: text, body: text, trailer: '', payloadWords: [], encrypted: false };
+
+  // Authenticated form: "<body> — <latin attribution>".
+  const di = text.lastIndexOf(EMDASH);
+  if (di > 0) {
+    const body = text.slice(0, di).trim();
+    const trailer = text.slice(di + EMDASH.length).trim();
+    try {
+      const tR = JSON.parse(wasmDecodeRawBaseN(trailer.toLowerCase(), 'latin', 'default', AEAD_TRAILER_LEN));
+      if (tR.error) throw new Error(tR.error);
+      const tb = fromHex(tR.decoded_hex || '');
+      if (tb.length < AEAD_TRAILER_LEN) throw new Error('bad trailer');
+      const ctlen = ((tb[0] << 8) | tb[1]) & AEAD_MAX_CTLEN;
+      const lang = msgLangById(detectLang(body));
+      const bR = JSON.parse(wasmDecodeRawBaseN(body, lang.language, lang.wordlist, ctlen));
+      const words = (bR.payload_words || []).concat(tR.payload_words || []);
+      return { prose: text, body, trailer, payloadWords: words, encrypted: true };
+    } catch { return { prose: text, body, trailer, payloadWords: [], encrypted: true }; }
+  }
+
+  // Bare, unencrypted prose.
+  try {
+    const lang = msgLangById(detectLang(text));
+    const r = JSON.parse(wasmDecodeRawBaseN(text, lang.language, lang.wordlist, 0));
+    return { prose: text, body: text, trailer: '', payloadWords: r.payload_words || [], encrypted: false };
+  } catch { return { prose: text, body: text, trailer: '', payloadWords: [], encrypted: false }; }
 }
 
 // Decode the authenticated "<body> — <attribution>" form. GCM verifies the tag,

--- a/web/glossia-nostr.js
+++ b/web/glossia-nostr.js
@@ -27,7 +27,6 @@ export const GLOSSIA_KIND = 1314;
 export const DEFAULT_RELAYS = [
   'wss://relay.damus.io',
   'wss://nos.lol',
-  'wss://relay.nostr.band',
   'wss://relay.primal.net',
 ];
 
@@ -117,6 +116,15 @@ export function isNpub(s) {
   try { npubToHex(s); return true; } catch { return false; }
 }
 
+// The board "write key": the 32-byte signing key, shared as nwrite1…. It is the
+// SAME secret as the nostr nsec (byte-identical, just a different bech32 HRP), so
+// it can still be imported into any nostr client as an nsec. The nwrite badge
+// lets the write key sit alongside nread in Glossia's capability naming:
+//   nwrite → publish AND decrypt · nread → decrypt only · npub → read prose only.
+export function nwriteEncode(secHex) { return encodeBech32Entity('nwrite', secHex); }
+export function nwriteToHex(nwrite) { return decodeBech32Entity('nwrite', nwrite.trim()); }
+export function isNwrite(s) { try { nwriteToHex(s); return true; } catch { return false; } }
+
 // The board "read key": a 32-byte symmetric content key, shared as nread1….
 // Holding it grants decrypt-only access — it cannot publish, since you can't
 // recover the signing key from it.
@@ -157,16 +165,46 @@ export function identityFromSk(sk) {
     secHex: bytesToHex(sk),
     npub: npubEncode(pubHex),
     nsec: nsecEncode(bytesToHex(sk)),
+    nwrite: nwriteEncode(bytesToHex(sk)),    // same secret as nsec, Glossia-badged
     readKey,                                 // Uint8Array(32) — symmetric content key
     readKeyHex: bytesToHex(readKey),
     nread: nreadEncode(bytesToHex(readKey)),
   };
 }
 
+// ─── seed phrase: a board's signing key ⇆ a checksummed hex payload ────
+// A board can be "saved" as a Glossia seed phrase — its 32-byte signing key
+// rendered as readable prose (the prose rendering lives in glossia-msg.js). We
+// append a short checksum here so a transcription error (a mistyped word) is
+// caught on load instead of silently restoring a different board. Layout:
+//   [signing key : 32][checksum : 4]     checksum = sha256(signing key)[..4]
+const SEED_CHECK_LEN = 4;
+export const SEED_PAYLOAD_LEN = 32 + SEED_CHECK_LEN;   // decodeSeedPhrase's byte count
+
+// The checksummed seed payload (hex) for an identity — feed to encodeSeedPhrase.
+export function seedPayloadHex(identity) {
+  const sk = identity.sk;
+  const sum = sha256(sk).subarray(0, SEED_CHECK_LEN);
+  return bytesToHex(concatBytes(sk, sum));
+}
+
+// Parse a checksummed seed payload (hex) back into an identity. Throws if the
+// payload is too short or the checksum fails (a mistyped / garbled seed phrase).
+export function identityFromSeedPayloadHex(hex) {
+  const bytes = hexToBytes((hex || '').trim().toLowerCase());
+  if (bytes.length < SEED_PAYLOAD_LEN) throw new Error('seed phrase too short');
+  const sk = bytes.slice(0, 32);
+  const got = bytes.subarray(32, SEED_PAYLOAD_LEN);
+  const want = sha256(sk).subarray(0, SEED_CHECK_LEN);
+  for (let i = 0; i < SEED_CHECK_LEN; i++) if (got[i] !== want[i]) throw new Error('seed phrase checksum failed');
+  return identityFromSk(sk);
+}
+
 // Bring an existing nostr publishing key (nsec or 64-char hex) as the board's
 // identity — used by the TWO-KEY model, where the publish key is independent of
 // the decrypt passphrase.
 export function identityFromNsec(nsec) { return identityFromSk(hexToBytes(nsecToHex(nsec))); }
+export function identityFromNwrite(nwrite) { return identityFromSk(hexToBytes(nwriteToHex(nwrite))); }
 export function identityFromSecHex(secHex) {
   const clean = secHex.trim().toLowerCase();
   if (!/^[0-9a-f]{64}$/.test(clean)) throw new Error('secret key must be 64 hex chars');
@@ -197,7 +235,8 @@ export async function deriveIdentity(passphrase) {
 }
 
 // Resolve a viewer's decryption credential to the 32-byte content key:
-//   • nsec   -> derive the read key from the signing key (full-access holder)
+//   • nwrite -> derive the read key from the signing key (full-access holder)
+//   • nsec   -> same, for a raw nostr key or an older author link
 //   • nread  -> the read key itself (read-only holder)
 //   • else   -> treat as a passphrase: derive the board identity, then its read
 //               key (works for a passphrase-derived board).
@@ -205,6 +244,7 @@ export async function deriveIdentity(passphrase) {
 export async function resolveContentKey(input) {
   const s = (input || '').trim();
   if (!s) return null;
+  if (s.startsWith('nwrite')) return deriveContentKey(hexToBytes(nwriteToHex(s)));
   if (s.startsWith('nsec')) return deriveContentKey(hexToBytes(nsecToHex(s)));
   if (s.startsWith('nread')) return hexToBytes(nreadToHex(s));
   return (await deriveIdentity(s)).readKey;

--- a/web/index.html
+++ b/web/index.html
@@ -783,7 +783,7 @@ footer a:hover { text-decoration: underline; }
 
       <div class="cta">
         <a href="#demo">Try the Demo</a>
-        <a href="editor.html" style="background:transparent; color:var(--accent); border:2px solid var(--accent); margin-left:0.75rem;">Open Editor</a>
+        <a href="compose.html" style="background:transparent; color:var(--accent); border:2px solid var(--accent); margin-left:0.75rem;">Create Bulletin</a>
       </div>
     </section>
 


### PR DESCRIPTION
Squashes the `bulletin` branch (44 commits) into a single commit against `master`. The tree is identical to `bulletin`; only the history is flattened.

## Highlights

- **Compose page redesign** — passphrase-keyed, realtime live preview, settings disclosure, share buttons in place of raw share URLs.
- **Viewer redesign** — three reading styles, lock/unlock for decoded bulletins, board `npub` surfaced as the board id.
- **Save/load a board** as a Glossia seed-phrase paragraph; encode board keys with `npub`/`nwrite` prefixes and keep decryption keys in reader URLs so pages stay bookmarkable.
- **Encryption** — always encrypt; default content key is derived from the board key (hash of nsec).
- **Private author link** (nsec) to reuse a board for more bulletins.
- Mobile compose overflow fix plus assorted copy and icon cleanups.
- Adds `docs/src/bulletin-board.md`.

## Diff summary

```
docs/src/bulletin-board.md |  25 ++
web/bulletin.html          | 503 +++++++++---
web/compose.html           | 922 +++++++++++++++++++---
web/glossia-msg.js         |  63 ++
web/glossia-nostr.js       |  44 +-
web/index.html             |   2 +-
6 files changed, 1184 insertions(+), 375 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0142UzxyEapPtbZdnwAzRPFD)_