### PR TITLE
web: move bulletin & composer settings into a slide-in drawer

### DIFF
--- a/web/bulletin.html
+++ b/web/bulletin.html
@@ -136,16 +136,36 @@ body[data-style="letterpress"] .keybar input:focus { border-bottom-color:var(--a
 .board-id input:focus { outline:none; border-color:var(--accent); }
 .board-id input::placeholder { color:var(--dim); opacity:.7; }
 
-/* settings disclosure */
-.settings { margin-top:16px; border-top:1px solid var(--rule); padding-top:14px; }
-.settings > summary { list-style:none; cursor:pointer; font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.16em; text-transform:uppercase; color:var(--dim); display:flex; align-items:center; gap:7px; }
-.settings > summary::-webkit-details-marker { display:none; }
-.settings > summary:hover { color:var(--accent); }
-.settings label { display:block; font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.16em; text-transform:uppercase; color:var(--dim); margin:16px 0 7px; }
-.settings input { width:100%; background:var(--input-bg); color:var(--ink); border:1px solid var(--input-bd); border-radius:var(--radius); font:400 13px/1.5 'IBM Plex Mono',monospace; padding:9px 11px; }
-.settings input:focus { outline:none; border-color:var(--accent); }
-.settings .hl-check { display:flex; align-items:center; gap:9px; text-transform:none; letter-spacing:0; color:var(--ink); font:400 13px/1.4 'Public Sans',sans-serif; cursor:pointer; }
-.settings .hl-check input { width:auto; margin:0; }
+/* settings gear button (opens the drawer) */
+.gear-btn { display:inline-flex; align-items:center; justify-content:center; background:transparent; border:1.5px solid var(--rule); border-radius:calc(var(--radius) + 3px); color:var(--dim); padding:7px; cursor:pointer; transition:border-color .2s, color .2s; }
+.gear-btn svg { width:15px; height:15px; display:block; }
+.gear-btn:hover { color:var(--ink); border-color:var(--accent); }
+.gear-btn[aria-expanded="true"] { color:var(--ink); border-color:var(--accent); }
+
+/* settings drawer — slides in from the right over a dimming backdrop */
+.drawer-backdrop { position:fixed; inset:0; z-index:60; background:rgba(20,18,14,.5); backdrop-filter:blur(2px); opacity:0; transition:opacity .28s ease; }
+.drawer-backdrop.is-open { opacity:1; }
+body[data-style="midnight"] .drawer-backdrop { background:rgba(0,0,0,.62); }
+.drawer {
+  position:fixed; top:0; right:0; z-index:61; height:100%; width:min(360px, 88vw);
+  background:var(--card); border-left:1px solid var(--card-bd);
+  box-shadow:-24px 0 60px -30px rgba(20,18,14,.55);
+  display:flex; flex-direction:column;
+  transform:translateX(100%); transition:transform .3s cubic-bezier(.4,0,.2,1);
+  overflow-y:auto;
+}
+.drawer.is-open { transform:translateX(0); }
+body[data-style="midnight"] .drawer { box-shadow:-24px 0 60px -28px rgba(0,0,0,.75); }
+.drawer-head { display:flex; align-items:center; justify-content:space-between; border-bottom:var(--masthead-rule); padding:22px 24px 14px; }
+.drawer-title { font:600 12.5px/1 var(--brand-font); letter-spacing:var(--brand-ls); text-transform:uppercase; color:var(--ink); }
+.drawer-x { background:none; border:none; color:var(--dim); font-size:26px; line-height:1; cursor:pointer; padding:0 4px; }
+.drawer-x:hover { color:var(--accent); }
+.drawer-body { padding:8px 24px 28px; }
+.drawer label { display:block; font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.16em; text-transform:uppercase; color:var(--dim); margin:20px 0 7px; }
+.drawer input[type="text"] { width:100%; background:var(--input-bg); color:var(--ink); border:1px solid var(--input-bd); border-radius:var(--radius); font:400 13px/1.5 'IBM Plex Mono',monospace; padding:9px 11px; }
+.drawer input[type="text"]:focus { outline:none; border-color:var(--accent); }
+.drawer .hl-check { display:flex; align-items:center; gap:9px; text-transform:none; letter-spacing:0; color:var(--ink); font:400 13px/1.4 'Public Sans',sans-serif; cursor:pointer; }
+.drawer .hl-check input { width:auto; margin:0; }
 .mini-btn { flex:0 0 auto; background:var(--accent); color:#faf8f3; border:none; border-radius:var(--radius); padding:10px 16px; font:600 12px/1 'Public Sans',sans-serif; letter-spacing:.02em; cursor:pointer; }
 .mini-btn:hover { filter:brightness(.92); }
 .mini-btn:disabled { opacity:.5; cursor:not-allowed; }
@@ -229,6 +249,9 @@ body[data-style="terminal"] .empty { font-family:'IBM Plex Mono',monospace; font
     <div class="masthead">
       <span class="brand">Glossia Bulletin</span>
       <div class="masthead-actions">
+        <button type="button" class="gear-btn" id="r-settings-btn" aria-haspopup="dialog" aria-expanded="false" aria-controls="r-drawer" title="Settings">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+        </button>
         <div class="share-wrap">
           <button type="button" class="share-btn" id="r-share" aria-haspopup="menu" aria-expanded="false" disabled>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.6" y1="10.5" x2="15.4" y2="6.5"/><line x1="8.6" y1="13.5" x2="15.4" y2="17.5"/></svg>
@@ -265,27 +288,6 @@ body[data-style="terminal"] .empty { font-family:'IBM Plex Mono',monospace; font
       <div class="keyhint hidden" id="r-keyhint">A decryption key is required to unlock these bulletins.</div>
     </div>
 
-    <!-- board / relay settings -->
-    <details class="settings" id="r-settings">
-      <summary>
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-        <span>Settings</span>
-      </summary>
-
-      <label>Reading style</label>
-      <div class="style-switch" role="group" aria-label="Reading style">
-        <button type="button" class="style-tile" data-set-style="letterpress"><span class="swatch letterpress"></span>Letterpress</button>
-        <button type="button" class="style-tile" data-set-style="midnight"><span class="swatch midnight"></span>Midnight</button>
-        <button type="button" class="style-tile" data-set-style="terminal"><span class="swatch terminal"></span>Terminal</button>
-      </div>
-
-      <label class="hl-check"><input type="checkbox" id="r-cover" checked> Show cover words</label>
-      <label class="hl-check"><input type="checkbox" id="r-hl"> Highlight payload words</label>
-
-      <label for="r-relays">Relays</label>
-      <input type="text" id="r-relays" autocomplete="off" spellcheck="false">
-    </details>
-
     <!-- bulletins -->
     <div class="bulletins" id="r-results"></div>
   </div>
@@ -296,6 +298,29 @@ body[data-style="terminal"] .empty { font-family:'IBM Plex Mono',monospace; font
     Your reading style is saved in the link's <b>#</b> — no app, no account.
   </div>
 </div>
+
+<!-- settings drawer -->
+<div class="drawer-backdrop hidden" id="r-drawer-backdrop"></div>
+<aside class="drawer hidden" id="r-drawer" role="dialog" aria-modal="true" aria-label="Board settings">
+  <div class="drawer-head">
+    <span class="drawer-title">Settings</span>
+    <button type="button" class="drawer-x" id="r-drawer-close" aria-label="Close settings">&times;</button>
+  </div>
+  <div class="drawer-body">
+    <label>Reading style</label>
+    <div class="style-switch" role="group" aria-label="Reading style">
+      <button type="button" class="style-tile" data-set-style="letterpress"><span class="swatch letterpress"></span>Letterpress</button>
+      <button type="button" class="style-tile" data-set-style="midnight"><span class="swatch midnight"></span>Midnight</button>
+      <button type="button" class="style-tile" data-set-style="terminal"><span class="swatch terminal"></span>Terminal</button>
+    </div>
+
+    <label class="hl-check"><input type="checkbox" id="r-cover" checked> Show cover words</label>
+    <label class="hl-check"><input type="checkbox" id="r-hl"> Highlight payload words</label>
+
+    <label for="r-relays">Relays</label>
+    <input type="text" id="r-relays" autocomplete="off" spellcheck="false">
+  </div>
+</aside>
 
 <script type="module">
 import { init, decodeMessage, skimArtifact } from './glossia-msg.js';
@@ -338,6 +363,32 @@ function applyCover(on, { persist = true } = {}) {
   if (persist) writeHash();
 }
 $('r-cover').addEventListener('change', () => applyCover($('r-cover').checked));
+
+// ── settings drawer ───────────────────────────────────────────────────
+const drawer = $('r-drawer');
+const drawerBackdrop = $('r-drawer-backdrop');
+const drawerBtn = $('r-settings-btn');
+function openDrawer() {
+  drawer.classList.remove('hidden');
+  drawerBackdrop.classList.remove('hidden');
+  // next frame so the transition runs from the off-screen/transparent state
+  requestAnimationFrame(() => { drawer.classList.add('is-open'); drawerBackdrop.classList.add('is-open'); });
+  drawerBtn.setAttribute('aria-expanded', 'true');
+  $('r-drawer-close').focus();
+}
+function closeDrawer() {
+  if (drawer.classList.contains('hidden')) return;
+  drawer.classList.remove('is-open');
+  drawerBackdrop.classList.remove('is-open');
+  drawerBtn.setAttribute('aria-expanded', 'false');
+  const done = () => { drawer.classList.add('hidden'); drawerBackdrop.classList.add('hidden'); drawer.removeEventListener('transitionend', done); };
+  drawer.addEventListener('transitionend', done);
+  drawerBtn.focus();
+}
+drawerBtn.addEventListener('click', () => drawer.classList.contains('is-open') ? closeDrawer() : openDrawer());
+$('r-drawer-close').addEventListener('click', closeDrawer);
+drawerBackdrop.addEventListener('click', closeDrawer);
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeDrawer(); });
 
 // ── engine load state ─────────────────────────────────────────────────
 function setEngine(state, msg) {

--- a/web/bulletin.html
+++ b/web/bulletin.html
@@ -240,6 +240,13 @@ body[data-style="terminal"] .empty { font-family:'IBM Plex Mono',monospace; font
 .foot { margin-top:20px; font:400 12px/1.6 'Public Sans',sans-serif; color:var(--dim); text-align:center; padding:0 8px; }
 .foot b { color:var(--accent); font-weight:600; }
 .hidden { display:none !important; }
+
+/* portrait: collapse the masthead's Share button to icon-only (the gear is
+   already icon-only) so the header stays compact on narrow screens */
+@media (orientation: portrait) {
+  .btn-label { display:none; }
+  .share-btn { padding:7px 8px; }
+}
 </style>
 </head>
 <body data-style="letterpress" data-hl="off" data-cover="on">
@@ -255,7 +262,7 @@ body[data-style="terminal"] .empty { font-family:'IBM Plex Mono',monospace; font
         <div class="share-wrap">
           <button type="button" class="share-btn" id="r-share" aria-haspopup="menu" aria-expanded="false" disabled>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.6" y1="10.5" x2="15.4" y2="6.5"/><line x1="8.6" y1="13.5" x2="15.4" y2="17.5"/></svg>
-            Share
+            <span class="btn-label">Share</span>
           </button>
           <div class="share-menu hidden" id="r-share-menu" role="menu" aria-label="Share this board">
             <button type="button" role="menuitem" data-share="native" class="hidden">Share…</button>

--- a/web/compose.html
+++ b/web/compose.html
@@ -238,7 +238,7 @@ mark { background:color-mix(in srgb, var(--accent) 16%, transparent); border-bot
 .board-actions .btn.sm { padding:7px 11px; }
 
 /* modal: save / load a board via its seed-phrase paragraph */
-.modal-overlay { position:fixed; inset:0; z-index:50; display:flex; align-items:flex-start; justify-content:center; padding:6vh 18px 40px; background:rgba(20,18,14,.55); backdrop-filter:blur(3px); overflow-y:auto; }
+.modal-overlay { position:fixed; inset:0; z-index:70; display:flex; align-items:flex-start; justify-content:center; padding:6vh 18px 40px; background:rgba(20,18,14,.55); backdrop-filter:blur(3px); overflow-y:auto; }
 body[data-style="midnight"] .modal-overlay { background:rgba(0,0,0,.66); }
 .modal { position:relative; width:100%; max-width:560px; background:var(--card); color:var(--ink); border:1px solid var(--card-bd); border-radius:14px; box-shadow:0 40px 90px -40px rgba(20,18,14,.7); padding:30px 32px 28px; }
 .modal-x { position:absolute; top:14px; right:16px; background:none; border:none; color:var(--dim); font-size:24px; line-height:1; cursor:pointer; padding:2px 6px; }
@@ -251,6 +251,29 @@ body[data-style="midnight"] .modal-overlay { background:rgba(0,0,0,.66); }
 .modal-actions .muted { margin-left:auto; font:400 12px/1.3 'IBM Plex Mono',monospace; }
 .modal-foot { margin:16px 0 0; font:400 12px/1.55 'Public Sans',sans-serif; }
 #c-seed-input { width:100%; min-height:120px; }
+
+/* settings drawer — slides in from the right over a dimming backdrop */
+.gear-btn { display:inline-flex; align-items:center; gap:6px; }
+.gear-btn svg { width:14px; height:14px; }
+.drawer-backdrop { position:fixed; inset:0; z-index:55; background:rgba(20,18,14,.5); backdrop-filter:blur(2px); opacity:0; transition:opacity .28s ease; }
+.drawer-backdrop.is-open { opacity:1; }
+body[data-style="midnight"] .drawer-backdrop { background:rgba(0,0,0,.62); }
+.drawer {
+  position:fixed; top:0; right:0; z-index:56; height:100%; width:min(430px, 92vw);
+  background:var(--card); border-left:1px solid var(--card-bd);
+  box-shadow:-24px 0 60px -30px rgba(20,18,14,.55);
+  display:flex; flex-direction:column;
+  transform:translateX(100%); transition:transform .3s cubic-bezier(.4,0,.2,1);
+  overflow-y:auto;
+}
+.drawer.is-open { transform:translateX(0); }
+body[data-style="midnight"] .drawer { box-shadow:-24px 0 60px -28px rgba(0,0,0,.75); }
+.drawer-head { display:flex; align-items:center; justify-content:space-between; border-bottom:1px solid var(--rule); padding:22px 26px 16px; position:sticky; top:0; background:var(--card); z-index:1; }
+.drawer-title { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.18em; text-transform:uppercase; color:var(--ink); }
+.drawer-x { background:none; border:none; color:var(--dim); font-size:26px; line-height:1; cursor:pointer; padding:0 4px; }
+.drawer-x:hover { color:var(--accent); }
+.drawer-body { padding:8px 26px 32px; }
+.drawer-body label:first-of-type { margin-top:8px; }
 
 /* live preview */
 .pv-caption { margin-top:14px; font:400 12px/1.55 'Public Sans',sans-serif; color:var(--dim); }
@@ -327,6 +350,10 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
           <a class="k board-new" id="c-new" href="./compose.html" title="Start a fresh bulletin — a brand-new board"><span class="plus">+</span> New bulletin</a>
           <div class="board-actions">
             <span class="n" id="c-head-npub">not yet published</span>
+            <button type="button" class="btn sm gear-btn" id="c-settings-btn" title="Settings" aria-haspopup="dialog" aria-expanded="false" aria-controls="c-drawer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+              Settings
+            </button>
             <button type="button" class="btn sm" id="c-load" title="Restore a board from a saved Glossia seed phrase">📂 Load</button>
           </div>
         </div>
@@ -338,11 +365,13 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
         <!-- on narrow screens the live preview is moved here, directly below the message -->
         <div id="c-preview-slot"></div>
 
-        <details class="settings" id="c-settings">
-          <summary>
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-            <span>Settings</span>
-          </summary>
+        <div class="drawer-backdrop hidden" id="c-drawer-backdrop"></div>
+        <aside class="drawer hidden" id="c-drawer" role="dialog" aria-modal="true" aria-label="Settings">
+          <div class="drawer-head">
+            <span class="drawer-title">Settings</span>
+            <button type="button" class="drawer-x" id="c-drawer-close" aria-label="Close settings">&times;</button>
+          </div>
+          <div class="drawer-body">
 
           <label>Passphrase <span class="muted">(optional)</span></label>
           <button type="button" class="btn sm" id="c-pass-btn">Set passphrase</button>
@@ -403,7 +432,8 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
 
           <label>Relays</label>
           <input type="text" id="c-relays" spellcheck="false">
-        </details>
+          </div>
+        </aside>
 
         <button type="button" class="btn block" id="c-publish" disabled>Publish</button>
         <div class="hint" id="c-status" style="margin-top:10px"></div>
@@ -962,6 +992,36 @@ cShareMenu.addEventListener('click', async (e) => {
     target = 'https://' + instance + '/share?text=' + enc(shareTruncate(post, 450) + '\n\n' + url);
   }
   if (target) window.open(target, '_blank', 'noopener,noreferrer');
+});
+
+// ── settings drawer ───────────────────────────────────────────────────
+const cDrawer = $('c-drawer');
+const cDrawerBackdrop = $('c-drawer-backdrop');
+const cDrawerBtn = $('c-settings-btn');
+function openCDrawer() {
+  cDrawer.classList.remove('hidden');
+  cDrawerBackdrop.classList.remove('hidden');
+  // next frame so the transition runs from the off-screen/transparent state
+  requestAnimationFrame(() => { cDrawer.classList.add('is-open'); cDrawerBackdrop.classList.add('is-open'); });
+  cDrawerBtn.setAttribute('aria-expanded', 'true');
+  $('c-drawer-close').focus();
+}
+function closeCDrawer() {
+  if (cDrawer.classList.contains('hidden')) return;
+  cDrawer.classList.remove('is-open');
+  cDrawerBackdrop.classList.remove('is-open');
+  cDrawerBtn.setAttribute('aria-expanded', 'false');
+  const done = () => { cDrawer.classList.add('hidden'); cDrawerBackdrop.classList.add('hidden'); cDrawer.removeEventListener('transitionend', done); };
+  cDrawer.addEventListener('transitionend', done);
+  cDrawerBtn.focus();
+}
+cDrawerBtn.addEventListener('click', () => cDrawer.classList.contains('is-open') ? closeCDrawer() : openCDrawer());
+$('c-drawer-close').addEventListener('click', closeCDrawer);
+cDrawerBackdrop.addEventListener('click', closeCDrawer);
+// Escape closes the drawer — but only when no modal (e.g. the passphrase dialog
+// opened from inside it) is on top, so Escape dismisses the modal's layer first.
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && cDrawer.classList.contains('is-open') && !document.querySelector('.modal-overlay:not(.hidden)')) closeCDrawer();
 });
 
 const ENGINE_BTNS = ['c-publish', 'c-id-gen'];

--- a/web/compose.html
+++ b/web/compose.html
@@ -542,7 +542,7 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
       <div class="foot">
         <details class="qa">
           <summary>What is Glossia?</summary>
-          <p>A <strong>readable encoding — not steganography</strong>. It doesn't hide that data is present; it makes machine data speakable and transcribable. Skipping steganography's constraints keeps the encoding compact and efficient while staying human-readable.</p>
+          <p>Glossia is a human-friendly way to represent data, making it far more portable than traditional methods. Transmission can occur over social media, email, voice notes, or even spoken word — because <strong>the data is the language</strong>.</p>
         </details>
       </div>
     </div>

--- a/web/compose.html
+++ b/web/compose.html
@@ -90,6 +90,12 @@ a:hover { text-decoration: underline; }
   #c-preview-slot { margin-top:18px; }
 }
 
+/* portrait: collapse the board-head actions to icon-only to save width */
+@media (orientation: portrait) {
+  .btn-label { display:none; }
+  .board-actions .btn.sm { padding:7px 9px; }
+}
+
 /* card */
 .board { background:var(--card); color:var(--ink); border:1px solid var(--card-bd); border-radius:12px; box-shadow:0 24px 60px -32px rgba(20,18,14,.4); padding:32px 36px 36px; margin-bottom:20px; transition:background .35s ease, border-color .35s ease; }
 .board-head { display:flex; align-items:baseline; justify-content:space-between; border-bottom:1px solid var(--rule); padding-bottom:14px; margin-bottom:20px; }
@@ -347,14 +353,14 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
       <form id="c-form" autocomplete="on" onsubmit="return false;">
       <div class="board">
         <div class="board-head">
-          <a class="k board-new" id="c-new" href="./compose.html" title="Start a fresh bulletin — a brand-new board"><span class="plus">+</span> New bulletin</a>
+          <a class="k board-new" id="c-new" href="./compose.html" title="Start a fresh bulletin — a brand-new board"><span class="plus">+</span><span class="btn-label">New bulletin</span></a>
           <div class="board-actions">
             <span class="n" id="c-head-npub">not yet published</span>
             <button type="button" class="btn sm gear-btn" id="c-settings-btn" title="Settings" aria-haspopup="dialog" aria-expanded="false" aria-controls="c-drawer">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-              Settings
+              <span class="btn-label">Settings</span>
             </button>
-            <button type="button" class="btn sm" id="c-load" title="Restore a board from a saved Glossia seed phrase">📂 Load</button>
+            <button type="button" class="btn sm" id="c-load" title="Restore a board from a saved Glossia seed phrase">📂<span class="btn-label"> Load</span></button>
           </div>
         </div>
         <input type="text" id="c-username" autocomplete="username" value="glossia bulletin" class="hidden" tabindex="-1" aria-hidden="true">

--- a/web/compose.html
+++ b/web/compose.html
@@ -240,7 +240,6 @@ mark { background:color-mix(in srgb, var(--accent) 16%, transparent); border-bot
 
 /* save / load board actions (in the board-head) */
 .board-actions { display:flex; gap:8px; align-items:center; }
-.board-actions .n { margin-right:4px; }
 .board-actions .btn.sm { padding:7px 11px; }
 
 /* modal: save / load a board via its seed-phrase paragraph */
@@ -355,7 +354,6 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
         <div class="board-head">
           <a class="k board-new" id="c-new" href="./compose.html" title="Start a fresh bulletin — a brand-new board"><span class="plus">+</span><span class="btn-label">New bulletin</span></a>
           <div class="board-actions">
-            <span class="n" id="c-head-npub">not yet published</span>
             <button type="button" class="btn sm gear-btn" id="c-settings-btn" title="Settings" aria-haspopup="dialog" aria-expanded="false" aria-controls="c-drawer">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H2a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V2a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H22a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
               <span class="btn-label">Settings</span>
@@ -1499,7 +1497,6 @@ function restoreBoard(id, readKey = null) {
   if (readKey && readKey.length === 32) { customKey = { readKey, nread: nreadFromKey(readKey) }; customKeyPass = null; }
   else { customKey = null; customKeyPass = null; }
   $('c-relay-results').innerHTML = '';          // old board's publish results no longer apply
-  $('c-head-npub').textContent = shortNpub(boardIdentity().npub);
   updatePassButton(); updateMode(); updateLinks(); writeHash(); schedulePreview();
   loadHistory();                                // a restored board likely has posts — show them
 }
@@ -1567,7 +1564,6 @@ loadFromHash();
   } else if (hashKey) {
     await applyPassphrase(hashKey);   // legacy: a raw passphrase author link
   }
-  $('c-head-npub').textContent = shortNpub(boardIdentity().npub);   // show the board id up front
   syncMeta();
   updatePassButton();
   updateMode();


### PR DESCRIPTION
Replace the inline `<details>` settings disclosures on both the reader board (`bulletin.html`) and the composer (`compose.html`) with a gear button that opens a right-hand drawer over a dimming backdrop.

## `web/bulletin.html` (reader board)

- Removed the inline `<details class="settings">` disclosure below the key bar.
- Added a gear button in the masthead (next to Share) that toggles the drawer.
- Drawer holds: reading-style switch, *Show cover words* / *Highlight payload words* toggles, and the *Relays* field.

## `web/compose.html` (composer)

- Converted the `SETTINGS` disclosure into the same drawer, opened by a **Settings** gear button in the board-head (next to Load).
- Drawer holds: passphrase, encoding language, cover/highlight toggles, the cover/payload/prose-quality steppers, subject, reading style, and relays.
- Message textarea and Publish button stay on the board.
- Raised `.modal-overlay` z-index above the drawer so the passphrase dialog (opened from inside the drawer) layers on top.

## Wiring preserved

On both pages every setting element kept its original id and `data-set-style` hooks, so existing persistence, URL routing, the live preview, and the variant steppers work unchanged. The settings markup stays inside its form; `position:fixed` renders the drawer as a viewport overlay regardless of DOM location (no ancestor establishes a containing block). Only open/close logic was added — gear toggle, × button, backdrop click, and Escape (which defers to any open modal first) — with `aria-expanded` / `aria-modal` and focus handling.

## Verification

Built the WASM, served `web/` over HTTP, and drove both pages with Playwright end-to-end: gear opens each drawer; every control inside works (style switch, toggles, language select, variant steppers, relays); the passphrase modal opens above the composer drawer (z-index 70 > 56) and the drawer stays open after it closes; and each drawer closes via backdrop, × button, and Escape, resetting `aria-expanded`. No console errors beyond blocked external resources (fonts/relays) in the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)