### PR TITLE
web: redesign the bulletin viewer with three reading styles

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -15,8 +15,14 @@ on:
 permissions:
   contents: write
 
+# Serialize every workflow that pushes to gh-pages under one repo-wide group.
+# Each push to gh-pages triggers GitHub's own pages-build-deployment, and Pages
+# only runs one deployment at a time — two overlapping pushes make the loser
+# fail with "Deployment failed, try again later", which is what leaves a freshly
+# deployed path (e.g. a PR preview) returning 404. The PR Preview workflow shares
+# this exact group name so production and preview deploys can never race.
 concurrency:
-  group: pages-deploy
+  group: gh-pages-deploy
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -14,9 +14,14 @@ permissions:
   contents: write
   pull-requests: write
 
+# Share one repo-wide group with the Deploy Web App workflow so no two gh-pages
+# pushes overlap. GitHub Pages serves one deployment at a time; overlapping
+# pushes make the loser fail with "Deployment failed, try again later", leaving
+# the just-deployed preview at pr-preview/pr-<N>/ returning 404. cancel-in-progress
+# is false so an in-flight deploy always finishes publishing before the next runs.
 concurrency:
-  group: pr-preview-${{ github.ref }}
-  cancel-in-progress: true
+  group: gh-pages-deploy
+  cancel-in-progress: false
 
 jobs:
   preview:


### PR DESCRIPTION
Reimplements the bulletin board reader to match the new "Glossia Bulletin"
design: a single viewer that renders in one of three reading styles —
Letterpress (warm paper, Spectral serif), Midnight (low-light dark,
Newsreader), and Terminal (monospace, log-like). The chosen style is
persisted in the URL hash (#<npub>&style=<style>) so a shared link opens
in the style it was composed for.

- bulletin.html: full visual redesign (masthead, identity/status line,
  reading-style switch, themed key bar + settings). Each bulletin renders
  its prose with payload words emphasised, an attribution line, and an
  animated "decoded" reveal when unlocked; locked bulletins show a lock
  affordance that focuses the key field. All existing functionality
  (WASM engine, nostr fetch, key/passphrase decode, relay settings) is
  preserved; the status line reflects reading/unlocked/wrong-key state.
- glossia-msg.js: add skimArtifact(), a key-free skim that recovers an
  artifact's payload words (and splits body from attribution) so locked
  bulletins still highlight their payload words. Verified in-browser to
  return the same payload words as decodeMessage.
- compose.html: add a "Reading style" picker and bake &style= into the
  generated read link, so the two pages interoperate end to end.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KZ28wxSZgafcDoiTyAya52