### PR TITLE
Add tap zones to compose preview for stepping variants

### DIFF
--- a/web/compose.html
+++ b/web/compose.html
@@ -281,30 +281,31 @@ body[data-style="midnight"] .drawer { box-shadow:-24px 0 60px -28px rgba(0,0,0,.
 .drawer-body label:first-of-type { margin-top:8px; }
 
 /* live preview */
-.pv-caption { margin-top:14px; font:400 12px/1.55 'Public Sans',sans-serif; color:var(--dim); min-height:1.55em; transition:color .18s ease; }
+.pv-caption { margin-top:14px; font:400 12px/1.55 'Public Sans',sans-serif; color:var(--dim); }
 
 /* tap zones on the preview — the body paragraph and the trailer each become a
    left/right pair of click targets that step a deterministic variant (cover
-   wording on the paragraph, payload nonce on the trailer). Purely a discoverable
-   shortcut for the steppers in Settings; the chevrons sit in the card's padding
-   gutter so they never overlap the prose, and text selection still works (a click
-   that lands inside an active selection is ignored — see wireTapZone). */
+   wording on the paragraph, payload nonce on the trailer). Purely a shortcut for
+   the steppers in Settings; text selection still works (a click inside an active
+   selection is ignored — see wireTapZone). The chevrons stay tucked in the card's
+   padding gutter — never past the border — and are hidden until the first tap
+   (tz-on), then mark each live region as steppable. */
 .pv-tap { position:relative; }
 .pv-tap.is-tappable { cursor:pointer; }
 .pv-tap .tz {
-  position:absolute; top:0; bottom:0; width:1.4em; display:flex; align-items:center;
+  position:absolute; top:0; bottom:0; width:12px; display:flex; align-items:center;
   pointer-events:none; opacity:0; color:currentColor;
-  font:400 22px/1 'IBM Plex Mono',monospace; user-select:none;
+  font:400 16px/1 'IBM Plex Mono',monospace; user-select:none;
   transition:opacity .18s ease;
 }
-.pv-tap .tz.l { left:-1.55em; justify-content:flex-start; }
-.pv-tap .tz.r { right:-1.55em; justify-content:flex-end; }
-/* a faint always-on hint that the region is tappable (visible on touch too),
-   brighter on hover, and brightest on the side the pointer is over */
-.pv-tap.is-tappable .tz { opacity:.14; }
-.pv-tap.is-tappable:hover .tz { opacity:.3; }
-.pv-tap.is-tappable[data-side="l"] .tz.l,
-.pv-tap.is-tappable[data-side="r"] .tz.r { opacity:.85; }
+.pv-tap .tz.l { left:-15px; justify-content:flex-start; }
+.pv-tap .tz.r { right:-15px; justify-content:flex-end; }
+/* revealed only after the first tap (tz-on), and only where the zone is live;
+   brighter on hover, brightest on the side the pointer is over */
+.pv-tap.is-tappable.tz-on .tz { opacity:.24; }
+.pv-tap.is-tappable.tz-on:hover .tz { opacity:.42; }
+.pv-tap.is-tappable.tz-on[data-side="l"] .tz.l,
+.pv-tap.is-tappable.tz-on[data-side="r"] .tz.r { opacity:.9; }
 .share { margin-bottom:8px; }
 .share label:first-of-type { margin-top:0; }
 .share-btn { margin-top:2px; padding:10px 16px; font-size:12.5px; display:inline-flex; align-items:center; gap:8px; }
@@ -592,7 +593,6 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
             <div class="pv-dec-text" id="c-pv-msg">Free Samourai</div>
           </div>
         </div>
-        <div class="pv-caption" id="c-pv-caption">Tap the paragraph ‹ › to reshuffle the wording · tap the trailer for a fresh nonce.</div>
       </div>
     </aside>
   </div>
@@ -1230,53 +1230,36 @@ $('c-best-inc').addEventListener('click', () => setBestOf(bestOf + 1));
 // different cover text); tapping the trailer steps the PAYLOAD variant, which
 // redraws the salt → the nonce, so the payload words (and the Latin trailer that
 // carries the salt) change. Both just call the same setters the Settings steppers
-// use, so decoding is unaffected and preview/publish stay in step.
-function setCaption(txt) { $('c-pv-caption').textContent = txt; }
-// The resting caption describes whichever zones are live right now (the paragraph
-// drops out when cover words are off; both drop out before any prose exists).
-function capDefault() {
-  const p = $('c-tap-prose').classList.contains('is-tappable');
-  const t = $('c-tap-attr').classList.contains('is-tappable');
-  if (p && t) return 'Tap the paragraph ‹ › to reshuffle the wording · tap the trailer for a fresh nonce.';
-  if (t) return 'Tap the trailer ‹ › for a fresh nonce — new payload words.';
-  if (p) return 'Tap the paragraph ‹ › to reshuffle the cover wording.';
-  return '';
-}
+// use, so decoding is unaffected and preview/publish stay in step. The chevrons
+// stay hidden until the first tap, then mark the live regions as steppable.
 function tapSide(el, e) {
   const r = el.getBoundingClientRect();
   return (e.clientX - r.left) < r.width / 2 ? 'l' : 'r';
 }
-function wireTapZone(el, { label, get, step }) {
-  el.addEventListener('mousemove', (e) => {
-    if (!el.classList.contains('is-tappable')) return;
-    el.dataset.side = tapSide(el, e);
-    setCaption(`${label} — variant ${get()} · tap ‹ back  ·  forward ›`);
-  });
-  el.addEventListener('mouseleave', () => { delete el.dataset.side; setCaption(capDefault()); });
+function revealTapZones() { $('c-tap-prose').classList.add('tz-on'); $('c-tap-attr').classList.add('tz-on'); }
+function wireTapZone(el, step) {
+  el.addEventListener('mousemove', (e) => { if (el.classList.contains('is-tappable')) el.dataset.side = tapSide(el, e); });
+  el.addEventListener('mouseleave', () => { delete el.dataset.side; });
   el.addEventListener('click', (e) => {
     if (!el.classList.contains('is-tappable')) return;
     // a click that finishes a text selection inside the zone shouldn't also step
     const sel = window.getSelection();
     if (sel && !sel.isCollapsed && sel.anchorNode && el.contains(sel.anchorNode)) return;
+    revealTapZones();                                  // first tap unveils the chevrons
     step(tapSide(el, e) === 'l' ? -1 : 1);
   });
 }
-wireTapZone($('c-tap-prose'), { label: 'Cover wording', get: () => coverVariant, step: (d) => setCoverVariant(coverVariant + d) });
-wireTapZone($('c-tap-attr'),  { label: 'Nonce (trailer)', get: () => payloadVariant, step: (d) => setPayloadVariant(payloadVariant + d) });
+wireTapZone($('c-tap-prose'), (d) => setCoverVariant(coverVariant + d));
+wireTapZone($('c-tap-attr'),  (d) => setPayloadVariant(payloadVariant + d));
 // Enable a zone only when it can actually do something: the paragraph needs cover
 // words on (its variant is a no-op otherwise, mirroring the disabled stepper); the
 // trailer needs an encrypted artifact (so a Latin trailer is present to redraw).
 function syncTapZones() {
   const hasBody = !!(lastBody && lastBody.trim());
-  const coverOn = $('c-cover').checked;
   const hasTrailer = !!$('c-pv-attr').textContent.trim();
-  $('c-tap-prose').classList.toggle('is-tappable', hasBody && coverOn);
+  $('c-tap-prose').classList.toggle('is-tappable', hasBody && $('c-cover').checked);
   $('c-tap-attr').classList.toggle('is-tappable', hasBody && hasTrailer);
-  if (!el0Hovered()) setCaption(capDefault());   // refresh the resting hint (unless mid-hover)
 }
-// true while the pointer is resting on a zone (a side is latched), so a re-render
-// doesn't stomp the live hover caption
-function el0Hovered() { return $('c-tap-prose').dataset.side || $('c-tap-attr').dataset.side; }
 
 // ── board passphrase (set / update via a dialog) ──────────────────────
 // The passphrase field lives in a dialog opened by the "Set / Update passphrase"

--- a/web/compose.html
+++ b/web/compose.html
@@ -288,8 +288,7 @@ body[data-style="midnight"] .drawer { box-shadow:-24px 0 60px -28px rgba(0,0,0,.
    wording on the paragraph, payload nonce on the trailer). Purely a shortcut for
    the steppers in Settings; text selection still works (a click inside an active
    selection is ignored — see wireTapZone). The chevrons stay tucked in the card's
-   padding gutter — never past the border — and are hidden until the first tap
-   (tz-on), then mark each live region as steppable. */
+   padding gutter — never past the border. */
 .pv-tap { position:relative; }
 .pv-tap.is-tappable { cursor:pointer; }
 .pv-tap .tz {
@@ -300,12 +299,13 @@ body[data-style="midnight"] .drawer { box-shadow:-24px 0 60px -28px rgba(0,0,0,.
 }
 .pv-tap .tz.l { left:-15px; justify-content:flex-start; }
 .pv-tap .tz.r { right:-15px; justify-content:flex-end; }
-/* revealed only after the first tap (tz-on), and only where the zone is live;
-   brighter on hover, brightest on the side the pointer is over */
-.pv-tap.is-tappable.tz-on .tz { opacity:.24; }
-.pv-tap.is-tappable.tz-on:hover .tz { opacity:.42; }
-.pv-tap.is-tappable.tz-on[data-side="l"] .tz.l,
-.pv-tap.is-tappable.tz-on[data-side="r"] .tz.r { opacity:.9; }
+/* the right chevron (step forward) sits faded whenever a zone is live; the left
+   chevron (step back) appears only once the variant is past 0 — i.e. there's a
+   lower variant to return to. The side under the pointer brightens to full. */
+.pv-tap.is-tappable .tz.r { opacity:.24; }
+.pv-tap.is-tappable.has-prev .tz.l { opacity:.24; }
+.pv-tap.is-tappable[data-side="r"] .tz.r { opacity:.9; }
+.pv-tap.is-tappable.has-prev[data-side="l"] .tz.l { opacity:.9; }
 .share { margin-bottom:8px; }
 .share label:first-of-type { margin-top:0; }
 .share-btn { margin-top:2px; padding:10px 16px; font-size:12.5px; display:inline-flex; align-items:center; gap:8px; }
@@ -1230,13 +1230,13 @@ $('c-best-inc').addEventListener('click', () => setBestOf(bestOf + 1));
 // different cover text); tapping the trailer steps the PAYLOAD variant, which
 // redraws the salt → the nonce, so the payload words (and the Latin trailer that
 // carries the salt) change. Both just call the same setters the Settings steppers
-// use, so decoding is unaffected and preview/publish stay in step. The chevrons
-// stay hidden until the first tap, then mark the live regions as steppable.
+// use, so decoding is unaffected and preview/publish stay in step. The forward (›)
+// chevron sits faded on every live zone; the back (‹) one only shows once its
+// variant is past 0 (see syncTapZones).
 function tapSide(el, e) {
   const r = el.getBoundingClientRect();
   return (e.clientX - r.left) < r.width / 2 ? 'l' : 'r';
 }
-function revealTapZones() { $('c-tap-prose').classList.add('tz-on'); $('c-tap-attr').classList.add('tz-on'); }
 function wireTapZone(el, step) {
   el.addEventListener('mousemove', (e) => { if (el.classList.contains('is-tappable')) el.dataset.side = tapSide(el, e); });
   el.addEventListener('mouseleave', () => { delete el.dataset.side; });
@@ -1245,7 +1245,6 @@ function wireTapZone(el, step) {
     // a click that finishes a text selection inside the zone shouldn't also step
     const sel = window.getSelection();
     if (sel && !sel.isCollapsed && sel.anchorNode && el.contains(sel.anchorNode)) return;
-    revealTapZones();                                  // first tap unveils the chevrons
     step(tapSide(el, e) === 'l' ? -1 : 1);
   });
 }
@@ -1254,11 +1253,14 @@ wireTapZone($('c-tap-attr'),  (d) => setPayloadVariant(payloadVariant + d));
 // Enable a zone only when it can actually do something: the paragraph needs cover
 // words on (its variant is a no-op otherwise, mirroring the disabled stepper); the
 // trailer needs an encrypted artifact (so a Latin trailer is present to redraw).
+// has-prev gates the back chevron — shown only when the variant can step down.
 function syncTapZones() {
   const hasBody = !!(lastBody && lastBody.trim());
   const hasTrailer = !!$('c-pv-attr').textContent.trim();
   $('c-tap-prose').classList.toggle('is-tappable', hasBody && $('c-cover').checked);
   $('c-tap-attr').classList.toggle('is-tappable', hasBody && hasTrailer);
+  $('c-tap-prose').classList.toggle('has-prev', coverVariant > 0);
+  $('c-tap-attr').classList.toggle('has-prev', payloadVariant > 0);
 }
 
 // ── board passphrase (set / update via a dialog) ──────────────────────

--- a/web/compose.html
+++ b/web/compose.html
@@ -281,7 +281,30 @@ body[data-style="midnight"] .drawer { box-shadow:-24px 0 60px -28px rgba(0,0,0,.
 .drawer-body label:first-of-type { margin-top:8px; }
 
 /* live preview */
-.pv-caption { margin-top:14px; font:400 12px/1.55 'Public Sans',sans-serif; color:var(--dim); }
+.pv-caption { margin-top:14px; font:400 12px/1.55 'Public Sans',sans-serif; color:var(--dim); min-height:1.55em; transition:color .18s ease; }
+
+/* tap zones on the preview — the body paragraph and the trailer each become a
+   left/right pair of click targets that step a deterministic variant (cover
+   wording on the paragraph, payload nonce on the trailer). Purely a discoverable
+   shortcut for the steppers in Settings; the chevrons sit in the card's padding
+   gutter so they never overlap the prose, and text selection still works (a click
+   that lands inside an active selection is ignored — see wireTapZone). */
+.pv-tap { position:relative; }
+.pv-tap.is-tappable { cursor:pointer; }
+.pv-tap .tz {
+  position:absolute; top:0; bottom:0; width:1.4em; display:flex; align-items:center;
+  pointer-events:none; opacity:0; color:currentColor;
+  font:400 22px/1 'IBM Plex Mono',monospace; user-select:none;
+  transition:opacity .18s ease;
+}
+.pv-tap .tz.l { left:-1.55em; justify-content:flex-start; }
+.pv-tap .tz.r { right:-1.55em; justify-content:flex-end; }
+/* a faint always-on hint that the region is tappable (visible on touch too),
+   brighter on hover, and brightest on the side the pointer is over */
+.pv-tap.is-tappable .tz { opacity:.14; }
+.pv-tap.is-tappable:hover .tz { opacity:.3; }
+.pv-tap.is-tappable[data-side="l"] .tz.l,
+.pv-tap.is-tappable[data-side="r"] .tz.r { opacity:.85; }
 .share { margin-bottom:8px; }
 .share label:first-of-type { margin-top:0; }
 .share-btn { margin-top:2px; padding:10px 16px; font-size:12.5px; display:inline-flex; align-items:center; gap:8px; }
@@ -551,13 +574,25 @@ body[data-hl="on"] .preview[data-style="terminal"]    .pv-prose .pw { font-weigh
       <div id="c-live-preview">
         <div class="preview" id="c-preview-card" data-style="letterpress">
           <div class="pv-subject hidden" id="c-pv-subject"></div>
-          <p class="pv-prose" id="c-pv-prose">Your prose will appear here as you type…</p>
-          <div class="pv-attr" id="c-pv-attr"></div>
+          <!-- tap zones: left/right halves of the paragraph step the cover variant
+               (wording only); the trailer's halves step the payload variant, which
+               redraws the salt → nonce. Both are shortcuts for the Settings steppers. -->
+          <div class="pv-tap" id="c-tap-prose">
+            <p class="pv-prose" id="c-pv-prose">Your prose will appear here as you type…</p>
+            <span class="tz l" aria-hidden="true">‹</span>
+            <span class="tz r" aria-hidden="true">›</span>
+          </div>
+          <div class="pv-tap" id="c-tap-attr">
+            <div class="pv-attr" id="c-pv-attr"></div>
+            <span class="tz l" aria-hidden="true">‹</span>
+            <span class="tz r" aria-hidden="true">›</span>
+          </div>
           <div class="pv-decoded">
             <div class="pv-dec-label">decoded</div>
             <div class="pv-dec-text" id="c-pv-msg">Free Samourai</div>
           </div>
         </div>
+        <div class="pv-caption" id="c-pv-caption">Tap the paragraph ‹ › to reshuffle the wording · tap the trailer for a fresh nonce.</div>
       </div>
     </aside>
   </div>
@@ -1088,7 +1123,7 @@ async function regenPreview() {
   syncMeta();
   updateMode();
   const msg = $('c-msg').value;
-  if (!msg.trim()) { $('c-pv-prose').textContent = 'Your prose will appear here as you type…'; $('c-pv-attr').textContent = ''; $('c-pv-msg').textContent = 'Your decrypted message appears here.'; lastBody = ''; updateLen(null); return; }
+  if (!msg.trim()) { $('c-pv-prose').textContent = 'Your prose will appear here as you type…'; $('c-pv-attr').textContent = ''; $('c-pv-msg').textContent = 'Your decrypted message appears here.'; lastBody = ''; updateLen(null); syncTapZones(); return; }
   if (!ready) { $('c-pv-prose').textContent = 'Loading the Glossia engine…'; return; }
   try {
     const cred = contentKey();                                // board key by default; custom read key when set
@@ -1100,6 +1135,7 @@ async function regenPreview() {
     $('c-pv-attr').textContent = attr ? '— ' + attr : '';
     lastBody = enc.body;
     updateLen(enc.body);
+    syncTapZones();
     // Live round-trip: decode the artifact we just built and show the recovered
     // message — a real reversal check, not an echo of the input.
     try {
@@ -1116,6 +1152,7 @@ async function regenPreview() {
     $('c-pv-attr').textContent = '';
     lastBody = '';
     updateLen(null);
+    syncTapZones();
   }
 }
 // A shared post carries the bulletin's body and adds the board link; X counts a
@@ -1186,6 +1223,60 @@ function setBestOf(n) {
 $('c-best').addEventListener('input', () => setBestOf($('c-best').value));
 $('c-best-dec').addEventListener('click', () => setBestOf(bestOf - 1));
 $('c-best-inc').addEventListener('click', () => setBestOf(bestOf + 1));
+
+// ── tap zones on the preview ──────────────────────────────────────────
+// The rendered artifact is "<body> — <trailer>". Tapping the left/right half of
+// the body paragraph steps the COVER variant (re-wraps the same payload words in
+// different cover text); tapping the trailer steps the PAYLOAD variant, which
+// redraws the salt → the nonce, so the payload words (and the Latin trailer that
+// carries the salt) change. Both just call the same setters the Settings steppers
+// use, so decoding is unaffected and preview/publish stay in step.
+function setCaption(txt) { $('c-pv-caption').textContent = txt; }
+// The resting caption describes whichever zones are live right now (the paragraph
+// drops out when cover words are off; both drop out before any prose exists).
+function capDefault() {
+  const p = $('c-tap-prose').classList.contains('is-tappable');
+  const t = $('c-tap-attr').classList.contains('is-tappable');
+  if (p && t) return 'Tap the paragraph ‹ › to reshuffle the wording · tap the trailer for a fresh nonce.';
+  if (t) return 'Tap the trailer ‹ › for a fresh nonce — new payload words.';
+  if (p) return 'Tap the paragraph ‹ › to reshuffle the cover wording.';
+  return '';
+}
+function tapSide(el, e) {
+  const r = el.getBoundingClientRect();
+  return (e.clientX - r.left) < r.width / 2 ? 'l' : 'r';
+}
+function wireTapZone(el, { label, get, step }) {
+  el.addEventListener('mousemove', (e) => {
+    if (!el.classList.contains('is-tappable')) return;
+    el.dataset.side = tapSide(el, e);
+    setCaption(`${label} — variant ${get()} · tap ‹ back  ·  forward ›`);
+  });
+  el.addEventListener('mouseleave', () => { delete el.dataset.side; setCaption(capDefault()); });
+  el.addEventListener('click', (e) => {
+    if (!el.classList.contains('is-tappable')) return;
+    // a click that finishes a text selection inside the zone shouldn't also step
+    const sel = window.getSelection();
+    if (sel && !sel.isCollapsed && sel.anchorNode && el.contains(sel.anchorNode)) return;
+    step(tapSide(el, e) === 'l' ? -1 : 1);
+  });
+}
+wireTapZone($('c-tap-prose'), { label: 'Cover wording', get: () => coverVariant, step: (d) => setCoverVariant(coverVariant + d) });
+wireTapZone($('c-tap-attr'),  { label: 'Nonce (trailer)', get: () => payloadVariant, step: (d) => setPayloadVariant(payloadVariant + d) });
+// Enable a zone only when it can actually do something: the paragraph needs cover
+// words on (its variant is a no-op otherwise, mirroring the disabled stepper); the
+// trailer needs an encrypted artifact (so a Latin trailer is present to redraw).
+function syncTapZones() {
+  const hasBody = !!(lastBody && lastBody.trim());
+  const coverOn = $('c-cover').checked;
+  const hasTrailer = !!$('c-pv-attr').textContent.trim();
+  $('c-tap-prose').classList.toggle('is-tappable', hasBody && coverOn);
+  $('c-tap-attr').classList.toggle('is-tappable', hasBody && hasTrailer);
+  if (!el0Hovered()) setCaption(capDefault());   // refresh the resting hint (unless mid-hover)
+}
+// true while the pointer is resting on a zone (a side is latched), so a re-render
+// doesn't stomp the live hover caption
+function el0Hovered() { return $('c-tap-prose').dataset.side || $('c-tap-attr').dataset.side; }
 
 // ── board passphrase (set / update via a dialog) ──────────────────────
 // The passphrase field lives in a dialog opened by the "Set / Update passphrase"


### PR DESCRIPTION
Make the live preview directly interactive: clicking the left/right half of
the body paragraph steps the cover variant (re-wraps the same payload words in
different cover text), and clicking the trailer's halves steps the payload
variant, which redraws the salt — the nonce — so the payload words and the Latin
trailer change. Both are discoverable shortcuts that call the same setters as the
Settings steppers, so preview/publish stay in step and decoding is unaffected.

Faint chevrons in the card's padding gutter mark each region as tappable
(brightest on the side the pointer is over), a caption below the preview explains
the gesture and shows the live variant number, and text selection still works.
A zone activates only when it can do something: the paragraph needs cover words
on, the trailer needs an encrypted artifact.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GpEbFRC9PRYgHMqrYnby37