### PR TITLE
web: trim compose copy to one-line hints, fold explainers behind "?"

### DIFF
--- a/web/bulletin.html
+++ b/web/bulletin.html
@@ -564,8 +564,8 @@ function updateShareState() {
 // the prose that goes into the post body; set just before the menu opens
 let shareBody = '';
 function setShareContext(body) { shareBody = (body || '').replace(/\s+/g, ' ').trim(); }
-// what to write as the post: the bulletin's own prose, quoted, else a tagline
-function sharePost() { return shareBody ? '“' + shareBody + '”' : SHARE_TEXT; }
+// what to write as the post: the bulletin's own prose, else a tagline
+function sharePost() { return shareBody ? shareBody : SHARE_TEXT; }
 function truncate(s, n) { return s.length <= n ? s : s.slice(0, n - 1).replace(/\s+\S*$/, '').trim() + '…'; }
 
 const shareBtn = $('r-share');

--- a/web/bulletin.html
+++ b/web/bulletin.html
@@ -653,7 +653,7 @@ shareMenu.addEventListener('click', async (e) => {
   // still shortens the URL (~23 chars) and unfurls its card from the body.
   // Reddit/Mastodon carry the prose in the title/body; Facebook's sharer is
   // URL-only, so its post can't carry the prose.
-  if (kind === 'x') target = 'https://twitter.com/intent/tweet?text=' + enc(truncate(post, 240) + '\n\n' + url);
+  if (kind === 'x') target = 'https://twitter.com/intent/tweet?text=' + enc(truncate(post, 255 /* 280 − "\n\n" − t.co url(23) */) + '\n\n' + url);
   else if (kind === 'reddit') target = 'https://www.reddit.com/submit?url=' + enc(url) + '&title=' + enc(truncate(post, 290));
   else if (kind === 'facebook') target = 'https://www.facebook.com/sharer/sharer.php?u=' + enc(url);
   else if (kind === 'mastodon') {

--- a/web/compose.html
+++ b/web/compose.html
@@ -203,9 +203,11 @@ body[data-style="midnight"] .modal-overlay { background:rgba(0,0,0,.66); }
 .share-menu button { text-align:left; background:transparent; border:none; border-radius:6px; color:var(--ink-soft); font:500 12.5px/1 'IBM Plex Mono',monospace; letter-spacing:.02em; padding:9px 11px; cursor:pointer; transition:background .15s, color .15s; }
 .share-menu button:hover { background:var(--chip-bg); color:var(--ink); }
 .share-sep { height:1px; background:var(--rule); margin:5px 6px; }
-.pv-len { font-variant-numeric:tabular-nums; }
-.pv-len.over { color:var(--error); }
-.pv-len.fits { color:var(--success); }
+/* X-length footnote inside the share menu */
+.share-len { padding:6px 11px 3px; font:500 11px/1.45 'IBM Plex Mono',monospace; letter-spacing:.02em; color:var(--dim); font-variant-numeric:tabular-nums; }
+.share-len:empty { display:none; }
+.share-len.over { color:var(--error); }
+.share-len.fits { color:var(--ok); }
 .preview { padding:26px 28px; transition:background .3s ease, border-color .3s ease; }
 .preview[data-style="letterpress"] { background:#f6f3ec; border:1px solid #d8d2c4; color:#26241d; border-radius:3px; box-shadow:0 20px 50px -30px rgba(38,36,29,.5); }
 .preview[data-style="midnight"]    { background:#0d0d10; border:1px solid #232228; color:#e8e4da; border-radius:6px; box-shadow:0 20px 50px -30px rgba(0,0,0,.7); }
@@ -345,6 +347,8 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
               <button type="button" role="menuitem" data-share="mastodon">Mastodon</button>
               <button type="button" role="menuitem" data-share="reddit">Reddit</button>
               <button type="button" role="menuitem" data-share="facebook">Facebook</button>
+              <div class="share-sep"></div>
+              <div class="share-len" id="c-share-len"></div>
             </div>
           </div>
         </div>
@@ -412,7 +416,6 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
             <div class="pv-dec-text" id="c-pv-msg">The pen is mightier than the sword.</div>
           </div>
         </div>
-        <div class="hint pv-len" id="c-pv-len" style="margin-top:10px"></div>
         <button type="button" class="btn block" id="c-publish" disabled>Publish</button>
         <div class="hint" id="c-status" style="margin-top:10px"></div>
         <div class="err" id="c-err"></div>
@@ -738,19 +741,19 @@ async function regenPreview() {
   }
 }
 // A shared post carries the bulletin's body and adds the board link; X counts a
-// link as 23 chars. Show whether that post fits X's 280 and, when it doesn't,
-// nudge toward turning cover words off to slim the body.
+// link as 23 chars. The share menu shows whether that post fits X's 280 and,
+// when it doesn't, nudges toward turning cover words off to slim the body.
 const TWEET_MAX = 280, TWEET_URL = 23;
 function updateLen(body) {
-  const el = $('c-pv-len');
-  if (body == null) { el.textContent = ''; el.className = 'hint pv-len'; return; }
+  const el = $('c-share-len');
+  if (body == null) { el.textContent = ''; el.className = 'share-len'; return; }
   const post = body.length + 2 /* \n\n */ + TWEET_URL;
   const fits = post <= TWEET_MAX;
   el.classList.toggle('over', !fits);
   el.classList.toggle('fits', fits);
   el.textContent = fits
-    ? `Shareable post ≈ ${post}/${TWEET_MAX} on X ✓`
-    : `Shareable post ≈ ${post}/${TWEET_MAX} on X — over the limit${$('c-cover').checked ? '; turn off cover words to slim it' : ''}`;
+    ? `X post ≈ ${post}/${TWEET_MAX} ✓`
+    : `X post ≈ ${post}/${TWEET_MAX} — over${$('c-cover').checked ? '; turn off cover words to slim it' : ''}`;
 }
 function schedulePreview() { clearTimeout(pvTimer); pvTimer = setTimeout(regenPreview, 400); }
 $('c-msg').addEventListener('input', () => { syncMeta(); schedulePreview(); });

--- a/web/compose.html
+++ b/web/compose.html
@@ -159,6 +159,16 @@ mark { background:color-mix(in srgb, var(--accent) 16%, transparent); border-bot
 .foot { margin-top:20px; padding-top:16px; border-top:1px solid var(--rule); font:400 12px/1.6 'Public Sans',sans-serif; color:var(--dim); text-align:center; }
 .foot strong { color:var(--accent); font-weight:600; }
 
+/* inline "?" explainers — educational content folded away by default so the
+   page reads as a short form; the philosophy is one click away, never in the way */
+.qa { margin-top:10px; }
+.qa > summary { list-style:none; cursor:pointer; display:inline-flex; align-items:center; gap:7px; font:600 12px/1.4 'Public Sans',sans-serif; color:var(--accent); }
+.qa > summary::-webkit-details-marker { display:none; }
+.qa > summary::before { content:"?"; flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center; width:16px; height:16px; border:1px solid currentColor; border-radius:50%; font:600 10px/1 'IBM Plex Mono',monospace; }
+.qa > summary:hover { color:var(--accent-2); }
+.qa p { margin:10px 0 0; font:400 13px/1.6 'Public Sans',sans-serif; color:var(--ink-soft); text-align:left; }
+.qa p strong { color:var(--accent); font-weight:600; }
+
 /* save / load board actions (in the board-head) */
 .board-actions { display:flex; gap:8px; align-items:center; }
 .board-actions .n { margin-right:4px; }
@@ -270,11 +280,13 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
             <span>Settings</span>
           </summary>
 
-          <label>Passphrase <span class="muted">(optional — overrides the board key)</span></label>
+          <label>Passphrase <span class="muted">(optional)</span></label>
+          <p class="hint" style="margin:0 0 9px">Sets a memorable key. Anyone with the passphrase can read the bulletin.</p>
           <button type="button" class="btn sm" id="c-pass-btn">Set passphrase</button>
           <div class="entropy" id="c-pass-state"></div>
 
           <label>Prose language</label>
+          <p class="hint" style="margin:0 0 9px">Which language the prose reads in. The data stays the same.</p>
           <select id="c-lang">
             <option value="english">English</option>
             <option value="latin">Latin</option>
@@ -287,6 +299,7 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
           <input type="text" id="c-subject" placeholder="label" spellcheck="false">
 
           <label>Reading style</label>
+          <p class="hint" style="margin:0 0 9px">Changes how the bulletin looks to readers. The data stays the same.</p>
           <input type="hidden" id="c-style" value="letterpress">
           <div class="tiles" role="group" aria-label="Reading style">
             <button type="button" class="tile" data-set-style="letterpress"><span class="mini letterpress">Aa</span>Letterpress</button>
@@ -307,8 +320,7 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
         <div class="share keep">
           <label>Keep this <span class="muted">· for you</span></label>
           <p class="hint" style="margin:0 0 12px">
-            <strong>Bookmark this page.</strong> Its address is your author link — the only way back in to publish more.
-            Losing it means you can't post to this board again. For a durable backup, save the seed phrase.
+            <strong>Bookmark this page</strong> — it's the only way back in to post again. Save the seed phrase for a durable backup.
           </p>
           <button type="button" class="btn sm" id="c-save-keep">💾 Save bulletin</button>
         </div>
@@ -317,7 +329,7 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
         <div class="share" style="margin-top:24px">
           <label>Share these <span class="muted">· for others</span></label>
 
-          <label style="margin-top:14px">Reader link <span class="lab warn">· includes the decryption key — readers unlock instantly (avoid pasting where the link is logged)</span></label>
+          <label style="margin-top:14px">Reader link <span class="lab warn">· unlocks instantly — carries the key, so keep it off public logs</span></label>
           <button type="button" class="btn sm share-btn" id="c-btn-reader"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>Reader link</button>
 
           <label>Public link <span class="muted">· read the encoded prose only (npub)</span></label>
@@ -373,18 +385,18 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
       </div>
 
       <div class="note">
-        <strong>How it works.</strong> Every board has three things: a <strong>public address</strong> anyone can open,
-        an <strong>author link</strong> that lets you publish, and a <strong>read key</strong> that lets readers decrypt.
-        All three come from one secret, so there's no separate password to set. Every message is encrypted and encoded into
-        Glossia prose before it's published — share a <strong>reader link</strong> (or the read key) for read-only access,
-        and keep your author link to keep posting. Prefer a memorable secret? Set a passphrase — it derives this board's
-        read key, so the reader link still unlocks it and anyone who knows the passphrase can decrypt too.
+        <strong>How it works.</strong> A bulletin is a stream of posts anyone with the link can read; keep your author link to keep posting.
+        <details class="qa">
+          <summary>Which link is which?</summary>
+          <p>One secret gives every board three things: a <strong>public address</strong> anyone can open, an <strong>author link</strong> that lets you publish, and a <strong>read key</strong> that lets readers decrypt. Share a reader link for read-only access; keep your author link to keep posting. Set a passphrase and the reader link still unlocks it.</p>
+        </details>
       </div>
 
       <div class="foot">
-        Glossia is <strong>not steganography</strong>. It does not try to hide the fact that data is encoded. By avoiding
-        the constraints of steganographic techniques, Glossia can use a much more compact and efficient encoding while
-        remaining human-readable.
+        <details class="qa">
+          <summary>What is Glossia?</summary>
+          <p>A <strong>readable encoding — not steganography</strong>. It doesn't hide that data is present; it makes machine data speakable and transcribable. Skipping steganography's constraints keeps the encoding compact and efficient while staying human-readable.</p>
+        </details>
       </div>
     </div>
 
@@ -447,8 +459,8 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
   <div class="modal" role="dialog" aria-modal="true">
     <button type="button" class="modal-x" id="c-pass-close" aria-label="Close">&times;</button>
     <h2 class="modal-title" id="c-pass-title">Set a passphrase</h2>
-    <p class="modal-lead">A passphrase overrides the board key — it derives this board's read key, so the reader link still
-      unlocks it and anyone who knows the passphrase can decrypt too. Leave it empty to use the board's own key.</p>
+    <p class="modal-lead">Readers unlock with the passphrase or with the reader link. <strong>Wrong passphrase → can't decrypt.</strong>
+      Leave it empty to use the board's own key.</p>
     <div class="row">
       <input type="password" id="c-id-value" autocomplete="new-password" placeholder="type a passphrase, or use 🎲" spellcheck="false">
       <button type="button" class="btn sm" data-reveal="c-id-value" title="Show / hide">👁</button>

--- a/web/compose.html
+++ b/web/compose.html
@@ -76,8 +76,11 @@ a:hover { text-decoration: underline; }
 .col-form { flex:1 1 520px; min-width:320px; }
 .col-preview { flex:0 1 380px; min-width:300px; position:sticky; top:24px; }
 #c-preview-slot:empty { display:none; }
-/* when the two columns stack, the live preview moves under the message */
-@media (max-width: 820px) {
+/* Stack below the width where the two columns (520 + 380 + 32 gap ≈ 932px of
+   inner width) can still sit side by side — otherwise .col-preview wraps to the
+   very bottom of the page. Below this, the live preview moves under the message
+   (see placePreview); the breakpoint here must match the matchMedia() below. */
+@media (max-width: 1000px) {
   .wrap { padding:32px 16px 64px; }
   .layout { flex-direction:column; align-items:stretch; }
   .col-form, .col-preview { flex:1 1 auto; width:100%; min-width:0; }
@@ -1027,9 +1030,11 @@ function loadFromHash() {
   if (keyM && keyM[1]) { try { hashKey = decodeURIComponent(keyM[1]); } catch { hashKey = keyM[1]; } }
 }
 
-// keep the live preview under the message when the columns stack (mobile),
-// and back in the right-hand column on wider screens
-const mqStack = window.matchMedia('(max-width: 820px)');
+// keep the live preview under the message when the columns stack (mobile /
+// landscape), and back in the right-hand column on wider screens. The width
+// must match the CSS stacking breakpoint above so the preview never wraps to
+// the bottom of the page.
+const mqStack = window.matchMedia('(max-width: 1000px)');
 function placePreview() {
   const live = $('c-live-preview');
   if (mqStack.matches) $('c-preview-slot').appendChild(live);

--- a/web/compose.html
+++ b/web/compose.html
@@ -648,7 +648,7 @@ cShareMenu.addEventListener('click', async (e) => {
   if (kind === 'copy') { navigator.clipboard.writeText(url).then(() => flashBtn(cShareBtn, 'Copied ✓')).catch(() => {}); return; }
   if (kind === 'nostr') { navigator.clipboard.writeText(post + '\n\n' + url).then(() => flashBtn(cShareBtn, 'Copied for nostr ✓')).catch(() => {}); return; }
   let target = null;
-  if (kind === 'x') target = 'https://twitter.com/intent/tweet?text=' + enc(shareTruncate(post, 240) + '\n\n' + url);
+  if (kind === 'x') target = 'https://twitter.com/intent/tweet?text=' + enc(shareTruncate(post, TWEET_MAX - 2 /* \n\n */ - TWEET_URL) + '\n\n' + url);
   else if (kind === 'reddit') target = 'https://www.reddit.com/submit?url=' + enc(url) + '&title=' + enc(shareTruncate(post, 290));
   else if (kind === 'facebook') target = 'https://www.facebook.com/sharer/sharer.php?u=' + enc(url);
   else if (kind === 'mastodon') {
@@ -744,7 +744,7 @@ const TWEET_MAX = 280, TWEET_URL = 23;
 function updateLen(body) {
   const el = $('c-pv-len');
   if (body == null) { el.textContent = ''; el.className = 'hint pv-len'; return; }
-  const post = body.length + 1 /* space */ + TWEET_URL;
+  const post = body.length + 2 /* \n\n */ + TWEET_URL;
   const fits = post <= TWEET_MAX;
   el.classList.toggle('over', !fits);
   el.classList.toggle('fits', fits);

--- a/web/compose.html
+++ b/web/compose.html
@@ -603,7 +603,7 @@ $('c-btn-reader').addEventListener('click', () => {
 // cover text, so it exposes nothing the board doesn't already publish.
 let lastBody = '';   // the current preview's body, set by regenPreview
 const SHARE_TEXT = 'An encrypted Glossia bulletin — messages published as natural-language prose on nostr.';
-function sharePost() { return lastBody ? '“' + lastBody.replace(/\s+/g, ' ').trim() + '”' : SHARE_TEXT; }
+function sharePost() { return lastBody ? lastBody.replace(/\s+/g, ' ').trim() : SHARE_TEXT; }
 function shareTruncate(s, n) { return s.length <= n ? s : s.slice(0, n - 1).replace(/\s+\S*$/, '').trim() + '…'; }
 
 const cShareBtn = $('c-btn-public');
@@ -737,14 +737,14 @@ async function regenPreview() {
     updateLen(null);
   }
 }
-// A shared post quotes the bulletin's body and adds the board link; X counts a
+// A shared post carries the bulletin's body and adds the board link; X counts a
 // link as 23 chars. Show whether that post fits X's 280 and, when it doesn't,
 // nudge toward turning cover words off to slim the body.
 const TWEET_MAX = 280, TWEET_URL = 23;
 function updateLen(body) {
   const el = $('c-pv-len');
   if (body == null) { el.textContent = ''; el.className = 'hint pv-len'; return; }
-  const post = body.length + 2 /* quotes */ + 1 /* space */ + TWEET_URL;
+  const post = body.length + 1 /* space */ + TWEET_URL;
   const fits = post <= TWEET_MAX;
   el.classList.toggle('over', !fits);
   el.classList.toggle('fits', fits);

--- a/web/compose.html
+++ b/web/compose.html
@@ -293,7 +293,8 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
             <option value="czech">Czech</option>
           </select>
 
-          <label class="check"><input type="checkbox" id="c-cover" checked> Cover words <span class="muted">· natural prose; off publishes payload words only — much shorter</span></label>
+          <label class="check"><input type="checkbox" id="c-cover" checked> Cover words</label>
+          <p class="hint" style="margin:6px 0 0">Wraps the payload in natural prose. Off = just the payload words, much shorter.</p>
 
           <label>Subject <span class="muted">(optional, public)</span></label>
           <input type="text" id="c-subject" placeholder="label" spellcheck="false">


### PR DESCRIPTION
Get people writing immediately. Replace the two long paragraphs at the
foot of the compose page with a single "How it works" sentence plus a
"?" disclosure, and move the "not steganography" philosophy behind a
"What is Glossia?" toggle. Trim the "keep this" blurb and reader-link
warning to one line each, add one-line hints to the passphrase, prose
language, and reading-style settings, and reframe the passphrase modal
around what users care about ("wrong passphrase -> can't decrypt").

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NaDx7WgY9bEt4rybh88rqq