### PR TITLE
web: make bulletin Payload a deterministic variant stepper

### DIFF
--- a/web/compose.html
+++ b/web/compose.html
@@ -600,6 +600,46 @@ const defaultMsgFor = (lang) => DEFAULT_MSG[lang] || DEFAULT_MSG.english;
 const isDefaultMsg = (s) => Object.values(DEFAULT_MSG).includes(s.trim());
 $('c-msg').value = defaultMsgFor($('c-lang').value);   // seed to match the picked language
 
+// Detect the language the author is WRITING IN so the carrier prose defaults to it.
+// The message is encrypted and the carrier language is independent of it, so this is
+// a readability nicety, not a requirement — and it only picks the DEFAULT: once the
+// author chooses a language by hand we stop (langLocked, set on the c-lang change).
+// It's tuned to the four encoding languages rather than pulling in a general
+// detector (e.g. franc): among just these four a single letter is often decisive
+// (ř/ě/ů and the háček letters are Czech; ä/ö/ü/ß are German), which also beats a
+// trigram model on the short text a bulletin tends to be. Otherwise it counts
+// function words, and returns null — keep the current default — when the signal is
+// too thin to be sure. Overlapping words (e.g. "in") wash out across languages, so
+// only a clear winner switches the selector.
+const DET_WORDS = {
+  german:  ['der','die','das','und','ist','nicht','ein','eine','sind','mit','sich','auf','für','von','den','dem','im','ich','wir','sie','auch','wird','werden','haben','nach','aus','war','oder'],
+  english: ['the','and','is','are','was','of','to','in','that','it','for','with','you','we','they','this','be','have','not','on','at','as','but','or','from','your','all'],
+  latin:   ['et','in','est','non','ad','cum','per','pro','sed','qui','quae','quod','sunt','ut','nec','ex','si','de','ab','hoc','esse','autem','enim','omnia','res','ipse','atque'],
+};
+function detectInputLang(text) {
+  const t = (text || '').toLowerCase();
+  if (/[řěůčšžňťď]/.test(t)) return 'czech';        // Czech-distinctive letters
+  if (/[äöüß]/.test(t)) return 'german';            // German umlauts / eszett
+  const words = t.split(/[^a-zà-ÿ]+/i).filter(Boolean);
+  if (words.length < 3) return null;                // too little to tell — keep default
+  const set = new Set(words);
+  let bestLang = null, best = 0, second = 0;
+  for (const [lang, list] of Object.entries(DET_WORDS)) {
+    let n = 0; for (const w of list) if (set.has(w)) n++;
+    if (n > best) { second = best; best = n; bestLang = lang; }
+    else if (n > second) { second = n; }
+  }
+  return (best >= 2 && best > second) ? bestLang : null;   // need a clear, unambiguous winner
+}
+// Follow the detected language until the author overrides it by hand. Set the value
+// directly (no change event) so we neither loop nor clobber their typed message.
+let langLocked = false;
+function maybeAutoLang() {
+  if (langLocked) return;
+  const det = detectInputLang($('c-msg').value);
+  if (det && det !== $('c-lang').value) $('c-lang').value = det;
+}
+
 function parseRelays(s) { return s.split(/[\s,]+/).map(x => x.trim()).filter(x => /^wss?:\/\//.test(x)); }
 function escapeHtml(s) { return s.replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
 function renderProse(prose, words) {
@@ -979,9 +1019,10 @@ function updateLen(body) {
     : `X post ≈ ${post}/${TWEET_MAX} — over${$('c-cover').checked ? '; turn off cover words to slim it' : ''}`;
 }
 function schedulePreview() { clearTimeout(pvTimer); pvTimer = setTimeout(regenPreview, 400); }
-$('c-msg').addEventListener('input', () => { syncMeta(); schedulePreview(); });
+$('c-msg').addEventListener('input', () => { syncMeta(); maybeAutoLang(); schedulePreview(); });
 $('c-subject').addEventListener('input', syncMeta);
 $('c-lang').addEventListener('change', () => {
+  langLocked = true;   // an explicit choice — stop following the message's language
   // Swap in the new language's demo message only if the box is still a default,
   // so a message the user typed is never clobbered.
   if (isDefaultMsg($('c-msg').value)) { $('c-msg').value = defaultMsgFor($('c-lang').value); syncMeta(); }

--- a/web/compose.html
+++ b/web/compose.html
@@ -593,6 +593,10 @@ const LANG_BY_BCP47 = { en: 'english', de: 'german', cs: 'czech', la: 'latin' };
     if (val && supported.has(val)) { $('c-lang').value = val; return; }
   }
 })();
+// The neutral fallback for auto-detection: the browser-picked default. When the
+// message stops looking like any specific language, the carrier returns here rather
+// than sticking on whatever was last detected.
+const baseLang = $('c-lang').value;
 
 // A demo message in the spirit of each language; English falls back to the rest.
 const DEFAULT_MSG = { english: 'Free Samourai', german: 'Die Gedanken sind frei', czech: 'Soukromí není zločin.', latin: 'Veritas in numeris' };
@@ -606,38 +610,45 @@ $('c-msg').value = defaultMsgFor($('c-lang').value);   // seed to match the pick
 // author chooses a language by hand we stop (langLocked, set on the c-lang change).
 // It's tuned to the four encoding languages rather than pulling in a general
 // detector (e.g. franc): among just these four a single letter is often decisive
-// (ř/ě/ů and the háček letters are Czech; ä/ö/ü/ß are German), which also beats a
-// trigram model on the short text a bulletin tends to be. Otherwise it counts
-// function words, and returns null — keep the current default — when the signal is
-// too thin to be sure. Overlapping words (e.g. "in") wash out across languages, so
-// only a clear winner switches the selector.
-const DET_WORDS = {
-  german:  ['der','die','das','und','ist','nicht','ein','eine','sind','mit','sich','auf','für','von','den','dem','im','ich','wir','sie','auch','wird','werden','haben','nach','aus','war','oder'],
-  english: ['the','and','is','are','was','of','to','in','that','it','for','with','you','we','they','this','be','have','not','on','at','as','but','or','from','your','all'],
-  latin:   ['et','in','est','non','ad','cum','per','pro','sed','qui','quae','quod','sunt','ut','nec','ex','si','de','ab','hoc','esse','autem','enim','omnia','res','ipse','atque'],
+// (ř/ě/ů and the háček letters are Czech; ä/ö/ü/ß are German). Otherwise it scores
+// substring markers over the space-padded text — whole function words AND affixes
+// (German -ung/-chen/sch-, Latin -orum/-ibus/-que, English -ing/-tion) — which
+// generalizes to far more sentences than a whole-word stopword set and still beats a
+// trigram model on the short text a bulletin tends to be. It returns null when no
+// language wins clearly; callers treat that as "fall back to the base default"
+// (baseLang) rather than keeping a previously detected language, so switching from
+// one language to another never leaves the carrier stuck on the old one.
+const DET_MARKERS = {
+  german:  [[' der ',2],[' die ',2],[' das ',2],[' und ',2],[' ist ',2],[' nicht',2],[' ein ',1],[' eine',2],[' einen',2],[' ich ',2],[' du ',1],[' wir ',2],[' sie ',1],[' mit ',1],[' den ',1],[' dem ',1],[' auf ',1],[' von ',1],[' zu ',1],[' zum ',2],[' zur ',2],[' uns ',2],[' mir ',2],[' mich ',2],[' sich',2],[' sind',2],[' war ',1],[' wird',2],[' nach',1],[' bei ',1],[' aus ',1],[' habe',2],[' keine',2],[' heute',2],[' mein',2],[' kann',1],[' bitte',2],[' guten',2],[' danke',2],[' freund',1],['sch',1],['ung ',2],['chen',2],['keit',2],['lich',2]],
+  english: [[' the ',2],[' and ',2],[' is ',2],[' are ',2],[' was ',2],[' of ',2],[' to ',1],[' in ',1],[' that',2],[' it ',1],[' for ',1],[' with',2],[' you ',2],[' we ',1],[' this',1],[' have',1],[' been',2],[' not ',1],[' from',1],[' your',1],[' will',1],[' at ',1],[' but ',1],[' can ',1],[' me ',1],['ing ',2],['tion',2],['ould',1]],
+  latin:   [[' et ',2],[' est',2],[' non ',1],[' cum ',2],[' qui ',2],[' quae',2],[' quod',2],[' sunt',2],[' per ',1],[' pro ',1],[' sed ',2],[' ad ',1],[' ex ',1],[' ut ',1],[' nec ',2],[' ab ',1],[' hoc ',2],[' nos ',1],['que ',2],['orum',2],['ibus',2],['arum',2],['tur ',1],['us ',1],['um ',1]],
+  czech:   [[' je ',2],[' se ',2],[' na ',1],[' to ',1],[' ne ',1],[' ale ',2],[' jak ',2],[' den ',1],[' jsem',2],[' jsi ',2],[' jsou',2],[' byl',2],[' bych',2],[' nebo',2],[' aby ',2],[' kdyz',2],[' co ',1],[' mate',2],[' dobry',2],[' neni',2],[' pravda',2]],
 };
 function detectInputLang(text) {
-  const t = (text || '').toLowerCase();
-  if (/[řěůčšžňťď]/.test(t)) return 'czech';        // Czech-distinctive letters
-  if (/[äöüß]/.test(t)) return 'german';            // German umlauts / eszett
-  const words = t.split(/[^a-zà-ÿ]+/i).filter(Boolean);
-  if (words.length < 3) return null;                // too little to tell — keep default
-  const set = new Set(words);
+  const raw = (text || '').toLowerCase();
+  if (/[řěůčšžňťď]/.test(raw)) return 'czech';          // háček letters: decisive (only Czech among our four)
+  if (/[äöüß]/.test(raw)) return 'german';              // umlaut / eszett: decisive
+  const t = ' ' + raw.replace(/[^a-z]+/g, ' ').trim() + ' ';   // ascii, space-padded so ' der ' etc. match word-bounded
+  if (t.length < 5) return null;
   let bestLang = null, best = 0, second = 0;
-  for (const [lang, list] of Object.entries(DET_WORDS)) {
-    let n = 0; for (const w of list) if (set.has(w)) n++;
-    if (n > best) { second = best; best = n; bestLang = lang; }
-    else if (n > second) { second = n; }
+  for (const [lang, markers] of Object.entries(DET_MARKERS)) {
+    let s = 0;
+    for (const [frag, w] of markers) { let i = t.indexOf(frag); while (i >= 0) { s += w; i = t.indexOf(frag, i + 1); } }
+    if (s > best) { second = best; best = s; bestLang = lang; }
+    else if (s > second) { second = s; }
   }
-  return (best >= 2 && best > second) ? bestLang : null;   // need a clear, unambiguous winner
+  return (best >= 3 && best >= second + 2) ? bestLang : null;   // a clear, unambiguous winner
 }
-// Follow the detected language until the author overrides it by hand. Set the value
-// directly (no change event) so we neither loop nor clobber their typed message.
+// Follow the message's language until the author overrides it by hand. On a confident
+// detection use it; when nothing wins, fall back to the base default — NOT the last
+// detected language — so retyping in a new language always moves the carrier off the
+// old one. Set the value directly (no change event) so we neither loop nor clobber
+// the typed message.
 let langLocked = false;
 function maybeAutoLang() {
   if (langLocked) return;
-  const det = detectInputLang($('c-msg').value);
-  if (det && det !== $('c-lang').value) $('c-lang').value = det;
+  const target = detectInputLang($('c-msg').value) || baseLang;
+  if (target !== $('c-lang').value) $('c-lang').value = target;
 }
 
 function parseRelays(s) { return s.split(/[\s,]+/).map(x => x.trim()).filter(x => /^wss?:\/\//.test(x)); }

--- a/web/compose.html
+++ b/web/compose.html
@@ -371,8 +371,12 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
             </div>
 
             <div class="ctl">
-              <span class="ctl-lab" title="A fresh encryption nonce is used each time, so the payload words change. The cover text stays on the chosen variant.">Payload</span>
-              <button type="button" class="btn sm" id="c-regen" title="A fresh encryption nonce is used each time.">↻ Regenerate</button>
+              <span class="ctl-lab" title="Step through payload variations. Each number encodes the same message with a different set of payload words; the same number always reproduces the same words. The cover text stays on the chosen variant.">Payload variant</span>
+              <span class="stepper">
+                <button type="button" class="btn sm step" id="c-pl-dec" aria-label="Previous payload variant">–</button>
+                <input type="number" id="c-pl" min="0" step="1" value="0" aria-label="Payload variant number">
+                <button type="button" class="btn sm step" id="c-pl-inc" aria-label="Next payload variant">+</button>
+              </span>
             </div>
           </div>
 
@@ -725,25 +729,52 @@ function credFingerprint(cred) {
   if (cred instanceof Uint8Array) return 'k:' + Array.from(cred).map(b => b.toString(16).padStart(2, '0')).join('');
   return 'none';
 }
+// The seal is a pure function of (cred, payload variant, message): the variant
+// picks the salt (payloadSalt), so it belongs in the cache key alongside the msg.
+function sealKey(cred, msg) {
+  return credFingerprint(cred) + '\x00' + Math.max(0, Math.floor(Number(payloadVariant) || 0)) + '\x00' + msg;
+}
 async function sealFor(msg, cred) {
-  const key = credFingerprint(cred) + '\x00' + msg;
+  const key = sealKey(cred, msg);
   if (sealCache && sealCache.key === key) return sealCache.state;
-  const state = await sealMessage(msg, cred);
+  const state = await sealMessage(msg, cred, await payloadSalt(msg));
   sealCache = { key, state };
   return state;
 }
 
-// Two independent knobs on what words appear (see renderArtifact):
+// Two independent, steppable knobs on what words appear (see renderArtifact):
 //  • Cover variant — a deterministic seed for the cover text. Same number → same
-//    wording, and the payload words never change. It's a live, in-session control
-//    (not persisted): every publish draws a fresh nonce, so a nonce×variant pair is
-//    unique per bulletin and pinning the variant could never reproduce an exact
-//    published wording anyway. No effect when cover words are off.
-//  • Payload — the payload words follow the encryption nonce, a cryptographic
-//    requirement rather than a style choice, so it's exposed as an action
-//    ("Regenerate") that draws a fresh nonce, never as an editable value.
+//    wording, and the payload words never change. No effect when cover words are off.
+//  • Payload variant — a deterministic seed for the encryption salt (see
+//    payloadSalt). Same number → same payload words for this message; stepping it
+//    re-draws the salt (hence the nonce) so the SAME message re-encodes into a
+//    different set of payload words. The cover text stays on the chosen variant.
+// Both are live, in-session controls (not persisted): a published salt is spent
+// (the nonce-reuse guard re-draws on the rare collision), so pinning a variant is a
+// drafting aid, not a way to reproduce an already-published wording.
 let coverVariant = 0;
+let payloadVariant = 0;
 function coverSeed() { return BigInt(Math.max(0, Math.floor(Number(coverVariant) || 0))); }
+
+// The payload variant is a deterministic 6-byte AES-GCM salt, so each number is a
+// reproducible set of payload words for this message — the twin of the cover
+// variant (which only re-wraps the SAME payload). The salt folds in the public
+// board id + the message + the variant, which makes it safe to derive it (rather
+// than draw it at random) without risking AES-GCM's nonce-reuse hazard:
+//   • edit the message and the salt moves, so a fixed variant never encrypts two
+//     DIFFERENT plaintexts under one key with the same nonce;
+//   • two boards posting identical text get different salts (their ids differ), so
+//     a shared salt can't amortize a PBKDF2 attack across boards;
+//   • stepping the variant with the text fixed re-draws the salt → new payload words.
+// The salt is public (it rides in the trailer), so deterministic derivation leaks
+// nothing. The publish-time ledger still guards the one genuine repeat — re-posting
+// an identical message+variant — by falling back to a fresh random salt.
+async function payloadSalt(msg) {
+  const material = new TextEncoder().encode(
+    (boardIdentity().npub || '') + '\x00' + Math.max(0, Math.floor(Number(payloadVariant) || 0)) + '\x00' + msg);
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', material));
+  return digest.subarray(0, 6);   // AEAD salt is 6 bytes (see glossia-msg trailer)
+}
 
 // ── nonce-reuse guard ──────────────────────────────────────────────────
 // AES-GCM breaks catastrophically if one (key, nonce) ever encrypts two DIFFERENT
@@ -770,13 +801,17 @@ function recordSalt(hex) {
   const s = loadSaltLedger(); s.add(hex);
   try { localStorage.setItem(saltLedgerKey(), JSON.stringify([...s])); } catch { /* storage blocked/full — ignore */ }
 }
-// A seal whose salt this board hasn't used before, re-drawing on the rare collision.
+// A seal whose salt this board hasn't used before. The variant's salt is
+// deterministic, so a collision means this board already published this exact
+// message+variant; re-running sealFor would just redraw the same salt, so fall back
+// to fresh RANDOM salts until one is unused — a nonce is never reused for two
+// ciphertexts. The random result is cached so preview and publish stay in step.
 async function freshSeal(msg, cred) {
   const ledger = loadSaltLedger();
   let state = await sealFor(msg, cred);
   for (let i = 0; state.encrypted && ledger.has(saltHexOf(state)) && i < 8; i++) {
-    sealCache = null;                 // drop the cached seal so sealFor draws a new salt
-    state = await sealFor(msg, cred);
+    state = await sealMessage(msg, cred);   // random salt, bypassing the variant
+    sealCache = { key: sealKey(cred, msg), state };
   }
   return state;
 }
@@ -954,10 +989,11 @@ $('c-lang').addEventListener('change', () => {
 });
 $('c-cover').addEventListener('change', () => { syncCoverVariantEnabled(); schedulePreview(); });
 
-// ── cover variant (deterministic) + payload regenerate (fresh nonce) ──────
+// ── cover variant + payload variant (both deterministic steppers) ─────────
 // Cover variant re-renders from the cached seal, so the payload words stay put; it
-// has no effect when cover words are off, so the stepper is disabled then. Regenerate
-// clears the seal cache so the next render draws a fresh nonce → new payload words.
+// has no effect when cover words are off, so the stepper is disabled then. Payload
+// variant changes the salt, so the seal itself differs — its stepper drops the seal
+// cache so the next render re-seals under the new variant → new payload words.
 function syncCoverVariantEnabled() {
   const on = $('c-cover').checked;
   $('c-cv-row').classList.toggle('off', !on);
@@ -971,7 +1007,18 @@ function setCoverVariant(n) {
 $('c-cv').addEventListener('input', () => setCoverVariant($('c-cv').value));
 $('c-cv-dec').addEventListener('click', () => setCoverVariant(coverVariant - 1));
 $('c-cv-inc').addEventListener('click', () => setCoverVariant(coverVariant + 1));
-$('c-regen').addEventListener('click', () => { sealCache = null; regenPreview(); });
+
+// Payload variant: the salt (and thus the payload words) depends on it, so drop the
+// seal cache before re-previewing so the message is re-sealed under the new variant.
+function setPayloadVariant(n) {
+  payloadVariant = Math.max(0, Math.floor(Number(n) || 0));
+  $('c-pl').value = String(payloadVariant);
+  sealCache = null;
+  schedulePreview();
+}
+$('c-pl').addEventListener('input', () => setPayloadVariant($('c-pl').value));
+$('c-pl-dec').addEventListener('click', () => setPayloadVariant(payloadVariant - 1));
+$('c-pl-inc').addEventListener('click', () => setPayloadVariant(payloadVariant + 1));
 
 // ── board passphrase (set / update via a dialog) ──────────────────────
 // The passphrase field lives in a dialog opened by the "Set / Update passphrase"
@@ -1099,7 +1146,9 @@ $('c-publish').addEventListener('click', async () => {
     $('c-status').innerHTML = okN
       ? `<span class="ok">Published to ${okN}/${results.length} relays.</span> Share the read link.`
       : '<span class="err">No relay accepted the event. Try different relays.</span>';
-    if (okN) { sealCache = null; loadHistory(); }   // refresh the board's post history (and start a fresh draft nonce)
+    // Advance to the next payload variant so the draft moves off the salt we just
+    // spent — the next preview re-seals cleanly instead of tripping the reuse guard.
+    if (okN) { setPayloadVariant(payloadVariant + 1); loadHistory(); }
   } catch (e) { $('c-err').textContent = e.message || String(e); }
   finally { $('c-publish').disabled = false; }
 });

--- a/web/glossia-msg.js
+++ b/web/glossia-msg.js
@@ -197,13 +197,22 @@ function payloadOnlyProse(prose, words) {
 // independent cipher state. Render it into any language with renderArtifact, as
 // often as you like, without re-encrypting. `cred` is a passphrase string or a
 // 32-byte key (Uint8Array); falsy/empty means do not encrypt.
+//
+// `salt` (optional) supplies the 6-byte AEAD salt instead of drawing one at random.
+// The salt seeds both key and nonce, so a caller can make the whole seal
+// reproducible (a "payload variant") by deriving the salt deterministically — as
+// long as it never repeats the salt for two DIFFERENT plaintexts under one key
+// (the AES-GCM nonce-reuse hazard). Omit it (or pass a wrong length) for the
+// default fresh-random salt. Salt is public: it rides in the trailer.
 // Returns { encrypted, ctHex, trailerHex }.
-export async function sealMessage(message, cred) {
+export async function sealMessage(message, cred, salt = null) {
   const { data: reduced, flag } = await maybeReduce(TE.encode(message));
   if (!hasCred(cred)) {
     return { encrypted: false, ctHex: toHex(buildEmbedded(flag, reduced)), trailerHex: null };
   }
-  const salt = crypto.getRandomValues(new Uint8Array(AEAD_SALT_LEN));
+  if (!(salt instanceof Uint8Array && salt.length === AEAD_SALT_LEN)) {
+    salt = crypto.getRandomValues(new Uint8Array(AEAD_SALT_LEN));
+  }
   const { key, nonce } = await deriveKeyNonce(cred, salt);
   const sealed = new Uint8Array(await crypto.subtle.encrypt(
     { name: 'AES-GCM', iv: nonce, tagLength: AEAD_TAG_BITS }, key, reduced));


### PR DESCRIPTION
The compose "Payload / ↻ Regenerate" control drew a fresh random nonce on
each click — a one-shot that couldn't be revisited. Replace it with a
"Payload variant" stepper that mirrors the cover-variant control: each
number encodes the same message into a different set of payload words, and
the same number always reproduces the same words.

The payload words follow the ciphertext, which follows the AES-GCM salt, so
stepping the variant means stepping the salt. sealMessage now accepts an
optional salt; compose derives it deterministically as
SHA-256(board id ‖ message ‖ variant)[:6]. Folding the message in means a
fixed variant never encrypts two different plaintexts under one nonce (the
AES-GCM reuse hazard), and folding the public board id in keeps two boards
from sharing a salt. The salt is public (it rides in the trailer), so
deterministic derivation leaks nothing. The publish-time salt ledger still
guards the one genuine repeat — re-posting an identical message+variant — by
falling back to a fresh random salt, and a successful publish advances the
variant so the next draft starts on an unspent salt.

Verified in-browser: stepping changes the payload words, returning to a
number reproduces them exactly, and every variant round-trips back to the
original message.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HD98f23BdaNsd8z31VGbT9