### PR TITLE
Add /bitcoin page: a block explorer that encodes transaction data into Glossia prose

### DIFF
--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -129,7 +129,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    even when a margin only holds a single glyph. fit-content grows a track
    only as far as its own content needs, capped at the given length. */
 .tx-grid { display: grid; grid-template-columns: fit-content(11em) 1fr fit-content(8em); column-gap: 18px; row-gap: .55em; align-items: baseline; }
-.tx-margin-left, .tx-margin-right { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--meta); }
+.tx-margin-left, .tx-margin-right { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--dim); }
 .tx-margin-left { text-align: right; }
 .tx-margin-right { text-align: left; }
 .tx-body-lead::first-letter {

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -179,6 +179,11 @@ const $ = (id) => document.getElementById(id);
 const ESPLORA = 'https://blockstream.info/api';
 const PAGE_SIZE = 25;   // matches Esplora's own /block/:hash/txs/:start_index granularity
 
+// Esplora's block hash, like a txid, is displayed byte-reversed relative to its
+// internal (wire/hashing) byte order -- see btc-tx.js's txid handling. Reverse
+// it back before encoding so the prose carries the hash's actual bytes.
+function reverseHex(hex) { return (hex.match(/../g) || []).reverse().join(''); }
+
 let ready = false;
 init().then(() => { ready = true; }).catch((e) => console.error('WASM init failed:', e));
 
@@ -262,7 +267,7 @@ async function readChapter(input, page) {
 
 function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
   $('ch-height').textContent = block.height.toLocaleString();
-  const { prose: hashProse } = encodeSeedPhrase(hash, 'english');
+  const { prose: hashProse } = encodeSeedPhrase(reverseHex(hash), 'english');
   $('ch-hash-short').textContent = hashProse;
   $('ch-hash-short').title = hash;
   const when = new Date(block.timestamp * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -95,6 +95,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 /* ── the chapter itself: a manuscript page, not a utility card ── */
 #chapter { margin-top: 48px; }
 .chapter-head { text-align: center; padding-bottom: 34px; margin-bottom: 34px; border-bottom: 1px solid var(--rule); }
+.chapter-num { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.3em; text-transform:uppercase; color: var(--accent); margin-bottom: 14px; }
 .chapter-title { font: 500 34px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 12px; letter-spacing: -.01em; }
 .chapter-hash { font: italic 400 15px/1.5 'Newsreader',serif; color: var(--meta); margin: 0 auto 16px; max-width: 46ch; }
 .chapter-meta { font: 400 12.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
@@ -150,7 +151,8 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
   <article id="chapter" class="hidden">
     <header class="chapter-head">
-      <h1 class="chapter-title">Chapter <span id="ch-height"></span></h1>
+      <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span id="ch-book"></span></div>
+      <h1 class="chapter-title">Chapter <span id="ch-chapter"></span></h1>
       <div class="chapter-hash" id="ch-hash-short"></div>
       <div class="chapter-meta" id="ch-meta"></div>
     </header>
@@ -193,6 +195,30 @@ function trimTrailingZeroBytes(hex) {
   let end = hex.length;
   while (end >= 2 && hex.slice(end - 2, end) === '00') end -= 2;
   return hex.slice(0, end);
+}
+
+// The book's three-tier numbering: Volume = halving era (210,000 blocks --
+// the block subsidy halves at each boundary), Book = a difficulty-adjustment
+// window (2016 blocks -- Bitcoin retargets every 2016 blocks), Chapter = a
+// block's position within its book. 210000 isn't a multiple of 2016
+// (210000/2016 ~= 104.17), so book numbering restarts at 1 with each volume
+// rather than counting real global difficulty periods -- the last book of
+// every era is a shorter, truncated one (336 blocks instead of 2016).
+const ERA_BLOCKS = 210000;
+const DIFFICULTY_BLOCKS = 2016;
+function volumeBookChapter(height) {
+  const volumeIndex = Math.floor(height / ERA_BLOCKS);
+  const eraStart = volumeIndex * ERA_BLOCKS;
+  const offsetInEra = height - eraStart;
+  const bookIndex = Math.floor(offsetInEra / DIFFICULTY_BLOCKS);
+  const bookStart = eraStart + bookIndex * DIFFICULTY_BLOCKS;
+  const bookLength = Math.min(DIFFICULTY_BLOCKS, ERA_BLOCKS - bookIndex * DIFFICULTY_BLOCKS);
+  return {
+    volume: volumeIndex + 1,
+    book: bookIndex + 1,
+    chapter: height - bookStart + 1,
+    chapterCount: bookLength,
+  };
 }
 
 let ready = false;
@@ -277,12 +303,15 @@ async function readChapter(input, page) {
 }
 
 function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
-  $('ch-height').textContent = block.height.toLocaleString();
+  const { volume, book, chapter, chapterCount } = volumeBookChapter(block.height);
+  $('ch-volume').textContent = volume.toLocaleString();
+  $('ch-book').textContent = book.toLocaleString();
+  $('ch-chapter').textContent = `${chapter.toLocaleString()} of ${chapterCount.toLocaleString()}`;
   const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(hash)), 'english', BEST_OF);
   $('ch-hash-short').textContent = hashProse;
   $('ch-hash-short').title = hash;
   const when = new Date(block.timestamp * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
-  $('ch-meta').innerHTML = `<span>${when}</span><span>${totalTx.toLocaleString()} transaction${totalTx === 1 ? '' : 's'}</span><span>${block.size.toLocaleString()} B</span><span>weight ${block.weight.toLocaleString()} WU</span>`;
+  $('ch-meta').innerHTML = `<span>block ${block.height.toLocaleString()}</span><span>${when}</span><span>${totalTx.toLocaleString()} transaction${totalTx === 1 ? '' : 's'}</span><span>${block.size.toLocaleString()} B</span><span>weight ${block.weight.toLocaleString()} WU</span>`;
 
   const body = $('ch-paragraphs');
   body.innerHTML = '';

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -133,7 +133,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .appendix-mark { font: 500 11px/1 'IBM Plex Mono',monospace; color: var(--accent); margin-right: .5em; font-style: normal; }
 
 .chapter-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin-top: 54px; padding-top: 24px; border-top: 1px solid var(--rule); }
-.chapter-nav .page-status { font: 400 12.5px/1 'IBM Plex Mono',monospace; color: var(--meta); }
 </style>
 </head>
 <body>
@@ -174,7 +173,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
     <nav class="chapter-nav">
       <button type="button" id="page-prev">← Previous</button>
-      <span class="page-status" id="page-status"></span>
       <button type="button" id="page-next">Next →</button>
     </nav>
   </article>
@@ -184,7 +182,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 import { init, encodeSeedPhrase } from './glossia-msg.js';
 import { parseTransaction, computeTxid } from './btc-tx.js';
 import { describeTransaction } from './btc-prose.js';
-import { volumeBookChapter, PAGE_SIZE } from './btc-citation.js';
+import { volumeBookChapter } from './btc-citation.js';
 
 const $ = (id) => document.getElementById(id);
 const ESPLORA = 'https://blockstream.info/api';
@@ -226,58 +224,112 @@ async function resolveBlockHash(input) {
   throw new Error('Enter a block height (e.g. 0) or a 64-character block hash.');
 }
 
-async function readChapter(input, page) {
+// The current block's info + full ordered txid list, plus which transaction
+// within it is on screen -- fetched once per block, so stepping between
+// transactions inside it needs no further list fetch. `null` before the
+// first successful load.
+let state = null;   // { hash, height, block, txids, index }
+
+// The chain tip isn't knowable in advance -- discovered only by trying to
+// fetch the next block and having it 404 -- so it's cached once learned
+// rather than reprobed on every step off the same last block.
+let tipHeight = null;
+
+async function loadBlockMeta(hash) {
+  const [blockRes, txidsRes] = await Promise.all([
+    fetch(`${ESPLORA}/block/${hash}`),
+    fetch(`${ESPLORA}/block/${hash}/txids`),
+  ]);
+  if (!blockRes.ok) throw new Error(`Esplora returned ${blockRes.status} fetching block info.`);
+  if (!txidsRes.ok) throw new Error(`Esplora returned ${txidsRes.status} fetching the transaction list.`);
+  const block = await blockRes.json();
+  const txids = await txidsRes.json();
+  return { hash, height: block.height, block, txids };
+}
+
+async function loadBlockByHeight(height) {
+  const res = await fetch(`${ESPLORA}/block-height/${height}`);
+  if (!res.ok) throw new Error(res.status === 404 ? `No block at height ${height}.` : `Esplora returned ${res.status}.`);
+  return loadBlockMeta((await res.text()).trim());
+}
+
+async function showCurrentTx() {
+  setStatus('<span class="spinner"></span>fetching transaction…');
+  const txid = state.txids[state.index];
+  const r = await fetch(`${ESPLORA}/tx/${txid}/hex`);
+  if (!r.ok) throw new Error(`Esplora returned ${r.status} fetching tx ${txid.slice(0, 8)}…`);
+  const hex = (await r.text()).trim();
+
+  if (!ready) await init().catch(() => {});
+  setStatus('<span class="spinner"></span>encoding as prose…');
+
+  const parsed = parseTransaction(hex);
+  const verifiedTxid = await computeTxid(parsed.baseHex);
+  const { prose: bodyProse } = describeTransaction(parsed, BEST_OF);
+  const witness = parsed.witnessHex ? encodeSeedPhrase(parsed.witnessHex, 'english', BEST_OF) : null;
+
+  renderChapter({
+    num: state.index + 1, txid, prose: bodyProse,
+    verified: verifiedTxid === txid, witnessProse: witness ? witness.prose : null,
+  });
+  updateUrl();
+  $('chapter').classList.remove('hidden');
+  setStatus('');
+}
+
+function renderChapter(para) {
+  const { volume, book, chapter } = volumeBookChapter(state.height);
+  $('ch-volume').textContent = volume.toLocaleString();
+  $('ch-book').textContent = book.toLocaleString();
+  // Volume 1, Book 1, Chapter 1 is block 0 -- the Genesis block -- so it
+  // earns its own title rather than just being "Chapter 1".
+  $('ch-title').textContent = (volume === 1 && book === 1 && chapter === 1) ? 'Genesis' : `Chapter ${chapter.toLocaleString()}`;
+  const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(state.hash)), 'english', BEST_OF);
+  $('ch-hash-short').textContent = hashProse;
+  $('ch-hash-short').title = state.hash;
+
+  const body = $('ch-paragraphs');
+  body.innerHTML = '';
+  const el = document.createElement('p');
+  el.className = 'para' + (para.verified ? '' : ' unverified');
+  const titleAttr = `txid ${para.txid}${para.verified ? '' : ' — could not be independently verified'}`;
+  const markInner = para.witnessProse
+    ? `<a href="#appendix-1" title="${titleAttr}">${para.num}</a>`
+    : `<span title="${titleAttr}">${para.num}</span>`;
+  el.innerHTML = `<span class="para-mark">${markInner}</span>${para.prose}`;
+  body.append(el);
+
+  const appendixEl = $('ch-appendix');
+  appendixEl.innerHTML = '';
+  $('ch-appendix-section').classList.toggle('hidden', !para.witnessProse);
+  if (para.witnessProse) {
+    const a = document.createElement('p');
+    a.className = 'appendix-entry';
+    a.id = 'appendix-1';
+    a.innerHTML = `<span class="appendix-mark">¶${para.num}</span>${para.witnessProse}`;
+    appendixEl.append(a);
+  }
+
+  $('page-prev').disabled = state.height === 0 && state.index === 0;
+  $('page-next').disabled = tipHeight !== null && state.height >= tipHeight && state.index >= state.txids.length - 1;
+}
+
+function updateUrl() {
+  const params = new URLSearchParams();
+  params.set('block', String(state.height));
+  if (state.index) params.set('index', String(state.index));
+  history.replaceState(null, '', `${location.pathname}?${params.toString()}`);
+}
+
+async function openBlock(input, index) {
   $('chapter').classList.add('hidden');
   setStatus('<span class="spinner"></span>fetching block…');
   $('block-btn').disabled = true;
   try {
     const hash = await resolveBlockHash(input);
-
-    const [blockRes, txidsRes] = await Promise.all([
-      fetch(`${ESPLORA}/block/${hash}`),
-      fetch(`${ESPLORA}/block/${hash}/txids`),
-    ]);
-    if (!blockRes.ok) throw new Error(`Esplora returned ${blockRes.status} fetching block info.`);
-    if (!txidsRes.ok) throw new Error(`Esplora returned ${txidsRes.status} fetching the transaction list.`);
-    const block = await blockRes.json();
-    const txids = await txidsRes.json();
-
-    const maxPage = Math.max(0, Math.ceil(txids.length / PAGE_SIZE) - 1);
-    page = Math.min(Math.max(0, page), maxPage);
-    const start = page * PAGE_SIZE;
-    const pageTxids = txids.slice(start, start + PAGE_SIZE);
-
-    setStatus(`<span class="spinner"></span>fetching ${pageTxids.length} transaction${pageTxids.length === 1 ? '' : 's'}…`);
-    const hexes = await Promise.all(pageTxids.map(async (txid) => {
-      const r = await fetch(`${ESPLORA}/tx/${txid}/hex`);
-      if (!r.ok) throw new Error(`Esplora returned ${r.status} fetching tx ${txid.slice(0, 8)}…`);
-      return (await r.text()).trim();
-    }));
-
-    if (!ready) await init().catch(() => {});
-    setStatus('<span class="spinner"></span>encoding as prose…');
-
-    const paragraphs = [];
-    const appendix = [];
-    for (let i = 0; i < hexes.length; i++) {
-      const parsed = parseTransaction(hexes[i]);
-      const txid = pageTxids[i];
-      const verifiedTxid = await computeTxid(parsed.baseHex);
-      const num = start + i + 1;
-      const { prose: bodyProse } = describeTransaction(parsed, BEST_OF);
-      let appendixIndex = null;
-      if (parsed.witnessHex) {
-        const { prose: witProse } = encodeSeedPhrase(parsed.witnessHex, 'english', BEST_OF);
-        appendixIndex = appendix.length + 1;
-        appendix.push({ num, txid, prose: witProse });
-      }
-      paragraphs.push({ num, txid, prose: bodyProse, appendixIndex, verified: verifiedTxid === txid });
-    }
-
-    renderChapter(block, hash, page, maxPage, txids.length, paragraphs, appendix);
-    updateUrl(input, page);
-    $('chapter').classList.remove('hidden');
-    setStatus('');
+    const next = await loadBlockMeta(hash);
+    state = { ...next, index: Math.min(Math.max(0, index), next.txids.length - 1) };
+    await showCurrentTx();
   } catch (e) {
     setStatus(e.message || 'Failed to load chapter.', 'err');
   } finally {
@@ -285,64 +337,49 @@ async function readChapter(input, page) {
   }
 }
 
-function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
-  const { volume, book, chapter } = volumeBookChapter(block.height);
-  $('ch-volume').textContent = volume.toLocaleString();
-  $('ch-book').textContent = book.toLocaleString();
-  // Volume 1, Book 1, Chapter 1 is block 0 -- the Genesis block -- so it
-  // earns its own title rather than just being "Chapter 1".
-  $('ch-title').textContent = (volume === 1 && book === 1 && chapter === 1) ? 'Genesis' : `Chapter ${chapter.toLocaleString()}`;
-  const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(hash)), 'english', BEST_OF);
-  $('ch-hash-short').textContent = hashProse;
-  $('ch-hash-short').title = hash;
-
-  const body = $('ch-paragraphs');
-  body.innerHTML = '';
-  for (const p of paragraphs) {
-    const el = document.createElement('p');
-    el.className = 'para' + (p.verified ? '' : ' unverified');
-    const markInner = p.appendixIndex
-      ? `<a href="#appendix-${p.appendixIndex}" title="txid ${p.txid}${p.verified ? '' : ' — could not be independently verified'}">${p.num}</a>`
-      : `<span title="txid ${p.txid}${p.verified ? '' : ' — could not be independently verified'}">${p.num}</span>`;
-    el.innerHTML = `<span class="para-mark">${markInner}</span>${p.prose}`;
-    body.append(el);
+// direction: +1 (Next) or -1 (Previous). Steps within the current block's
+// transaction list; at either edge, crosses into the adjacent block (if one
+// exists) and continues from its first/last transaction.
+async function stepTx(direction) {
+  const withinBlock = state.index + direction;
+  if (withinBlock >= 0 && withinBlock < state.txids.length) {
+    state.index = withinBlock;
+    try {
+      await showCurrentTx();
+    } catch (e) {
+      setStatus(e.message || 'Failed to load transaction.', 'err');
+    }
+    return;
   }
 
-  const appendixEl = $('ch-appendix');
-  appendixEl.innerHTML = '';
-  $('ch-appendix-section').classList.toggle('hidden', !appendix.length);
-  for (const [i, a] of appendix.entries()) {
-    const el = document.createElement('p');
-    el.className = 'appendix-entry';
-    el.id = `appendix-${i + 1}`;
-    el.innerHTML = `<span class="appendix-mark">¶${a.num}</span>${a.prose}`;
-    appendixEl.append(el);
+  const newHeight = state.height + direction;
+  if (newHeight < 0) return;   // Genesis has no earlier block
+
+  $('page-prev').disabled = true;
+  $('page-next').disabled = true;
+  setStatus(`<span class="spinner"></span>loading ${direction > 0 ? 'next' : 'previous'} block…`);
+  try {
+    const next = await loadBlockByHeight(newHeight);
+    state = { ...next, index: direction > 0 ? 0 : next.txids.length - 1 };
+    await showCurrentTx();
+  } catch (e) {
+    if (direction > 0) tipHeight = state.height;
+    setStatus(direction > 0 ? 'No next block yet — this is the current chain tip.' : (e.message || 'Failed to load previous block.'), 'err');
+    $('page-prev').disabled = state.height === 0 && state.index === 0;
+    $('page-next').disabled = direction > 0;
   }
-
-  const start = page * PAGE_SIZE + 1;
-  const end = Math.min((page + 1) * PAGE_SIZE, totalTx);
-  $('page-status').textContent = `paragraphs ${start.toLocaleString()}–${end.toLocaleString()} of ${totalTx.toLocaleString()}`;
-  $('page-prev').disabled = page <= 0;
-  $('page-next').disabled = page >= maxPage;
-  $('page-prev').onclick = () => readChapter($('block-input').value, page - 1);
-  $('page-next').onclick = () => readChapter($('block-input').value, page + 1);
 }
 
-function updateUrl(input, page) {
-  const params = new URLSearchParams();
-  params.set('block', input.trim());
-  if (page) params.set('page', String(page));
-  history.replaceState(null, '', `${location.pathname}?${params.toString()}`);
-}
-
-$('block-btn').addEventListener('click', () => readChapter($('block-input').value, 0));
-$('block-input').addEventListener('keydown', (e) => { if (e.key === 'Enter') readChapter($('block-input').value, 0); });
+$('block-btn').addEventListener('click', () => openBlock($('block-input').value, 0));
+$('block-input').addEventListener('keydown', (e) => { if (e.key === 'Enter') openBlock($('block-input').value, 0); });
+$('page-prev').addEventListener('click', () => stepTx(-1));
+$('page-next').addEventListener('click', () => stepTx(1));
 
 const params = new URLSearchParams(location.search);
 const blockParam = params.get('block');
-const pageParam = parseInt(params.get('page'), 10) || 0;
+const indexParam = parseInt(params.get('index'), 10) || 0;
 if (blockParam) $('block-input').value = blockParam;
-readChapter($('block-input').value, pageParam);
+openBlock($('block-input').value, indexParam);
 </script>
 </body>
 </html>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -100,7 +100,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .chapter-meta { font: 400 12.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
 .chapter-meta span + span::before { content: ' · '; color: var(--rule); }
 
-.chapter-body { font-family: 'Newsreader', serif; font-size: 19px; line-height: 1.75; color: var(--ink-soft); }
+.chapter-body { font-family: 'Newsreader', serif; font-size: 19px; line-height: 1.75; color: var(--ink-soft); font-variant-numeric: oldstyle-nums; }
 .para { margin: 0 0 1.6em; text-indent: 1.6em; position: relative; }
 .para:first-of-type { text-indent: 0; }
 .para:first-of-type::first-letter {
@@ -145,7 +145,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <input type="text" id="block-input" class="mono" value="0" placeholder="e.g. 0, or a 64-character block hash" autocomplete="off" spellcheck="false">
       <button type="button" id="block-btn">Read chapter</button>
     </div>
-    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph; its witness stack, if any, becomes an appendix entry. Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
+    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, its witness stack an appendix entry. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits; the genuinely opaque bytes — prevout references, scripts — are what's rendered in prose. Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
     <div id="block-status" class="status-line hidden"></div>
   </div>
 
@@ -193,6 +193,36 @@ function trimTrailingZeroBytes(hex) {
   let end = hex.length;
   while (end >= 2 && hex.slice(end - 2, end) === '00') end -= 2;
   return hex.slice(0, end);
+}
+
+// Compose a transaction's paragraph: small structural integers (version, an
+// input's referenced output index and sequence, an output's value, locktime)
+// are spliced in as literal numerals rather than routed through the
+// wordlist -- they're exactly what produces long zero-byte word runs (see
+// the zero-run note above), and as plain digits they read as digits, not
+// noise. The genuinely opaque bytes (prevout txid, scriptSig, scriptPubKey)
+// stay Glossia-encoded, one call per field so its numeral sits right beside it.
+function describeTransaction(parsed) {
+  const clauses = [
+    `Version ${parsed.version}, ${parsed.vin.length} input${parsed.vin.length === 1 ? '' : 's'}, ${parsed.vout.length} output${parsed.vout.length === 1 ? '' : 's'}.`,
+  ];
+
+  for (const v of parsed.vin) {
+    const isNullPrevout = v.txid === '00'.repeat(32);
+    const opaqueHex = isNullPrevout ? v.scriptSig : v.txid + v.scriptSig;
+    const prose = opaqueHex ? encodeSeedPhrase(opaqueHex, 'english', BEST_OF).prose : '(empty script)';
+    clauses.push(isNullPrevout
+      ? `Minted new, unbacked by any prior output — its coinbase script speaks: ${prose} Sequence ${v.sequence}.`
+      : `Drawing on output ${v.vout} of an earlier hand, secured by: ${prose} Sequence ${v.sequence}.`);
+  }
+
+  for (const o of parsed.vout) {
+    const prose = o.scriptPubKey ? encodeSeedPhrase(o.scriptPubKey, 'english', BEST_OF).prose : '(empty script)';
+    clauses.push(`It pays ${o.value.toLocaleString()} satoshis to: ${prose}`);
+  }
+
+  clauses.push(`Locktime ${parsed.locktime}.`);
+  return clauses.join(' ');
 }
 
 let ready = false;
@@ -253,9 +283,9 @@ async function readChapter(input, page) {
       const parsed = parseTransaction(hexes[i]);
       const txid = pageTxids[i];
       const verifiedTxid = await computeTxid(parsed.baseHex);
-      const { prose: bodyProse } = encodeSeedPhrase(parsed.baseHex, 'english', BEST_OF);
       const num = start + i + 1;
       const isCoinbase = parsed.vin.length === 1 && parsed.vin[0].txid === '00'.repeat(32);
+      const bodyProse = describeTransaction(parsed);
       let appendixIndex = null;
       if (parsed.witnessHex) {
         const { prose: witProse } = encodeSeedPhrase(parsed.witnessHex, 'english', BEST_OF);

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -96,7 +96,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 #chapter { margin-top: 48px; }
 .chapter-head { text-align: center; padding-bottom: 34px; margin-bottom: 34px; border-bottom: 1px solid var(--rule); }
 .chapter-title { font: 500 34px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 12px; letter-spacing: -.01em; }
-.chapter-hash { font-size: 13px; color: var(--meta); margin-bottom: 14px; }
+.chapter-hash { font: italic 400 15px/1.5 'Newsreader',serif; color: var(--meta); margin: 0 auto 16px; max-width: 46ch; }
 .chapter-meta { font: 400 12.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
 .chapter-meta span + span::before { content: ' · '; color: var(--rule); }
 
@@ -152,7 +152,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <article id="chapter" class="hidden">
     <header class="chapter-head">
       <h1 class="chapter-title">Chapter <span id="ch-height"></span></h1>
-      <div class="chapter-hash mono" id="ch-hash-short"></div>
+      <div class="chapter-hash" id="ch-hash-short"></div>
       <div class="chapter-meta" id="ch-meta"></div>
     </header>
 
@@ -262,10 +262,8 @@ async function readChapter(input, page) {
 
 function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
   $('ch-height').textContent = block.height.toLocaleString();
-  // Every real block hash starts with a long run of zeros (that's what proof-of-work
-  // requires), so a leading-substring truncation shows nothing but zeros. Show both
-  // ends instead -- the tail is where a block hash's actual entropy lives.
-  $('ch-hash-short').textContent = hash.slice(0, 8) + '…' + hash.slice(-8);
+  const { prose: hashProse } = encodeSeedPhrase(hash, 'english');
+  $('ch-hash-short').textContent = hashProse;
   $('ch-hash-short').title = hash;
   const when = new Date(block.timestamp * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
   $('ch-meta').innerHTML = `<span>${when}</span><span>${totalTx.toLocaleString()} transaction${totalTx === 1 ? '' : 's'}</span><span>${block.size.toLocaleString()} B</span><span>weight ${block.weight.toLocaleString()} WU</span>`;

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -187,10 +187,10 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 import { init, encodeSeedPhrase } from './glossia-msg.js';
 import { parseTransaction, computeTxid } from './btc-tx.js';
 import { describeTransaction } from './btc-prose.js';
+import { volumeBookChapter, PAGE_SIZE } from './btc-citation.js';
 
 const $ = (id) => document.getElementById(id);
 const ESPLORA = 'https://blockstream.info/api';
-const PAGE_SIZE = 25;   // matches Esplora's own /block/:hash/txs/:start_index granularity
 const BEST_OF = 5;
 
 // Esplora's block hash, like a txid, is displayed byte-reversed relative to its
@@ -206,30 +206,6 @@ function trimTrailingZeroBytes(hex) {
   let end = hex.length;
   while (end >= 2 && hex.slice(end - 2, end) === '00') end -= 2;
   return hex.slice(0, end);
-}
-
-// The book's three-tier numbering: Volume = halving era (210,000 blocks --
-// the block subsidy halves at each boundary), Book = a difficulty-adjustment
-// window (2016 blocks -- Bitcoin retargets every 2016 blocks), Chapter = a
-// block's position within its book. 210000 isn't a multiple of 2016
-// (210000/2016 ~= 104.17), so book numbering restarts at 1 with each volume
-// rather than counting real global difficulty periods -- the last book of
-// every era is a shorter, truncated one (336 blocks instead of 2016).
-const ERA_BLOCKS = 210000;
-const DIFFICULTY_BLOCKS = 2016;
-function volumeBookChapter(height) {
-  const volumeIndex = Math.floor(height / ERA_BLOCKS);
-  const eraStart = volumeIndex * ERA_BLOCKS;
-  const offsetInEra = height - eraStart;
-  const bookIndex = Math.floor(offsetInEra / DIFFICULTY_BLOCKS);
-  const bookStart = eraStart + bookIndex * DIFFICULTY_BLOCKS;
-  const bookLength = Math.min(DIFFICULTY_BLOCKS, ERA_BLOCKS - bookIndex * DIFFICULTY_BLOCKS);
-  return {
-    volume: volumeIndex + 1,
-    book: bookIndex + 1,
-    chapter: height - bookStart + 1,
-    chapterCount: bookLength,
-  };
 }
 
 let ready = false;

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -132,14 +132,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .appendix-entry { margin: 0 0 1.5em; font: italic 400 15.5px/1.65 'Newsreader',serif; color: var(--meta); }
 .appendix-mark { font: 500 11px/1 'IBM Plex Mono',monospace; color: var(--accent); margin-right: .5em; font-style: normal; }
 
-.chapter-marginalia { margin-top: 48px; padding-top: 26px; border-top: 1px dashed var(--rule); }
-.chapter-marginalia h2 {
-  font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.24em; text-transform:uppercase;
-  color: var(--dim); margin: 0 0 18px; text-align: center;
-}
-.marginalia-entry { margin: 0 0 .9em; font: italic 400 14.5px/1.6 'Newsreader',serif; color: var(--meta); }
-.marginalia-mark { font: 500 11px/1 'IBM Plex Mono',monospace; color: var(--accent); margin-right: .5em; font-style: normal; }
-
 .chapter-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin-top: 54px; padding-top: 24px; border-top: 1px solid var(--rule); }
 .chapter-nav .page-status { font: 400 12.5px/1 'IBM Plex Mono',monospace; color: var(--meta); }
 </style>
@@ -175,11 +167,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
     <div class="chapter-body" id="ch-paragraphs"></div>
 
-    <div class="chapter-marginalia hidden" id="ch-marginalia-section">
-      <h2>Marginalia</h2>
-      <div id="ch-marginalia"></div>
-    </div>
-
     <div class="chapter-appendix hidden" id="ch-appendix-section">
       <h2>Appendix — Witness Data</h2>
       <div id="ch-appendix"></div>
@@ -195,7 +182,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
 <script type="module">
 import { init, encodeSeedPhrase } from './glossia-msg.js';
-import { parseTransaction, computeTxid, findTransactionAscii } from './btc-tx.js';
+import { parseTransaction, computeTxid } from './btc-tx.js';
 import { describeTransaction } from './btc-prose.js';
 import { volumeBookChapter, PAGE_SIZE } from './btc-citation.js';
 
@@ -272,13 +259,11 @@ async function readChapter(input, page) {
 
     const paragraphs = [];
     const appendix = [];
-    const marginalia = [];
     for (let i = 0; i < hexes.length; i++) {
       const parsed = parseTransaction(hexes[i]);
       const txid = pageTxids[i];
       const verifiedTxid = await computeTxid(parsed.baseHex);
       const num = start + i + 1;
-      const isCoinbase = parsed.vin.length === 1 && parsed.vin[0].txid === '00'.repeat(32);
       const { prose: bodyProse } = describeTransaction(parsed, BEST_OF);
       let appendixIndex = null;
       if (parsed.witnessHex) {
@@ -286,11 +271,10 @@ async function readChapter(input, page) {
         appendixIndex = appendix.length + 1;
         appendix.push({ num, txid, prose: witProse });
       }
-      for (const text of findTransactionAscii(parsed, isCoinbase)) marginalia.push({ num, txid, text });
-      paragraphs.push({ num, txid, prose: bodyProse, isCoinbase, appendixIndex, verified: verifiedTxid === txid });
+      paragraphs.push({ num, txid, prose: bodyProse, appendixIndex, verified: verifiedTxid === txid });
     }
 
-    renderChapter(block, hash, page, maxPage, txids.length, paragraphs, appendix, marginalia);
+    renderChapter(block, hash, page, maxPage, txids.length, paragraphs, appendix);
     updateUrl(input, page);
     $('chapter').classList.remove('hidden');
     setStatus('');
@@ -301,15 +285,7 @@ async function readChapter(input, page) {
   }
 }
 
-// Marginalia text comes directly from raw blockchain data -- a miner's
-// coinbase tag, an OP_RETURN message -- so unlike the Glossia-generated
-// prose (always built from our own wordlist), it's untrusted content and
-// must be escaped before it ever reaches innerHTML.
-function escapeHtml(s) {
-  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
-}
-
-function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix, marginalia) {
+function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
   const { volume, book, chapter } = volumeBookChapter(block.height);
   $('ch-volume').textContent = volume.toLocaleString();
   $('ch-book').textContent = book.toLocaleString();
@@ -328,16 +304,6 @@ function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix
       : `<span title="txid ${p.txid}${p.verified ? '' : ' — could not be independently verified'}">${p.num}</span>`;
     el.innerHTML = `<span class="para-mark">${markInner}</span>${p.prose}`;
     body.append(el);
-  }
-
-  const marginaliaEl = $('ch-marginalia');
-  marginaliaEl.innerHTML = '';
-  $('ch-marginalia-section').classList.toggle('hidden', !marginalia.length);
-  for (const m of marginalia) {
-    const el = document.createElement('p');
-    el.className = 'marginalia-entry';
-    el.innerHTML = `<span class="marginalia-mark">¶${m.num}</span>“${escapeHtml(m.text)}”`;
-    marginaliaEl.append(el);
   }
 
   const appendixEl = $('ch-appendix');

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -87,6 +87,16 @@ button:hover:not(:disabled) { background: var(--accent-2); }
 button:disabled { opacity: .4; cursor: not-allowed; }
 .hint { margin-top: 10px; font-size: 12.5px; color: var(--meta); }
 
+.about { margin-top: 16px; }
+.about summary {
+  cursor: pointer; font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.1em; text-transform:uppercase;
+  color: var(--dim); list-style: none;
+}
+.about summary::-webkit-details-marker { display: none; }
+.about summary::before { content: '+ '; color: var(--accent); }
+.about[open] summary::before { content: '– '; }
+.about .hint { margin-top: 10px; }
+
 .status-line { margin-top: 16px; font: 500 13px/1.4 'IBM Plex Mono',monospace; }
 .status-line.err { color: var(--error); }
 .spinner { display:inline-block; width:12px; height:12px; border:2px solid var(--rule); border-top-color: var(--accent); border-radius:50%; animation: spin .7s linear infinite; vertical-align: -1px; margin-right: 6px; }
@@ -98,8 +108,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .chapter-num { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.3em; text-transform:uppercase; color: var(--accent); margin-bottom: 14px; }
 .chapter-title { font: 500 34px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 12px; letter-spacing: -.01em; }
 .chapter-hash { font: italic 400 15px/1.5 'Newsreader',serif; color: var(--meta); margin: 0 auto 16px; max-width: 46ch; }
-.chapter-meta { font: 400 12.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
-.chapter-meta span + span::before { content: ' · '; color: var(--rule); }
 
 .chapter-body { font-family: 'Newsreader', serif; font-size: 19px; line-height: 1.75; color: var(--ink-soft); font-variant-numeric: oldstyle-nums; }
 .para { margin: 0 0 1.6em; text-indent: 1.6em; position: relative; }
@@ -134,9 +142,9 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 <body>
 <div class="wrap">
   <div class="masthead">
-    <span class="title">Glossia · Bitcoin Book</span>
+    <span class="title">The Bitcoin Book</span>
     <span class="sub">a block, read as a chapter</span>
-    <span class="home"><a href="./bitcoin.html">transaction lookup</a> &nbsp;·&nbsp; <a href="./index.html">demo</a></span>
+    <span class="home"><a href="./bitcoin.html">transaction lookup</a> &nbsp;·&nbsp; <a href="./index.html">Glossia</a></span>
   </div>
 
   <div class="card">
@@ -145,16 +153,19 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <input type="text" id="block-input" class="mono" value="0" placeholder="e.g. 0, or a 64-character block hash" autocomplete="off" spellcheck="false">
       <button type="button" id="block-btn">Read chapter</button>
     </div>
-    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, its witness stack an appendix entry. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits; the genuinely opaque bytes — prevout references, scripts — are what's rendered in prose. Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
     <div id="block-status" class="status-line hidden"></div>
   </div>
+
+  <details class="about">
+    <summary>About</summary>
+    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, its witness stack an appendix entry. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits; the genuinely opaque bytes — prevout references, scripts — are what's rendered in prose. Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
+  </details>
 
   <article id="chapter" class="hidden">
     <header class="chapter-head">
       <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span id="ch-book"></span></div>
       <h1 class="chapter-title">Chapter <span id="ch-chapter"></span></h1>
       <div class="chapter-hash" id="ch-hash-short"></div>
-      <div class="chapter-meta" id="ch-meta"></div>
     </header>
 
     <div class="chapter-body" id="ch-paragraphs"></div>
@@ -310,8 +321,6 @@ function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix
   const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(hash)), 'english', BEST_OF);
   $('ch-hash-short').textContent = hashProse;
   $('ch-hash-short').title = hash;
-  const when = new Date(block.timestamp * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
-  $('ch-meta').innerHTML = `<span>block ${block.height.toLocaleString()}</span><span>${when}</span><span>${totalTx.toLocaleString()} transaction${totalTx === 1 ? '' : 's'}</span><span>${block.size.toLocaleString()} B</span><span>weight ${block.weight.toLocaleString()} WU</span>`;
 
   const body = $('ch-paragraphs');
   body.innerHTML = '';

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -178,7 +178,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
   <article id="chapter" class="hidden">
     <header class="chapter-head">
-      <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span id="ch-book"></span></div>
+      <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span id="ch-book"></span><span id="ch-chapter-inline"></span></div>
       <h1 class="chapter-title" id="ch-title"></h1>
       <div class="chapter-hash" id="ch-hash-short"></div>
     </header>
@@ -300,18 +300,23 @@ function renderChapter(para) {
   const { volume, book, chapter } = volumeBookChapter(state.height);
   $('ch-volume').textContent = volume.toLocaleString();
   $('ch-book').textContent = book.toLocaleString();
-  // Volume 1, Book 1, Chapter 1 is block 0 -- the Genesis block -- so it
-  // earns its own title rather than just being "Chapter 1".
-  $('ch-title').textContent = (volume === 1 && book === 1 && chapter === 1) ? 'Genesis' : `Chapter ${chapter.toLocaleString()}`;
-  // The block-hash subtitle introduces the chapter as a whole, so it only
-  // belongs on the chapter's first transaction, not every one stepped to.
+
+  // The big title (and hash subtitle) introduce the chapter as a whole, so
+  // they only belong on its first transaction. Every later transaction
+  // instead folds the chapter number into the Volume/Book eyebrow line --
+  // "Volume 1 · Book 100 · Chapter 333" -- a running head, not a heading.
   const onFirstTx = state.index === 0;
+  // Volume 1, Book 1, Chapter 1 is block 0 -- the Genesis block -- so it
+  // earns its own title rather than just being "Chapter 1". Set both the
+  // big title and the inline running-head form unconditionally (not just
+  // whichever is visible) so neither goes stale while hidden.
+  $('ch-title').textContent = (volume === 1 && book === 1 && chapter === 1) ? 'Genesis' : `Chapter ${chapter.toLocaleString()}`;
+  $('ch-chapter-inline').textContent = onFirstTx ? '' : ` · Chapter ${chapter.toLocaleString()}`;
+  $('ch-title').classList.toggle('hidden', !onFirstTx);
   $('ch-hash-short').classList.toggle('hidden', !onFirstTx);
-  if (onFirstTx) {
-    const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(state.hash)), 'english', BEST_OF);
-    $('ch-hash-short').textContent = hashProse;
-    $('ch-hash-short').title = state.hash;
-  }
+  const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(state.hash)), 'english', BEST_OF);
+  $('ch-hash-short').textContent = hashProse;
+  $('ch-hash-short').title = state.hash;
 
   const body = $('ch-paragraphs');
   body.innerHTML = '';

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -178,6 +178,7 @@ import { parseTransaction, computeTxid } from './btc-tx.js';
 const $ = (id) => document.getElementById(id);
 const ESPLORA = 'https://blockstream.info/api';
 const PAGE_SIZE = 25;   // matches Esplora's own /block/:hash/txs/:start_index granularity
+const BEST_OF = 5;
 
 // Esplora's block hash, like a txid, is displayed byte-reversed relative to its
 // internal (wire/hashing) byte order -- see btc-tx.js's txid handling. Reverse
@@ -252,12 +253,12 @@ async function readChapter(input, page) {
       const parsed = parseTransaction(hexes[i]);
       const txid = pageTxids[i];
       const verifiedTxid = await computeTxid(parsed.baseHex);
-      const { prose: bodyProse } = encodeSeedPhrase(parsed.baseHex, 'english');
+      const { prose: bodyProse } = encodeSeedPhrase(parsed.baseHex, 'english', BEST_OF);
       const num = start + i + 1;
       const isCoinbase = parsed.vin.length === 1 && parsed.vin[0].txid === '00'.repeat(32);
       let appendixIndex = null;
       if (parsed.witnessHex) {
-        const { prose: witProse } = encodeSeedPhrase(parsed.witnessHex, 'english');
+        const { prose: witProse } = encodeSeedPhrase(parsed.witnessHex, 'english', BEST_OF);
         appendixIndex = appendix.length + 1;
         appendix.push({ num, txid, prose: witProse });
       }
@@ -277,7 +278,7 @@ async function readChapter(input, page) {
 
 function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
   $('ch-height').textContent = block.height.toLocaleString();
-  const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(hash)), 'english');
+  const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(hash)), 'english', BEST_OF);
   $('ch-hash-short').textContent = hashProse;
   $('ch-hash-short').title = hash;
   const when = new Date(block.timestamp * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -123,7 +123,12 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .para-mark a { color: var(--meta); text-decoration: none; }
 .para-mark a:hover { color: var(--accent); text-decoration: underline; }
 
-.tx-grid { display: grid; grid-template-columns: minmax(3.5em, 11em) 1fr minmax(3em, 8em); column-gap: 18px; row-gap: .55em; align-items: baseline; }
+/* fit-content, not minmax(min, <length>) -- a fixed-length max is still the
+   track's growth *target*, so grid's "maximize tracks" step fills it in
+   regardless of actual content, stealing width from the 1fr body column
+   even when a margin only holds a single glyph. fit-content grows a track
+   only as far as its own content needs, capped at the given length. */
+.tx-grid { display: grid; grid-template-columns: fit-content(11em) 1fr fit-content(8em); column-gap: 18px; row-gap: .55em; align-items: baseline; }
 .tx-margin-left, .tx-margin-right { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--meta); }
 .tx-margin-left { text-align: right; }
 .tx-margin-right { text-align: left; }

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -303,10 +303,10 @@ async function readChapter(input, page) {
 }
 
 function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
-  const { volume, book, chapter, chapterCount } = volumeBookChapter(block.height);
+  const { volume, book, chapter } = volumeBookChapter(block.height);
   $('ch-volume').textContent = volume.toLocaleString();
   $('ch-book').textContent = book.toLocaleString();
-  $('ch-chapter').textContent = `${chapter.toLocaleString()} of ${chapterCount.toLocaleString()}`;
+  $('ch-chapter').textContent = chapter.toLocaleString();
   const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(hash)), 'english', BEST_OF);
   $('ch-hash-short').textContent = hashProse;
   $('ch-hash-short').title = hash;

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -95,8 +95,8 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 /* ── the chapter itself: a manuscript page, not a utility card ── */
 #chapter { margin-top: 48px; }
 .chapter-head { text-align: center; padding-bottom: 34px; margin-bottom: 34px; border-bottom: 1px solid var(--rule); }
-.chapter-num { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.3em; text-transform:uppercase; color: var(--accent); margin-bottom: 14px; }
-.chapter-title { font: 500 34px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 14px; letter-spacing: -.01em; }
+.chapter-title { font: 500 34px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 12px; letter-spacing: -.01em; }
+.chapter-hash { font-size: 13px; color: var(--meta); margin-bottom: 14px; }
 .chapter-meta { font: 400 12.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
 .chapter-meta span + span::before { content: ' · '; color: var(--rule); }
 
@@ -151,8 +151,8 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
   <article id="chapter" class="hidden">
     <header class="chapter-head">
-      <div class="chapter-num">Chapter <span id="ch-height"></span></div>
-      <h1 class="chapter-title">Block <span id="ch-hash-short" class="mono"></span></h1>
+      <h1 class="chapter-title">Chapter <span id="ch-height"></span></h1>
+      <div class="chapter-hash mono" id="ch-hash-short"></div>
       <div class="chapter-meta" id="ch-meta"></div>
     </header>
 

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -174,6 +174,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 <script type="module">
 import { init, encodeSeedPhrase } from './glossia-msg.js';
 import { parseTransaction, computeTxid } from './btc-tx.js';
+import { describeTransaction } from './btc-prose.js';
 
 const $ = (id) => document.getElementById(id);
 const ESPLORA = 'https://blockstream.info/api';
@@ -193,35 +194,6 @@ function trimTrailingZeroBytes(hex) {
   let end = hex.length;
   while (end >= 2 && hex.slice(end - 2, end) === '00') end -= 2;
   return hex.slice(0, end);
-}
-
-// Compose a transaction's paragraph, wire field by wire field, in wire
-// order: small structural integers (version, counts, an input's referenced
-// output index and sequence, an output's value, locktime) are spliced in as
-// literal numerals -- they're exactly what produces long zero-byte word
-// runs (see the zero-run note above). Only the genuinely opaque bytes
-// (prevout txid, scriptSig, scriptPubKey) are still Glossia-encoded. No
-// added wording -- just the numbers where the numbers are.
-function endSentence(s) { s = s.trim(); return s.endsWith('.') ? s : s + '.'; }
-
-function describeTransaction(parsed) {
-  const parts = [`${parsed.version}.`, `${parsed.vin.length}.`];
-
-  for (const v of parsed.vin) {
-    const isNullPrevout = v.txid === '00'.repeat(32);
-    const txidPart = isNullPrevout ? '0' : encodeSeedPhrase(v.txid, 'english', BEST_OF).prose;
-    const scriptProse = v.scriptSig ? encodeSeedPhrase(v.scriptSig, 'english', BEST_OF).prose : '';
-    parts.push(endSentence(`${txidPart} ${v.vout} ${scriptProse} ${v.sequence}`));
-  }
-
-  parts.push(`${parsed.vout.length}.`);
-  for (const o of parsed.vout) {
-    const scriptProse = o.scriptPubKey ? encodeSeedPhrase(o.scriptPubKey, 'english', BEST_OF).prose : '';
-    parts.push(endSentence(`${o.value} ${scriptProse}`));
-  }
-
-  parts.push(`${parsed.locktime}.`);
-  return parts.join(' ').replace(/\s+/g, ' ').trim();
 }
 
 let ready = false;
@@ -284,7 +256,7 @@ async function readChapter(input, page) {
       const verifiedTxid = await computeTxid(parsed.baseHex);
       const num = start + i + 1;
       const isCoinbase = parsed.vin.length === 1 && parsed.vin[0].txid === '00'.repeat(32);
-      const bodyProse = describeTransaction(parsed);
+      const { prose: bodyProse } = describeTransaction(parsed, BEST_OF);
       let appendixIndex = null;
       if (parsed.witnessHex) {
         const { prose: witProse } = encodeSeedPhrase(parsed.witnessHex, 'english', BEST_OF);

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -125,7 +125,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 }
 .appendix-entry { margin: 0 0 1.5em; font: italic 400 15.5px/1.65 'Newsreader',serif; color: var(--meta); }
 .appendix-mark { font: 500 11px/1 'IBM Plex Mono',monospace; color: var(--accent); margin-right: .5em; font-style: normal; }
-.appendix-empty { text-align: center; font: italic 400 14px/1.6 'Newsreader',serif; color: var(--meta); }
 
 .chapter-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin-top: 54px; padding-top: 24px; border-top: 1px solid var(--rule); }
 .chapter-nav .page-status { font: 400 12.5px/1 'IBM Plex Mono',monospace; color: var(--meta); }
@@ -158,7 +157,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
     <div class="chapter-body" id="ch-paragraphs"></div>
 
-    <div class="chapter-appendix">
+    <div class="chapter-appendix hidden" id="ch-appendix-section">
       <h2>Appendix — Witness Data</h2>
       <div id="ch-appendix"></div>
     </div>
@@ -299,16 +298,13 @@ function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix
 
   const appendixEl = $('ch-appendix');
   appendixEl.innerHTML = '';
-  if (!appendix.length) {
-    appendixEl.innerHTML = '<p class="appendix-empty">No witness data on this page — every transaction here predates or opts out of segwit.</p>';
-  } else {
-    for (const [i, a] of appendix.entries()) {
-      const el = document.createElement('p');
-      el.className = 'appendix-entry';
-      el.id = `appendix-${i + 1}`;
-      el.innerHTML = `<span class="appendix-mark">¶${a.num}</span>${a.prose}`;
-      appendixEl.append(el);
-    }
+  $('ch-appendix-section').classList.toggle('hidden', !appendix.length);
+  for (const [i, a] of appendix.entries()) {
+    const el = document.createElement('p');
+    el.className = 'appendix-entry';
+    el.id = `appendix-${i + 1}`;
+    el.innerHTML = `<span class="appendix-mark">¶${a.num}</span>${a.prose}`;
+    appendixEl.append(el);
   }
 
   const start = page * PAGE_SIZE + 1;

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -122,9 +122,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 }
 .para-mark a { color: var(--meta); text-decoration: none; }
 .para-mark a:hover { color: var(--accent); text-decoration: underline; }
-.para.coinbase::after {
-  content: 'coinbase'; margin-left: .6em; font: italic 400 13px/1 'Newsreader',serif; color: var(--meta);
-}
 .para-txid { display:none; }   /* carries the txid for JS reference; hidden from the reading view */
 
 .chapter-appendix { margin-top: 56px; padding-top: 30px; border-top: 1px solid var(--rule); }
@@ -134,6 +131,14 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 }
 .appendix-entry { margin: 0 0 1.5em; font: italic 400 15.5px/1.65 'Newsreader',serif; color: var(--meta); }
 .appendix-mark { font: 500 11px/1 'IBM Plex Mono',monospace; color: var(--accent); margin-right: .5em; font-style: normal; }
+
+.chapter-marginalia { margin-top: 48px; padding-top: 26px; border-top: 1px dashed var(--rule); }
+.chapter-marginalia h2 {
+  font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.24em; text-transform:uppercase;
+  color: var(--dim); margin: 0 0 18px; text-align: center;
+}
+.marginalia-entry { margin: 0 0 .9em; font: italic 400 14.5px/1.6 'Newsreader',serif; color: var(--meta); }
+.marginalia-mark { font: 500 11px/1 'IBM Plex Mono',monospace; color: var(--accent); margin-right: .5em; font-style: normal; }
 
 .chapter-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin-top: 54px; padding-top: 24px; border-top: 1px solid var(--rule); }
 .chapter-nav .page-status { font: 400 12.5px/1 'IBM Plex Mono',monospace; color: var(--meta); }
@@ -170,6 +175,11 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
     <div class="chapter-body" id="ch-paragraphs"></div>
 
+    <div class="chapter-marginalia hidden" id="ch-marginalia-section">
+      <h2>Marginalia</h2>
+      <div id="ch-marginalia"></div>
+    </div>
+
     <div class="chapter-appendix hidden" id="ch-appendix-section">
       <h2>Appendix — Witness Data</h2>
       <div id="ch-appendix"></div>
@@ -185,7 +195,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
 <script type="module">
 import { init, encodeSeedPhrase } from './glossia-msg.js';
-import { parseTransaction, computeTxid } from './btc-tx.js';
+import { parseTransaction, computeTxid, findTransactionAscii } from './btc-tx.js';
 import { describeTransaction } from './btc-prose.js';
 import { volumeBookChapter, PAGE_SIZE } from './btc-citation.js';
 
@@ -262,6 +272,7 @@ async function readChapter(input, page) {
 
     const paragraphs = [];
     const appendix = [];
+    const marginalia = [];
     for (let i = 0; i < hexes.length; i++) {
       const parsed = parseTransaction(hexes[i]);
       const txid = pageTxids[i];
@@ -275,10 +286,11 @@ async function readChapter(input, page) {
         appendixIndex = appendix.length + 1;
         appendix.push({ num, txid, prose: witProse });
       }
+      for (const text of findTransactionAscii(parsed, isCoinbase)) marginalia.push({ num, txid, text });
       paragraphs.push({ num, txid, prose: bodyProse, isCoinbase, appendixIndex, verified: verifiedTxid === txid });
     }
 
-    renderChapter(block, hash, page, maxPage, txids.length, paragraphs, appendix);
+    renderChapter(block, hash, page, maxPage, txids.length, paragraphs, appendix, marginalia);
     updateUrl(input, page);
     $('chapter').classList.remove('hidden');
     setStatus('');
@@ -289,7 +301,15 @@ async function readChapter(input, page) {
   }
 }
 
-function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
+// Marginalia text comes directly from raw blockchain data -- a miner's
+// coinbase tag, an OP_RETURN message -- so unlike the Glossia-generated
+// prose (always built from our own wordlist), it's untrusted content and
+// must be escaped before it ever reaches innerHTML.
+function escapeHtml(s) {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix, marginalia) {
   const { volume, book, chapter } = volumeBookChapter(block.height);
   $('ch-volume').textContent = volume.toLocaleString();
   $('ch-book').textContent = book.toLocaleString();
@@ -302,12 +322,22 @@ function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix
   body.innerHTML = '';
   for (const p of paragraphs) {
     const el = document.createElement('p');
-    el.className = 'para' + (p.isCoinbase ? ' coinbase' : '') + (p.verified ? '' : ' unverified');
+    el.className = 'para' + (p.verified ? '' : ' unverified');
     const markInner = p.appendixIndex
       ? `<a href="#appendix-${p.appendixIndex}" title="txid ${p.txid}${p.verified ? '' : ' — could not be independently verified'}">${p.num}</a>`
       : `<span title="txid ${p.txid}${p.verified ? '' : ' — could not be independently verified'}">${p.num}</span>`;
     el.innerHTML = `<span class="para-mark">${markInner}</span>${p.prose}`;
     body.append(el);
+  }
+
+  const marginaliaEl = $('ch-marginalia');
+  marginaliaEl.innerHTML = '';
+  $('ch-marginalia-section').classList.toggle('hidden', !marginalia.length);
+  for (const m of marginalia) {
+    const el = document.createElement('p');
+    el.className = 'marginalia-entry';
+    el.innerHTML = `<span class="marginalia-mark">¶${m.num}</span>“${escapeHtml(m.text)}”`;
+    marginaliaEl.append(el);
   }
 
   const appendixEl = $('ch-appendix');

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -195,34 +195,33 @@ function trimTrailingZeroBytes(hex) {
   return hex.slice(0, end);
 }
 
-// Compose a transaction's paragraph: small structural integers (version, an
-// input's referenced output index and sequence, an output's value, locktime)
-// are spliced in as literal numerals rather than routed through the
-// wordlist -- they're exactly what produces long zero-byte word runs (see
-// the zero-run note above), and as plain digits they read as digits, not
-// noise. The genuinely opaque bytes (prevout txid, scriptSig, scriptPubKey)
-// stay Glossia-encoded, one call per field so its numeral sits right beside it.
+// Compose a transaction's paragraph, wire field by wire field, in wire
+// order: small structural integers (version, counts, an input's referenced
+// output index and sequence, an output's value, locktime) are spliced in as
+// literal numerals -- they're exactly what produces long zero-byte word
+// runs (see the zero-run note above). Only the genuinely opaque bytes
+// (prevout txid, scriptSig, scriptPubKey) are still Glossia-encoded. No
+// added wording -- just the numbers where the numbers are.
+function endSentence(s) { s = s.trim(); return s.endsWith('.') ? s : s + '.'; }
+
 function describeTransaction(parsed) {
-  const clauses = [
-    `Version ${parsed.version}, ${parsed.vin.length} input${parsed.vin.length === 1 ? '' : 's'}, ${parsed.vout.length} output${parsed.vout.length === 1 ? '' : 's'}.`,
-  ];
+  const parts = [`${parsed.version}.`, `${parsed.vin.length}.`];
 
   for (const v of parsed.vin) {
     const isNullPrevout = v.txid === '00'.repeat(32);
-    const opaqueHex = isNullPrevout ? v.scriptSig : v.txid + v.scriptSig;
-    const prose = opaqueHex ? encodeSeedPhrase(opaqueHex, 'english', BEST_OF).prose : '(empty script)';
-    clauses.push(isNullPrevout
-      ? `Minted new, unbacked by any prior output — its coinbase script speaks: ${prose} Sequence ${v.sequence}.`
-      : `Drawing on output ${v.vout} of an earlier hand, secured by: ${prose} Sequence ${v.sequence}.`);
+    const txidPart = isNullPrevout ? '0' : encodeSeedPhrase(v.txid, 'english', BEST_OF).prose;
+    const scriptProse = v.scriptSig ? encodeSeedPhrase(v.scriptSig, 'english', BEST_OF).prose : '';
+    parts.push(endSentence(`${txidPart} ${v.vout} ${scriptProse} ${v.sequence}`));
   }
 
+  parts.push(`${parsed.vout.length}.`);
   for (const o of parsed.vout) {
-    const prose = o.scriptPubKey ? encodeSeedPhrase(o.scriptPubKey, 'english', BEST_OF).prose : '(empty script)';
-    clauses.push(`It pays ${o.value.toLocaleString()} satoshis to: ${prose}`);
+    const scriptProse = o.scriptPubKey ? encodeSeedPhrase(o.scriptPubKey, 'english', BEST_OF).prose : '';
+    parts.push(endSentence(`${o.value} ${scriptProse}`));
   }
 
-  clauses.push(`Locktime ${parsed.locktime}.`);
-  return clauses.join(' ');
+  parts.push(`${parsed.locktime}.`);
+  return parts.join(' ').replace(/\s+/g, ' ').trim();
 }
 
 let ready = false;

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -184,6 +184,16 @@ const PAGE_SIZE = 25;   // matches Esplora's own /block/:hash/txs/:start_index g
 // it back before encoding so the prose carries the hash's actual bytes.
 function reverseHex(hex) { return (hex.match(/../g) || []).reverse().join(''); }
 
+// A block hash's leading (display-order) zero bytes -- required by proof-of-work,
+// and longer for higher-difficulty blocks -- become TRAILING zero bytes once
+// reversed into internal order. They carry no information, so drop them before
+// encoding rather than spending payload words on them.
+function trimTrailingZeroBytes(hex) {
+  let end = hex.length;
+  while (end >= 2 && hex.slice(end - 2, end) === '00') end -= 2;
+  return hex.slice(0, end);
+}
+
 let ready = false;
 init().then(() => { ready = true; }).catch((e) => console.error('WASM init failed:', e));
 
@@ -267,7 +277,7 @@ async function readChapter(input, page) {
 
 function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
   $('ch-height').textContent = block.height.toLocaleString();
-  const { prose: hashProse } = encodeSeedPhrase(reverseHex(hash), 'english');
+  const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(hash)), 'english');
   $('ch-hash-short').textContent = hashProse;
   $('ch-hash-short').title = hash;
   const when = new Date(block.timestamp * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Glossia Bitcoin Book — a block, read as a chapter</title>
+<meta name="description" content="A Bitcoin block rendered as a chapter: each transaction a paragraph, its witness data an appendix, in grammatically correct Glossia prose.">
+<link rel="icon" type="image/png" sizes="32x32" href="./icons/glossia-icon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="./icons/glossia-icon-16.png">
+<link rel="icon" href="./favicon.svg" type="image/svg+xml">
+
+<!-- PWA: installable, offline-capable app shell -->
+<link rel="manifest" href="./manifest.webmanifest">
+<meta name="theme-color" content="#08080a">
+<link rel="apple-touch-icon" href="./icons/glossia-icon-180.png">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="Glossia">
+<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('./sw.js').catch((e) => console.warn('SW registration failed:', e));
+    });
+  }
+</script>
+
+<!-- Social / rich unfurl -->
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Glossia">
+<meta property="og:title" content="Glossia Bitcoin Book — a block, read as a chapter">
+<meta property="og:description" content="Each transaction in a Bitcoin block, rendered as a paragraph of grammatically correct prose — witness data collected as an appendix.">
+<meta property="og:url" content="https://glossia.io/bitcoin-book.html">
+<meta property="og:image" content="https://glossia.io/og-glossia.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Glossia — machine data, made human. A lossless linguistic codec.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Glossia Bitcoin Book — a block, read as a chapter">
+<meta name="twitter:description" content="Each transaction in a Bitcoin block, rendered as a paragraph of grammatically correct prose.">
+<meta name="twitter:image" content="https://glossia.io/og-glossia.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,300;1,6..72,400;1,6..72,500&family=IBM+Plex+Mono:wght@400;500;600&family=Public+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --page:#08080a; --card:#0d0d10; --card-bd:#232228; --ink:#e8e4da; --ink-soft:#cfcabf;
+  --accent:#c9a25f; --accent-2:#dcb877; --btn-ink:#17140c;
+  --dim:#8a8794; --meta:#5c5a63; --rule:#1c1b21; --hair:#2a2930;
+  --input-bg:#151519; --input-bd:#2a2930; --error:#e07b6a; --ok:#7fb98a;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; }
+body {
+  min-height: 100vh; background: var(--page); color: var(--ink);
+  font-family: 'Public Sans', system-ui, sans-serif; line-height: 1.55;
+}
+.wrap { max-width: 720px; margin: 0 auto; padding: 48px 22px 100px; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.mono { font-family: 'IBM Plex Mono', monospace; }
+.muted { color: var(--dim); }
+.hidden { display: none !important; }
+
+.masthead { display:flex; align-items:baseline; justify-content:space-between; gap:12px; flex-wrap:wrap; margin-bottom:24px; }
+.masthead .title { font:600 13px/1 'IBM Plex Mono',monospace; letter-spacing:.22em; text-transform:uppercase; color:var(--ink); }
+.masthead .sub { font:400 13px/1.4 'Public Sans',sans-serif; color:var(--dim); }
+.masthead .home { margin-left:auto; font:500 12px/1 'IBM Plex Mono',monospace; letter-spacing:.04em; }
+
+.card {
+  background: var(--card); border: 1px solid var(--card-bd); border-radius: 6px;
+  padding: 24px 26px 26px; box-shadow: 0 24px 60px -32px rgba(0,0,0,.7);
+}
+label { display:block; font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.06em; text-transform:uppercase; color:var(--dim); margin-bottom:8px; }
+.lookup-row { display:flex; gap:10px; }
+#block-input {
+  flex: 1; background: var(--input-bg); border: 1px solid var(--input-bd); border-radius: 4px;
+  color: var(--ink); font: 400 14px/1.4 'IBM Plex Mono',monospace; padding: 11px 12px;
+}
+#block-input:focus { outline: none; border-color: var(--accent); }
+button {
+  background: var(--accent); color: var(--btn-ink); border: none; border-radius: 4px;
+  font: 600 12.5px/1 'IBM Plex Mono',monospace; letter-spacing: .04em; text-transform: uppercase;
+  padding: 0 20px; cursor: pointer; transition: background .15s ease;
+}
+button:hover:not(:disabled) { background: var(--accent-2); }
+button:disabled { opacity: .4; cursor: not-allowed; }
+.hint { margin-top: 10px; font-size: 12.5px; color: var(--meta); }
+
+.status-line { margin-top: 16px; font: 500 13px/1.4 'IBM Plex Mono',monospace; }
+.status-line.err { color: var(--error); }
+.spinner { display:inline-block; width:12px; height:12px; border:2px solid var(--rule); border-top-color: var(--accent); border-radius:50%; animation: spin .7s linear infinite; vertical-align: -1px; margin-right: 6px; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── the chapter itself: a manuscript page, not a utility card ── */
+#chapter { margin-top: 48px; }
+.chapter-head { text-align: center; padding-bottom: 34px; margin-bottom: 34px; border-bottom: 1px solid var(--rule); }
+.chapter-num { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.3em; text-transform:uppercase; color: var(--accent); margin-bottom: 14px; }
+.chapter-title { font: 500 34px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 14px; letter-spacing: -.01em; }
+.chapter-meta { font: 400 12.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
+.chapter-meta span + span::before { content: ' · '; color: var(--rule); }
+
+.chapter-body { font-family: 'Newsreader', serif; font-size: 19px; line-height: 1.75; color: var(--ink-soft); }
+.para { margin: 0 0 1.6em; text-indent: 1.6em; position: relative; }
+.para:first-of-type { text-indent: 0; }
+.para:first-of-type::first-letter {
+  font-size: 3.4em; float: left; line-height: .82; padding: .04em .07em 0 0;
+  font-weight: 500; color: var(--accent);
+}
+.para-mark {
+  position: absolute; left: -2.4em; top: .15em; font: italic 400 13px/1 'Newsreader',serif;
+  color: var(--meta); text-indent: 0; width: 2em; text-align: right;
+}
+.para-mark a { color: var(--meta); text-decoration: none; }
+.para-mark a:hover { color: var(--accent); text-decoration: underline; }
+.para.coinbase::after {
+  content: 'coinbase'; margin-left: .6em; font: italic 400 13px/1 'Newsreader',serif; color: var(--meta);
+}
+.para-txid { display:none; }   /* carries the txid for JS reference; hidden from the reading view */
+
+.chapter-appendix { margin-top: 56px; padding-top: 30px; border-top: 1px solid var(--rule); }
+.chapter-appendix h2 {
+  font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.24em; text-transform:uppercase;
+  color: var(--dim); margin: 0 0 22px; text-align: center;
+}
+.appendix-entry { margin: 0 0 1.5em; font: italic 400 15.5px/1.65 'Newsreader',serif; color: var(--meta); }
+.appendix-mark { font: 500 11px/1 'IBM Plex Mono',monospace; color: var(--accent); margin-right: .5em; font-style: normal; }
+.appendix-empty { text-align: center; font: italic 400 14px/1.6 'Newsreader',serif; color: var(--meta); }
+
+.chapter-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin-top: 54px; padding-top: 24px; border-top: 1px solid var(--rule); }
+.chapter-nav .page-status { font: 400 12.5px/1 'IBM Plex Mono',monospace; color: var(--meta); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="masthead">
+    <span class="title">Glossia · Bitcoin Book</span>
+    <span class="sub">a block, read as a chapter</span>
+    <span class="home"><a href="./bitcoin.html">transaction lookup</a> &nbsp;·&nbsp; <a href="./index.html">demo</a></span>
+  </div>
+
+  <div class="card">
+    <label for="block-input">Block height or hash</label>
+    <div class="lookup-row">
+      <input type="text" id="block-input" class="mono" value="0" placeholder="e.g. 0, or a 64-character block hash" autocomplete="off" spellcheck="false">
+      <button type="button" id="block-btn">Read chapter</button>
+    </div>
+    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph; its witness stack, if any, becomes an appendix entry. Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
+    <div id="block-status" class="status-line hidden"></div>
+  </div>
+
+  <article id="chapter" class="hidden">
+    <header class="chapter-head">
+      <div class="chapter-num">Chapter <span id="ch-height"></span></div>
+      <h1 class="chapter-title">Block <span id="ch-hash-short" class="mono"></span></h1>
+      <div class="chapter-meta" id="ch-meta"></div>
+    </header>
+
+    <div class="chapter-body" id="ch-paragraphs"></div>
+
+    <div class="chapter-appendix">
+      <h2>Appendix — Witness Data</h2>
+      <div id="ch-appendix"></div>
+    </div>
+
+    <nav class="chapter-nav">
+      <button type="button" id="page-prev">← Previous</button>
+      <span class="page-status" id="page-status"></span>
+      <button type="button" id="page-next">Next →</button>
+    </nav>
+  </article>
+</div>
+
+<script type="module">
+import { init, encodeSeedPhrase } from './glossia-msg.js';
+import { parseTransaction, computeTxid } from './btc-tx.js';
+
+const $ = (id) => document.getElementById(id);
+const ESPLORA = 'https://blockstream.info/api';
+const PAGE_SIZE = 25;   // matches Esplora's own /block/:hash/txs/:start_index granularity
+
+let ready = false;
+init().then(() => { ready = true; }).catch((e) => console.error('WASM init failed:', e));
+
+function setStatus(msg, kind) {
+  const el = $('block-status');
+  el.className = 'status-line' + (kind ? ' ' + kind : '');
+  el.innerHTML = msg;
+  el.classList.toggle('hidden', !msg);
+}
+
+async function resolveBlockHash(input) {
+  input = input.trim();
+  if (/^[0-9a-f]{64}$/i.test(input)) return input.toLowerCase();
+  if (/^\d+$/.test(input)) {
+    const res = await fetch(`${ESPLORA}/block-height/${input}`);
+    if (!res.ok) throw new Error(res.status === 404 ? `No block at height ${input}.` : `Esplora returned ${res.status}.`);
+    return (await res.text()).trim();
+  }
+  throw new Error('Enter a block height (e.g. 0) or a 64-character block hash.');
+}
+
+async function readChapter(input, page) {
+  $('chapter').classList.add('hidden');
+  setStatus('<span class="spinner"></span>fetching block…');
+  $('block-btn').disabled = true;
+  try {
+    const hash = await resolveBlockHash(input);
+
+    const [blockRes, txidsRes] = await Promise.all([
+      fetch(`${ESPLORA}/block/${hash}`),
+      fetch(`${ESPLORA}/block/${hash}/txids`),
+    ]);
+    if (!blockRes.ok) throw new Error(`Esplora returned ${blockRes.status} fetching block info.`);
+    if (!txidsRes.ok) throw new Error(`Esplora returned ${txidsRes.status} fetching the transaction list.`);
+    const block = await blockRes.json();
+    const txids = await txidsRes.json();
+
+    const maxPage = Math.max(0, Math.ceil(txids.length / PAGE_SIZE) - 1);
+    page = Math.min(Math.max(0, page), maxPage);
+    const start = page * PAGE_SIZE;
+    const pageTxids = txids.slice(start, start + PAGE_SIZE);
+
+    setStatus(`<span class="spinner"></span>fetching ${pageTxids.length} transaction${pageTxids.length === 1 ? '' : 's'}…`);
+    const hexes = await Promise.all(pageTxids.map(async (txid) => {
+      const r = await fetch(`${ESPLORA}/tx/${txid}/hex`);
+      if (!r.ok) throw new Error(`Esplora returned ${r.status} fetching tx ${txid.slice(0, 8)}…`);
+      return (await r.text()).trim();
+    }));
+
+    if (!ready) await init().catch(() => {});
+    setStatus('<span class="spinner"></span>encoding as prose…');
+
+    const paragraphs = [];
+    const appendix = [];
+    for (let i = 0; i < hexes.length; i++) {
+      const parsed = parseTransaction(hexes[i]);
+      const txid = pageTxids[i];
+      const verifiedTxid = await computeTxid(parsed.baseHex);
+      const { prose: bodyProse } = encodeSeedPhrase(parsed.baseHex, 'english');
+      const num = start + i + 1;
+      const isCoinbase = parsed.vin.length === 1 && parsed.vin[0].txid === '00'.repeat(32);
+      let appendixIndex = null;
+      if (parsed.witnessHex) {
+        const { prose: witProse } = encodeSeedPhrase(parsed.witnessHex, 'english');
+        appendixIndex = appendix.length + 1;
+        appendix.push({ num, txid, prose: witProse });
+      }
+      paragraphs.push({ num, txid, prose: bodyProse, isCoinbase, appendixIndex, verified: verifiedTxid === txid });
+    }
+
+    renderChapter(block, hash, page, maxPage, txids.length, paragraphs, appendix);
+    updateUrl(input, page);
+    $('chapter').classList.remove('hidden');
+    setStatus('');
+  } catch (e) {
+    setStatus(e.message || 'Failed to load chapter.', 'err');
+  } finally {
+    $('block-btn').disabled = false;
+  }
+}
+
+function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
+  $('ch-height').textContent = block.height.toLocaleString();
+  $('ch-hash-short').textContent = hash.slice(0, 12) + '…';
+  $('ch-hash-short').title = hash;
+  const when = new Date(block.timestamp * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+  $('ch-meta').innerHTML = `<span>${when}</span><span>${totalTx.toLocaleString()} transaction${totalTx === 1 ? '' : 's'}</span><span>${block.size.toLocaleString()} B</span><span>weight ${block.weight.toLocaleString()} WU</span>`;
+
+  const body = $('ch-paragraphs');
+  body.innerHTML = '';
+  for (const p of paragraphs) {
+    const el = document.createElement('p');
+    el.className = 'para' + (p.isCoinbase ? ' coinbase' : '') + (p.verified ? '' : ' unverified');
+    const markInner = p.appendixIndex
+      ? `<a href="#appendix-${p.appendixIndex}" title="txid ${p.txid}${p.verified ? '' : ' — could not be independently verified'}">${p.num}</a>`
+      : `<span title="txid ${p.txid}${p.verified ? '' : ' — could not be independently verified'}">${p.num}</span>`;
+    el.innerHTML = `<span class="para-mark">${markInner}</span>${p.prose}`;
+    body.append(el);
+  }
+
+  const appendixEl = $('ch-appendix');
+  appendixEl.innerHTML = '';
+  if (!appendix.length) {
+    appendixEl.innerHTML = '<p class="appendix-empty">No witness data on this page — every transaction here predates or opts out of segwit.</p>';
+  } else {
+    for (const [i, a] of appendix.entries()) {
+      const el = document.createElement('p');
+      el.className = 'appendix-entry';
+      el.id = `appendix-${i + 1}`;
+      el.innerHTML = `<span class="appendix-mark">¶${a.num}</span>${a.prose}`;
+      appendixEl.append(el);
+    }
+  }
+
+  const start = page * PAGE_SIZE + 1;
+  const end = Math.min((page + 1) * PAGE_SIZE, totalTx);
+  $('page-status').textContent = `paragraphs ${start.toLocaleString()}–${end.toLocaleString()} of ${totalTx.toLocaleString()}`;
+  $('page-prev').disabled = page <= 0;
+  $('page-next').disabled = page >= maxPage;
+  $('page-prev').onclick = () => readChapter($('block-input').value, page - 1);
+  $('page-next').onclick = () => readChapter($('block-input').value, page + 1);
+}
+
+function updateUrl(input, page) {
+  const params = new URLSearchParams();
+  params.set('block', input.trim());
+  if (page) params.set('page', String(page));
+  history.replaceState(null, '', `${location.pathname}?${params.toString()}`);
+}
+
+$('block-btn').addEventListener('click', () => readChapter($('block-input').value, 0));
+$('block-input').addEventListener('keydown', (e) => { if (e.key === 'Enter') readChapter($('block-input').value, 0); });
+
+const params = new URLSearchParams(location.search);
+const blockParam = params.get('block');
+const pageParam = parseInt(params.get('page'), 10) || 0;
+if (blockParam) $('block-input').value = blockParam;
+readChapter($('block-input').value, pageParam);
+</script>
+</body>
+</html>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -110,19 +110,33 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .chapter-hash { font: italic 400 15px/1.5 'Newsreader',serif; color: var(--meta); margin: 0 auto 16px; max-width: 46ch; }
 
 .chapter-body { font-family: 'Newsreader', serif; font-size: 19px; line-height: 1.75; color: var(--ink-soft); font-variant-numeric: oldstyle-nums; }
-.para { margin: 0 0 1.6em; text-indent: 1.6em; position: relative; }
-.para:first-of-type { text-indent: 0; }
-.para:first-of-type::first-letter {
-  font-size: 3.4em; float: left; line-height: .82; padding: .04em .07em 0 0;
-  font-weight: 500; color: var(--accent);
-}
+
+/* Each transaction is a three-column manuscript layout: a left margin for
+   provenance (what this text refers back to), a body for the canonical
+   prose, a right margin for consequences (what this text produces / how it
+   ends). The verse number sits further left still, outside the grid. */
+.tx-wrap { position: relative; margin: 0 0 2em; }
 .para-mark {
   position: absolute; left: -2.4em; top: .15em; font: italic 400 13px/1 'Newsreader',serif;
-  color: var(--meta); text-indent: 0; width: 2em; text-align: right;
+  color: var(--meta); width: 2em; text-align: right;
 }
 .para-mark a { color: var(--meta); text-decoration: none; }
 .para-mark a:hover { color: var(--accent); text-decoration: underline; }
-.para-txid { display:none; }   /* carries the txid for JS reference; hidden from the reading view */
+
+.tx-grid { display: grid; grid-template-columns: minmax(3.5em, 11em) 1fr minmax(3em, 8em); column-gap: 18px; row-gap: .55em; align-items: baseline; }
+.tx-margin-left, .tx-margin-right { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--meta); }
+.tx-margin-left { text-align: right; }
+.tx-margin-right { text-align: left; }
+.tx-body-lead::first-letter {
+  font-size: 3.4em; float: left; line-height: .82; padding: .04em .07em 0 0;
+  font-weight: 500; color: var(--accent);
+}
+@media (max-width: 560px) {
+  .tx-grid { grid-template-columns: 1fr; row-gap: .2em; }
+  .tx-margin-left, .tx-margin-right { text-align: left; font-size: 12px; }
+  .tx-margin-left:not(:empty)::before { content: '← '; }
+  .tx-margin-right:not(:empty)::before { content: '→ '; }
+}
 
 .chapter-appendix { margin-top: 56px; padding-top: 30px; border-top: 1px solid var(--rule); }
 .chapter-appendix h2 {
@@ -167,7 +181,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
     <div class="chapter-body" id="ch-paragraphs"></div>
 
     <div class="chapter-appendix hidden" id="ch-appendix-section">
-      <h2>Appendix — Witness Data</h2>
+      <h2>Appendix</h2>
       <div id="ch-appendix"></div>
     </div>
 
@@ -181,7 +195,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 <script type="module">
 import { init, encodeSeedPhrase } from './glossia-msg.js';
 import { parseTransaction, computeTxid } from './btc-tx.js';
-import { describeTransaction } from './btc-prose.js';
+import { composeTransactionFields } from './btc-prose.js';
 import { volumeBookChapter } from './btc-citation.js';
 
 const $ = (id) => document.getElementById(id);
@@ -265,11 +279,11 @@ async function showCurrentTx() {
 
   const parsed = parseTransaction(hex);
   const verifiedTxid = await computeTxid(parsed.baseHex);
-  const { prose: bodyProse } = describeTransaction(parsed, BEST_OF);
+  const fields = composeTransactionFields(parsed, BEST_OF);
   const witness = parsed.witnessHex ? encodeSeedPhrase(parsed.witnessHex, 'english', BEST_OF) : null;
 
   renderChapter({
-    num: state.index + 1, txid, prose: bodyProse,
+    num: state.index + 1, txid, fields,
     verified: verifiedTxid === txid, witnessProse: witness ? witness.prose : null,
   });
   updateUrl();
@@ -290,14 +304,41 @@ function renderChapter(para) {
 
   const body = $('ch-paragraphs');
   body.innerHTML = '';
-  const el = document.createElement('p');
-  el.className = 'para' + (para.verified ? '' : ' unverified');
+
+  const wrap = document.createElement('div');
+  wrap.className = 'tx-wrap' + (para.verified ? '' : ' unverified');
+
   const titleAttr = `txid ${para.txid}${para.verified ? '' : ' — could not be independently verified'}`;
   const markInner = para.witnessProse
     ? `<a href="#appendix-1" title="${titleAttr}">${para.num}</a>`
     : `<span title="${titleAttr}">${para.num}</span>`;
-  el.innerHTML = `<span class="para-mark">${markInner}</span>${para.prose}`;
-  body.append(el);
+  const mark = document.createElement('span');
+  mark.className = 'para-mark';
+  mark.innerHTML = markInner;
+  wrap.append(mark);
+
+  // Left margin (provenance): what this row's text refers back to.
+  // Right margin (consequences): what it produces / how it ends. The body
+  // in between is the canonical prose -- scripts, quoted ASCII literals.
+  const grid = document.createElement('div');
+  grid.className = 'tx-grid';
+  let leadUsed = false;
+  const addRow = (left, bodyHtml, right) => {
+    const l = document.createElement('div'); l.className = 'tx-margin-left'; l.innerHTML = left || '';
+    const b = document.createElement('div');
+    b.className = 'tx-body' + (!leadUsed && bodyHtml ? (leadUsed = true, ' tx-body-lead') : '');
+    b.innerHTML = bodyHtml || '';
+    const r = document.createElement('div'); r.className = 'tx-margin-right'; r.innerHTML = right || '';
+    grid.append(l, b, r);
+  };
+
+  const f = para.fields;
+  if (f.version !== '1') addRow(f.version, '', '');   // version 1 is the default -- omitted
+  for (const inp of f.inputs) addRow(inp.prevout, inp.script, inp.sequence);
+  for (const out of f.outputs) addRow('', out.script, out.value);
+  addRow('', '', f.locktime);
+  wrap.append(grid);
+  body.append(wrap);
 
   const appendixEl = $('ch-appendix');
   appendixEl.innerHTML = '';

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -262,7 +262,10 @@ async function readChapter(input, page) {
 
 function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix) {
   $('ch-height').textContent = block.height.toLocaleString();
-  $('ch-hash-short').textContent = hash.slice(0, 12) + '…';
+  // Every real block hash starts with a long run of zeros (that's what proof-of-work
+  // requires), so a leading-substring truncation shows nothing but zeros. Show both
+  // ends instead -- the tail is where a block hash's actual entropy lives.
+  $('ch-hash-short').textContent = hash.slice(0, 8) + '…' + hash.slice(-8);
   $('ch-hash-short').title = hash;
   const when = new Date(block.timestamp * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
   $('ch-meta').innerHTML = `<span>${when}</span><span>${totalTx.toLocaleString()} transaction${totalTx === 1 ? '' : 's'}</span><span>${block.size.toLocaleString()} B</span><span>weight ${block.weight.toLocaleString()} WU</span>`;

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -123,24 +123,26 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .para-mark a { color: var(--meta); text-decoration: none; }
 .para-mark a:hover { color: var(--accent); text-decoration: underline; }
 
-/* fit-content, not minmax(min, <length>) -- a fixed-length max is still the
-   track's growth *target*, so grid's "maximize tracks" step fills it in
-   regardless of actual content, stealing width from the 1fr body column
-   even when a margin only holds a single glyph. fit-content grows a track
-   only as far as its own content needs, capped at the given length. */
-.tx-grid { display: grid; grid-template-columns: fit-content(11em) 1fr fit-content(8em); column-gap: 18px; row-gap: .55em; align-items: baseline; }
-.tx-margin-left, .tx-margin-right { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--dim); }
-.tx-margin-left { text-align: right; }
-.tx-margin-right { text-align: left; }
-.tx-body-lead::first-letter {
+/* Margins are floats, not grid cells -- a grid row's height is the tallest
+   of its cells, so a long prevout reference paired with an empty scriptSig
+   (the common case for a segwit input, whose signature lives in the
+   witness) produced a tall, mostly-blank row that pushed the next
+   transaction field's real prose down behind it. Floats fall out of normal
+   flow, so a body line just starts wherever the flow already is instead of
+   waiting for a tall neighboring note to finish. */
+.tx-flow::after { content: ''; display: table; clear: both; }
+.tx-note { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--dim); }
+.tx-note-left { float: left; clear: left; width: auto; max-width: 11em; margin: 0 1.1em .55em 0; text-align: right; }
+.tx-note-right { float: right; clear: right; width: auto; max-width: 8em; margin: 0 0 .55em 1.1em; text-align: left; }
+.tx-line { margin: 0 0 .55em; }
+.tx-line.tx-body-lead::first-letter {
   font-size: 3.4em; float: left; line-height: .82; padding: .04em .07em 0 0;
   font-weight: 500; color: var(--accent);
 }
 @media (max-width: 560px) {
-  .tx-grid { grid-template-columns: 1fr; row-gap: .2em; }
-  .tx-margin-left, .tx-margin-right { text-align: left; font-size: 12px; }
-  .tx-margin-left:not(:empty)::before { content: '← '; }
-  .tx-margin-right:not(:empty)::before { content: '→ '; }
+  .tx-note-left, .tx-note-right { float: none; clear: both; max-width: none; width: auto; text-align: left; margin: 0 0 .2em; }
+  .tx-note-left::before { content: '← '; }
+  .tx-note-right::before { content: '→ '; }
 }
 
 .chapter-appendix { margin-top: 56px; padding-top: 30px; border-top: 1px solid var(--rule); }
@@ -158,7 +160,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 <div class="wrap">
   <div class="masthead">
     <span class="title">The Bitcoin Book</span>
-    <span class="sub">a block, read as a chapter</span>
     <span class="home"><a href="./bitcoin.html">transaction lookup</a> &nbsp;·&nbsp; <a href="./index.html">Glossia</a></span>
   </div>
 
@@ -333,27 +334,42 @@ function renderChapter(para) {
   mark.innerHTML = markInner;
   wrap.append(mark);
 
-  // Left margin (provenance): what this row's text refers back to.
-  // Right margin (consequences): what it produces / how it ends. The body
-  // in between is the canonical prose -- scripts, quoted ASCII literals.
-  const grid = document.createElement('div');
-  grid.className = 'tx-grid';
+  // Left margin (provenance): what this text refers back to. Right margin
+  // (consequences): what it produces / how it ends. Both float alongside
+  // the canonical prose -- scripts, quoted ASCII literals -- rather than
+  // sharing a grid row with it, so an empty script doesn't leave a blank
+  // gap the height of a long neighboring reference.
+  const flow = document.createElement('div');
+  flow.className = 'tx-flow';
   let leadUsed = false;
-  const addRow = (left, bodyHtml, right) => {
-    const l = document.createElement('div'); l.className = 'tx-margin-left'; l.innerHTML = left || '';
-    const b = document.createElement('div');
-    b.className = 'tx-body' + (!leadUsed && bodyHtml ? (leadUsed = true, ' tx-body-lead') : '');
-    b.innerHTML = bodyHtml || '';
-    const r = document.createElement('div'); r.className = 'tx-margin-right'; r.innerHTML = right || '';
-    grid.append(l, b, r);
+  const addNote = (cls, html) => {
+    if (!html) return;
+    const n = document.createElement('div');
+    n.className = cls;
+    n.innerHTML = html;
+    flow.append(n);
+  };
+  const addLine = (html) => {
+    if (!html) return;
+    const p = document.createElement('p');
+    p.className = 'tx-line' + (!leadUsed ? (leadUsed = true, ' tx-body-lead') : '');
+    p.innerHTML = html;
+    flow.append(p);
   };
 
   const f = para.fields;
-  if (f.version !== '1') addRow(f.version, '', '');   // version 1 is the default -- omitted
-  for (const inp of f.inputs) addRow(inp.prevout, inp.script, inp.sequence);
-  for (const out of f.outputs) addRow('', out.script, out.value);
-  addRow('', '', f.locktime);
-  wrap.append(grid);
+  if (f.version !== '1') addNote('tx-note tx-note-left', f.version);   // version 1 is the default -- omitted
+  for (const inp of f.inputs) {
+    addNote('tx-note tx-note-left', inp.prevout);
+    addNote('tx-note tx-note-right', inp.sequence);
+    addLine(inp.script);
+  }
+  for (const out of f.outputs) {
+    addNote('tx-note tx-note-right', out.value);
+    addLine(out.script);
+  }
+  addNote('tx-note tx-note-right', f.locktime);
+  wrap.append(flow);
   body.append(wrap);
 
   const appendixEl = $('ch-appendix');

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -298,9 +298,15 @@ function renderChapter(para) {
   // Volume 1, Book 1, Chapter 1 is block 0 -- the Genesis block -- so it
   // earns its own title rather than just being "Chapter 1".
   $('ch-title').textContent = (volume === 1 && book === 1 && chapter === 1) ? 'Genesis' : `Chapter ${chapter.toLocaleString()}`;
-  const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(state.hash)), 'english', BEST_OF);
-  $('ch-hash-short').textContent = hashProse;
-  $('ch-hash-short').title = state.hash;
+  // The block-hash subtitle introduces the chapter as a whole, so it only
+  // belongs on the chapter's first transaction, not every one stepped to.
+  const onFirstTx = state.index === 0;
+  $('ch-hash-short').classList.toggle('hidden', !onFirstTx);
+  if (onFirstTx) {
+    const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(state.hash)), 'english', BEST_OF);
+    $('ch-hash-short').textContent = hashProse;
+    $('ch-hash-short').title = state.hash;
+  }
 
   const body = $('ch-paragraphs');
   body.innerHTML = '';

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -161,7 +161,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <article id="chapter" class="hidden">
     <header class="chapter-head">
       <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span id="ch-book"></span></div>
-      <h1 class="chapter-title">Chapter <span id="ch-chapter"></span></h1>
+      <h1 class="chapter-title" id="ch-title"></h1>
       <div class="chapter-hash" id="ch-hash-short"></div>
     </header>
 
@@ -289,7 +289,9 @@ function renderChapter(block, hash, page, maxPage, totalTx, paragraphs, appendix
   const { volume, book, chapter } = volumeBookChapter(block.height);
   $('ch-volume').textContent = volume.toLocaleString();
   $('ch-book').textContent = book.toLocaleString();
-  $('ch-chapter').textContent = chapter.toLocaleString();
+  // Volume 1, Book 1, Chapter 1 is block 0 -- the Genesis block -- so it
+  // earns its own title rather than just being "Chapter 1".
+  $('ch-title').textContent = (volume === 1 && book === 1 && chapter === 1) ? 'Genesis' : `Chapter ${chapter.toLocaleString()}`;
   const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(hash)), 'english', BEST_OF);
   $('ch-hash-short').textContent = hashProse;
   $('ch-hash-short').title = hash;

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -169,17 +169,25 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
 
     <div class="card">
       <h2>Encoded as Glossia prose</h2>
-      <p class="muted" style="margin:0 0 4px; font-size:13px;">The raw signed transaction — every byte, verbatim — rendered as natural-language English. Filtering this prose against the wordlist recovers the exact hex.</p>
+      <p class="muted" style="margin:0 0 4px; font-size:13px;">Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits; the genuinely opaque bytes — prevout references, scripts — are what's rendered in prose.</p>
       <div class="prose-box" id="tx-prose"></div>
       <div class="prose-meta">
         <span class="muted mono" id="tx-prose-stats" style="font-size:12px;"></span>
         <button type="button" class="copy-btn" id="tx-copy">Copy prose</button>
       </div>
+      <div id="tx-witness-wrap" class="hidden" style="margin-top:22px;">
+        <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">Witness data</div>
+        <div class="prose-box" id="tx-witness-prose"></div>
+        <div class="prose-meta">
+          <span class="muted mono" id="tx-witness-stats" style="font-size:12px;"></span>
+          <button type="button" class="copy-btn" id="tx-witness-copy">Copy witness prose</button>
+        </div>
+      </div>
     </div>
 
     <div class="card">
-      <h2>Decoded independently from the prose</h2>
-      <p class="muted" style="margin:0 0 4px; font-size:13px;">The prose above, filtered back to bytes and parsed as a raw transaction — no explorer API involved below this line. Input amounts and fee are absent on purpose: a transaction only references its inputs by <span class="mono">txid:vout</span>, not their value, so recovering those still requires chain context.</p>
+      <h2>Parsed independently</h2>
+      <p class="muted" style="margin:0 0 4px; font-size:13px;">The same raw bytes fetched above, parsed by Glossia's own transaction parser rather than Esplora's JSON — its txid verified by hashing those bytes directly, no explorer API involved below this line. Input amounts and fee are absent on purpose: a transaction only references its inputs by <span class="mono">txid:vout</span>, not their value, so recovering those still requires chain context.</p>
       <dl class="rows" id="tx-decoded-summary"></dl>
       <div class="io-cols" style="margin-top:18px;">
         <div>
@@ -197,8 +205,9 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
 </div>
 
 <script type="module">
-import { init, encodeSeedPhrase, decodeSeedPhrase } from './glossia-msg.js';
-import { parseTransaction, withAddresses } from './btc-tx.js';
+import { init } from './glossia-msg.js';
+import { parseTransaction, computeTxid, withAddresses } from './btc-tx.js';
+import { describeTransaction, describeWitness } from './btc-prose.js';
 
 const $ = (id) => document.getElementById(id);
 const ESPLORA = 'https://blockstream.info/api';
@@ -257,22 +266,28 @@ function renderIO(tx) {
 
 const BEST_OF = 5;
 
-function renderProse(hex) {
-  const { prose, payloadWords } = encodeSeedPhrase(hex, 'english', BEST_OF);
+function renderProse(parsed) {
+  const { prose, payloadWords } = describeTransaction(parsed, BEST_OF);
   $('tx-prose').textContent = prose;
-  const bytes = hex.length / 2;
-  $('tx-prose-stats').textContent = `${bytes.toLocaleString()} bytes → ${payloadWords.length.toLocaleString()} payload words`;
-  return prose;
+  $('tx-prose-stats').textContent = `${payloadWords.length.toLocaleString()} payload words`;
+
+  const { prose: witProse, payloadWords: witWords } = describeWitness(parsed, BEST_OF);
+  if (witProse) {
+    $('tx-witness-prose').textContent = witProse;
+    $('tx-witness-stats').textContent = `${witWords.length.toLocaleString()} payload words`;
+    $('tx-witness-wrap').classList.remove('hidden');
+  } else {
+    $('tx-witness-wrap').classList.add('hidden');
+  }
 }
 
-async function renderDecoded(prose, expectedHex, esploraTx) {
+async function renderVerified(parsed, txid, esploraTx) {
   const errEl = $('tx-decoded-error');
   errEl.classList.add('hidden');
   try {
-    const { hex: recoveredHex } = decodeSeedPhrase(prose, expectedHex.length / 2, 'english');
-    if (recoveredHex !== expectedHex) throw new Error('decoded bytes did not match the original transaction — round-trip mismatch.');
-
-    const parsed = await withAddresses(parseTransaction(recoveredHex));
+    const withAddr = await withAddresses(parsed);
+    const verifiedTxid = await computeTxid(parsed.baseHex);
+    const txidMatch = verifiedTxid === txid;
     const sizeMatch = parsed.size === esploraTx.size && parsed.vsize === esploraTx.vsize && parsed.weight === esploraTx.weight;
 
     const dl = $('tx-decoded-summary');
@@ -281,6 +296,7 @@ async function renderDecoded(prose, expectedHex, esploraTx) {
       ['Version', String(parsed.version)],
       ['Locktime', String(parsed.locktime)],
       ['Segwit', parsed.segwit ? 'yes' : 'no'],
+      ['Txid', txidMatch ? '<span class="pill confirmed">independently verified</span>' : '<span class="pill pending">mismatch</span>'],
       ['Size / vsize / weight', `${parsed.size} B / ${parsed.vsize} vB / ${parsed.weight} WU ` +
         (sizeMatch ? '<span class="pill confirmed">matches explorer</span>' : '<span class="pill pending">mismatch</span>')],
     ];
@@ -288,7 +304,7 @@ async function renderDecoded(prose, expectedHex, esploraTx) {
 
     const vinEl = $('tx-decoded-vin'), voutEl = $('tx-decoded-vout');
     vinEl.innerHTML = ''; voutEl.innerHTML = '';
-    for (const vin of parsed.vin) {
+    for (const vin of withAddr.vin) {
       const li = document.createElement('li');
       const witnessLine = vin.witness.length
         ? `<div class="io-detail"><b>witness</b> (${vin.witness.length} item${vin.witness.length === 1 ? '' : 's'}): ${vin.witness.join(' ')}</div>`
@@ -299,7 +315,7 @@ async function renderDecoded(prose, expectedHex, esploraTx) {
         ${witnessLine}`;
       vinEl.append(li);
     }
-    for (const vout of parsed.vout) {
+    for (const vout of withAddr.vout) {
       const li = document.createElement('li');
       li.innerHTML = `<span class="io-addr">${vout.address || vout.type}</span><span class="io-val">${sats(vout.value)}</span>`;
       voutEl.append(li);
@@ -308,7 +324,7 @@ async function renderDecoded(prose, expectedHex, esploraTx) {
     $('tx-decoded-summary').innerHTML = '';
     $('tx-decoded-vin').innerHTML = '';
     $('tx-decoded-vout').innerHTML = '';
-    errEl.textContent = e.message || 'Decode failed.';
+    errEl.textContent = e.message || 'Verification failed.';
     errEl.classList.remove('hidden');
   }
 }
@@ -335,8 +351,9 @@ async function lookup(txid) {
     renderSummary(tx);
     renderIO(tx);
     if (!ready) await init().catch(() => {});
-    const prose = renderProse(hex);
-    await renderDecoded(prose, hex, tx);
+    const parsed = parseTransaction(hex);
+    renderProse(parsed);
+    await renderVerified(parsed, txid, tx);
 
     $('tx-result').classList.remove('hidden');
     setStatus('');
@@ -353,6 +370,13 @@ $('tx-copy').addEventListener('click', async () => {
   try {
     await navigator.clipboard.writeText($('tx-prose').textContent);
     const btn = $('tx-copy'); const old = btn.textContent;
+    btn.textContent = 'Copied ✓'; setTimeout(() => { btn.textContent = old; }, 1400);
+  } catch (e) { /* clipboard unavailable */ }
+});
+$('tx-witness-copy').addEventListener('click', async () => {
+  try {
+    await navigator.clipboard.writeText($('tx-witness-prose').textContent);
+    const btn = $('tx-witness-copy'); const old = btn.textContent;
     btn.textContent = 'Copied ✓'; setTimeout(() => { btn.textContent = old; }, 1400);
   } catch (e) { /* clipboard unavailable */ }
 });

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -134,7 +134,7 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
   <div class="masthead">
     <span class="title">Glossia · Bitcoin</span>
     <span class="sub">look up a transaction, encode it into prose</span>
-    <span class="home"><a href="./index.html">demo</a></span>
+    <span class="home"><a href="./bitcoin-book.html">read a block as a chapter →</a> &nbsp;·&nbsp; <a href="./index.html">demo</a></span>
   </div>
 
   <div class="card">

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Glossia Bitcoin — a block explorer in prose</title>
+<meta name="description" content="Look up a Bitcoin transaction and encode its data into grammatically correct Glossia prose — readable, speakable, transcribable.">
+<link rel="icon" type="image/png" sizes="32x32" href="./icons/glossia-icon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="./icons/glossia-icon-16.png">
+<link rel="icon" href="./favicon.svg" type="image/svg+xml">
+
+<!-- PWA: installable, offline-capable app shell -->
+<link rel="manifest" href="./manifest.webmanifest">
+<meta name="theme-color" content="#08080a">
+<link rel="apple-touch-icon" href="./icons/glossia-icon-180.png">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="Glossia">
+<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('./sw.js').catch((e) => console.warn('SW registration failed:', e));
+    });
+  }
+</script>
+
+<!-- Social / rich unfurl -->
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Glossia">
+<meta property="og:title" content="Glossia Bitcoin — a block explorer in prose">
+<meta property="og:description" content="Look up a Bitcoin transaction and encode its data into grammatically correct Glossia prose.">
+<meta property="og:url" content="https://glossia.io/bitcoin.html">
+<meta property="og:image" content="https://glossia.io/og-glossia.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Glossia — machine data, made human. A lossless linguistic codec.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Glossia Bitcoin — a block explorer in prose">
+<meta name="twitter:description" content="Look up a Bitcoin transaction and encode its data into grammatically correct Glossia prose.">
+<meta name="twitter:image" content="https://glossia.io/og-glossia.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,300;1,6..72,400&family=IBM+Plex+Mono:wght@400;500;600&family=Public+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --page:#08080a; --card:#0d0d10; --card-bd:#232228; --ink:#e8e4da; --ink-soft:#cfcabf;
+  --accent:#c9a25f; --accent-2:#dcb877; --btn-ink:#17140c;
+  --dim:#8a8794; --meta:#5c5a63; --rule:#1c1b21; --hair:#2a2930;
+  --input-bg:#151519; --input-bd:#2a2930; --error:#e07b6a; --ok:#7fb98a;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; }
+body {
+  min-height: 100vh; background: var(--page); color: var(--ink);
+  font-family: 'Public Sans', system-ui, sans-serif; line-height: 1.55;
+}
+.wrap { max-width: 760px; margin: 0 auto; padding: 48px 22px 80px; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.mono { font-family: 'IBM Plex Mono', monospace; }
+.muted { color: var(--dim); }
+.hidden { display: none !important; }
+
+/* masthead */
+.masthead { display:flex; align-items:baseline; justify-content:space-between; gap:12px; flex-wrap:wrap; margin-bottom:24px; }
+.masthead .title { font:600 13px/1 'IBM Plex Mono',monospace; letter-spacing:.22em; text-transform:uppercase; color:var(--ink); }
+.masthead .sub { font:400 13px/1.4 'Public Sans',sans-serif; color:var(--dim); }
+.masthead .home { margin-left:auto; font:500 12px/1 'IBM Plex Mono',monospace; letter-spacing:.04em; }
+
+.card {
+  background: var(--card); border: 1px solid var(--card-bd); border-radius: 6px;
+  padding: 28px 28px 30px; box-shadow: 0 24px 60px -30px rgba(0,0,0,.7);
+}
+.card + .card { margin-top: 20px; }
+
+label { display:block; font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.06em; text-transform:uppercase; color:var(--dim); margin-bottom:8px; }
+.lookup-row { display:flex; gap:10px; }
+#tx-input {
+  flex: 1; background: var(--input-bg); border: 1px solid var(--input-bd); border-radius: 4px;
+  color: var(--ink); font: 400 14px/1.4 'IBM Plex Mono',monospace; padding: 11px 12px;
+}
+#tx-input:focus { outline: none; border-color: var(--accent); }
+button {
+  background: var(--accent); color: var(--btn-ink); border: none; border-radius: 4px;
+  font: 600 12.5px/1 'IBM Plex Mono',monospace; letter-spacing: .04em; text-transform: uppercase;
+  padding: 0 20px; cursor: pointer; transition: background .15s ease;
+}
+button:hover:not(:disabled) { background: var(--accent-2); }
+button:disabled { opacity: .5; cursor: not-allowed; }
+.hint { margin-top: 10px; font-size: 12.5px; color: var(--meta); }
+.hint a { color: var(--meta); text-decoration: underline; }
+
+.status-line { margin-top: 16px; font: 500 13px/1.4 'IBM Plex Mono',monospace; }
+.status-line.err { color: var(--error); }
+.status-line.ok { color: var(--ok); }
+
+/* result table */
+.rows { display: grid; grid-template-columns: max-content 1fr; gap: 8px 18px; margin-top: 4px; }
+.rows dt { font: 500 11px/1.5 'IBM Plex Mono',monospace; letter-spacing: .04em; text-transform: uppercase; color: var(--dim); white-space: nowrap; }
+.rows dd { margin: 0; font: 400 13.5px/1.5 'IBM Plex Mono',monospace; color: var(--ink-soft); word-break: break-all; }
+.pill { display:inline-block; font:600 10.5px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; padding:4px 8px; border-radius:3px; }
+.pill.confirmed { background: rgba(127,185,138,.15); color: var(--ok); }
+.pill.pending { background: rgba(224,123,106,.15); color: var(--error); }
+
+h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color: var(--dim); margin: 0 0 14px; }
+.io-list { list-style: none; margin: 0; padding: 0; }
+.io-list li { display:flex; justify-content:space-between; gap:12px; padding: 7px 0; border-bottom: 1px solid var(--hair); font: 400 13px/1.4 'IBM Plex Mono',monospace; }
+.io-list li:last-child { border-bottom: none; }
+.io-addr { color: var(--ink-soft); word-break: break-all; }
+.io-val { color: var(--dim); white-space: nowrap; margin-left: 12px; }
+.io-cols { display:flex; gap:24px; flex-wrap:wrap; margin-top: 4px; }
+.io-cols > div { flex: 1 1 280px; min-width: 240px; }
+
+.prose-box {
+  font-family: 'Newsreader', serif; font-size: 18px; line-height: 1.65; color: var(--ink-soft);
+  background: var(--input-bg); border: 1px solid var(--input-bd); border-radius: 4px;
+  padding: 20px 22px; margin-top: 6px; white-space: pre-wrap;
+}
+.prose-meta { display:flex; justify-content:space-between; align-items:center; margin-top: 12px; gap: 12px; flex-wrap: wrap; }
+.copy-btn { background: transparent; border: 1.5px solid var(--rule); color: var(--dim); padding: 7px 12px; }
+.copy-btn:hover:not(:disabled) { color: var(--ink); border-color: var(--accent); }
+
+.spinner { display:inline-block; width:12px; height:12px; border:2px solid var(--rule); border-top-color: var(--accent); border-radius:50%; animation: spin .7s linear infinite; vertical-align: -1px; margin-right: 6px; }
+@keyframes spin { to { transform: rotate(360deg); } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="masthead">
+    <span class="title">Glossia · Bitcoin</span>
+    <span class="sub">look up a transaction, encode it into prose</span>
+    <span class="home"><a href="./index.html">demo</a></span>
+  </div>
+
+  <div class="card">
+    <label for="tx-input">Transaction ID</label>
+    <div class="lookup-row">
+      <input type="text" id="tx-input" class="mono" placeholder="e.g. 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33" autocomplete="off" spellcheck="false">
+      <button type="button" id="tx-btn">Look up</button>
+    </div>
+    <p class="hint">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet). Nothing is sent anywhere else — the lookup and encoding both happen in your browser.</p>
+    <div id="tx-status" class="status-line hidden"></div>
+  </div>
+
+  <div id="tx-result" class="hidden">
+    <div class="card">
+      <h2>Transaction</h2>
+      <dl class="rows" id="tx-summary"></dl>
+    </div>
+
+    <div class="card">
+      <h2>Inputs &amp; outputs</h2>
+      <div class="io-cols">
+        <div>
+          <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">In</div>
+          <ul class="io-list" id="tx-vin"></ul>
+        </div>
+        <div>
+          <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">Out</div>
+          <ul class="io-list" id="tx-vout"></ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Encoded as Glossia prose</h2>
+      <p class="muted" style="margin:0 0 4px; font-size:13px;">The raw signed transaction — every byte, verbatim — rendered as natural-language English. Filtering this prose against the wordlist recovers the exact hex.</p>
+      <div class="prose-box" id="tx-prose"></div>
+      <div class="prose-meta">
+        <span class="muted mono" id="tx-prose-stats" style="font-size:12px;"></span>
+        <button type="button" class="copy-btn" id="tx-copy">Copy prose</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script type="module">
+import { init, encodeSeedPhrase } from './glossia-msg.js';
+
+const $ = (id) => document.getElementById(id);
+const ESPLORA = 'https://blockstream.info/api';
+
+let ready = false;
+init().then(() => { ready = true; }).catch((e) => console.error('WASM init failed:', e));
+
+function setStatus(msg, kind) {
+  const el = $('tx-status');
+  el.className = 'status-line' + (kind ? ' ' + kind : '');
+  el.innerHTML = msg;
+  el.classList.toggle('hidden', !msg);
+}
+
+function sats(n) { return (n / 1e8).toFixed(8).replace(/0+$/, '').replace(/\.$/, '.0') + ' BTC'; }
+
+function row(dt, dd) {
+  const dtEl = document.createElement('dt'); dtEl.textContent = dt;
+  const ddEl = document.createElement('dd'); ddEl.innerHTML = dd;
+  return [dtEl, ddEl];
+}
+
+function renderSummary(tx) {
+  const dl = $('tx-summary');
+  dl.innerHTML = '';
+  const totalOut = tx.vout.reduce((s, o) => s + o.value, 0);
+  const pairs = [
+    ['TXID', `<span class="mono">${tx.txid}</span>`],
+    ['Status', tx.status.confirmed
+      ? `<span class="pill confirmed">confirmed</span> block ${tx.status.block_height} · ${new Date(tx.status.block_time * 1000).toISOString().replace('T', ' ').slice(0, 19)} UTC`
+      : `<span class="pill pending">unconfirmed</span>`],
+    ['Size / vsize / weight', `${tx.size} B / ${tx.vsize} vB / ${tx.weight} WU`],
+    ['Fee', `${tx.fee.toLocaleString()} sat (${sats(tx.fee)})`],
+    ['Inputs / outputs', `${tx.vin.length} / ${tx.vout.length}`],
+    ['Total output value', `${totalOut.toLocaleString()} sat (${sats(totalOut)})`],
+  ];
+  for (const [dt, dd] of pairs) dl.append(...row(dt, dd));
+}
+
+function renderIO(tx) {
+  const vinEl = $('tx-vin'), voutEl = $('tx-vout');
+  vinEl.innerHTML = ''; voutEl.innerHTML = '';
+  for (const vin of tx.vin) {
+    const li = document.createElement('li');
+    const addr = vin.is_coinbase ? '(coinbase)' : (vin.prevout?.scriptpubkey_address || vin.prevout?.scriptpubkey_type || 'unknown');
+    li.innerHTML = `<span class="io-addr">${addr}</span><span class="io-val">${vin.prevout ? sats(vin.prevout.value) : ''}</span>`;
+    vinEl.append(li);
+  }
+  for (const vout of tx.vout) {
+    const li = document.createElement('li');
+    const addr = vout.scriptpubkey_address || vout.scriptpubkey_type || 'unknown';
+    li.innerHTML = `<span class="io-addr">${addr}</span><span class="io-val">${sats(vout.value)}</span>`;
+    voutEl.append(li);
+  }
+}
+
+function renderProse(hex) {
+  const { prose, payloadWords } = encodeSeedPhrase(hex, 'english');
+  $('tx-prose').textContent = prose;
+  const bytes = hex.length / 2;
+  $('tx-prose-stats').textContent = `${bytes.toLocaleString()} bytes → ${payloadWords.length.toLocaleString()} payload words`;
+}
+
+async function lookup(txid) {
+  txid = txid.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(txid)) {
+    setStatus('Enter a valid 64-character hex transaction ID.', 'err');
+    return;
+  }
+  $('tx-result').classList.add('hidden');
+  setStatus('<span class="spinner"></span>fetching transaction…');
+  $('tx-btn').disabled = true;
+  try {
+    const [txRes, hexRes] = await Promise.all([
+      fetch(`${ESPLORA}/tx/${txid}`),
+      fetch(`${ESPLORA}/tx/${txid}/hex`),
+    ]);
+    if (!txRes.ok) throw new Error(txRes.status === 404 ? 'Transaction not found.' : `Esplora returned ${txRes.status}.`);
+    if (!hexRes.ok) throw new Error(`Esplora returned ${hexRes.status} fetching raw hex.`);
+    const tx = await txRes.json();
+    const hex = (await hexRes.text()).trim();
+
+    renderSummary(tx);
+    renderIO(tx);
+    if (!ready) await init().catch(() => {});
+    renderProse(hex);
+
+    $('tx-result').classList.remove('hidden');
+    setStatus('');
+  } catch (e) {
+    setStatus(e.message || 'Lookup failed.', 'err');
+  } finally {
+    $('tx-btn').disabled = false;
+  }
+}
+
+$('tx-btn').addEventListener('click', () => lookup($('tx-input').value));
+$('tx-input').addEventListener('keydown', (e) => { if (e.key === 'Enter') lookup($('tx-input').value); });
+$('tx-copy').addEventListener('click', async () => {
+  try {
+    await navigator.clipboard.writeText($('tx-prose').textContent);
+    const btn = $('tx-copy'); const old = btn.textContent;
+    btn.textContent = 'Copied ✓'; setTimeout(() => { btn.textContent = old; }, 1400);
+  } catch (e) { /* clipboard unavailable */ }
+});
+
+// Prefill from ?txid= for shareable links.
+const params = new URLSearchParams(location.search);
+const prefill = params.get('txid');
+if (prefill) { $('tx-input').value = prefill; lookup(prefill); }
+</script>
+</body>
+</html>

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -136,7 +136,7 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
   <div class="card">
     <label for="tx-input">Transaction ID</label>
     <div class="lookup-row">
-      <input type="text" id="tx-input" class="mono" placeholder="e.g. 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33" autocomplete="off" spellcheck="false">
+      <input type="text" id="tx-input" class="mono" value="4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b" placeholder="e.g. 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b" autocomplete="off" spellcheck="false">
       <button type="button" id="tx-btn">Look up</button>
     </div>
     <p class="hint">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet). Nothing is sent anywhere else — the lookup and encoding both happen in your browser.</p>
@@ -283,10 +283,12 @@ $('tx-copy').addEventListener('click', async () => {
   } catch (e) { /* clipboard unavailable */ }
 });
 
-// Prefill from ?txid= for shareable links.
+// ?txid= overrides the default (input's value attribute) for shareable links;
+// either way, look up whatever ends up in the field on load.
 const params = new URLSearchParams(location.search);
 const prefill = params.get('txid');
-if (prefill) { $('tx-input').value = prefill; lookup(prefill); }
+if (prefill) $('tx-input').value = prefill;
+lookup($('tx-input').value);
 </script>
 </body>
 </html>

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -157,7 +157,7 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
 import { init } from './glossia-msg.js';
 import { parseTransaction } from './btc-tx.js';
 import { describeTransaction, describeWitness } from './btc-prose.js';
-import { volumeBookChapter, PAGE_SIZE } from './btc-citation.js';
+import { volumeBookChapter } from './btc-citation.js';
 
 const $ = (id) => document.getElementById(id);
 const ESPLORA = 'https://blockstream.info/api';
@@ -214,8 +214,7 @@ async function renderCitation(tx, txid) {
       const txids = await r.json();
       const idx = txids.indexOf(txid);
       if (idx >= 0) {
-        const page = Math.floor(idx / PAGE_SIZE);
-        const href = `bitcoin-book.html?block=${height}&page=${page}`;
+        const href = `bitcoin-book.html?block=${height}&index=${idx}`;
         verseHtml = ` · Verse <a href="${href}">${(idx + 1).toLocaleString()}</a>`;
       }
     }

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -172,11 +172,29 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
         <button type="button" class="copy-btn" id="tx-copy">Copy prose</button>
       </div>
     </div>
+
+    <div class="card">
+      <h2>Decoded independently from the prose</h2>
+      <p class="muted" style="margin:0 0 4px; font-size:13px;">The prose above, filtered back to bytes and parsed as a raw transaction — no explorer API involved below this line. Input amounts and fee are absent on purpose: a transaction only references its inputs by <span class="mono">txid:vout</span>, not their value, so recovering those still requires chain context.</p>
+      <dl class="rows" id="tx-decoded-summary"></dl>
+      <div class="io-cols" style="margin-top:18px;">
+        <div>
+          <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">In (prevout refs)</div>
+          <ul class="io-list" id="tx-decoded-vin"></ul>
+        </div>
+        <div>
+          <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">Out</div>
+          <ul class="io-list" id="tx-decoded-vout"></ul>
+        </div>
+      </div>
+      <div id="tx-decoded-error" class="status-line err hidden" style="margin-top:14px;"></div>
+    </div>
   </div>
 </div>
 
 <script type="module">
-import { init, encodeSeedPhrase } from './glossia-msg.js';
+import { init, encodeSeedPhrase, decodeSeedPhrase } from './glossia-msg.js';
+import { parseTransaction, withAddresses } from './btc-tx.js';
 
 const $ = (id) => document.getElementById(id);
 const ESPLORA = 'https://blockstream.info/api';
@@ -238,6 +256,49 @@ function renderProse(hex) {
   $('tx-prose').textContent = prose;
   const bytes = hex.length / 2;
   $('tx-prose-stats').textContent = `${bytes.toLocaleString()} bytes → ${payloadWords.length.toLocaleString()} payload words`;
+  return prose;
+}
+
+async function renderDecoded(prose, expectedHex, esploraTx) {
+  const errEl = $('tx-decoded-error');
+  errEl.classList.add('hidden');
+  try {
+    const { hex: recoveredHex } = decodeSeedPhrase(prose, expectedHex.length / 2, 'english');
+    if (recoveredHex !== expectedHex) throw new Error('decoded bytes did not match the original transaction — round-trip mismatch.');
+
+    const parsed = await withAddresses(parseTransaction(recoveredHex));
+    const sizeMatch = parsed.size === esploraTx.size && parsed.vsize === esploraTx.vsize && parsed.weight === esploraTx.weight;
+
+    const dl = $('tx-decoded-summary');
+    dl.innerHTML = '';
+    const pairs = [
+      ['Version', String(parsed.version)],
+      ['Locktime', String(parsed.locktime)],
+      ['Segwit', parsed.segwit ? 'yes' : 'no'],
+      ['Size / vsize / weight', `${parsed.size} B / ${parsed.vsize} vB / ${parsed.weight} WU ` +
+        (sizeMatch ? '<span class="pill confirmed">matches explorer</span>' : '<span class="pill pending">mismatch</span>')],
+    ];
+    for (const [dt, dd] of pairs) dl.append(...row(dt, dd));
+
+    const vinEl = $('tx-decoded-vin'), voutEl = $('tx-decoded-vout');
+    vinEl.innerHTML = ''; voutEl.innerHTML = '';
+    for (const vin of parsed.vin) {
+      const li = document.createElement('li');
+      li.innerHTML = `<span class="io-addr">${vin.txid}:${vin.vout}</span><span class="io-val">${vin.witness.length ? 'witness' : 'legacy'}</span>`;
+      vinEl.append(li);
+    }
+    for (const vout of parsed.vout) {
+      const li = document.createElement('li');
+      li.innerHTML = `<span class="io-addr">${vout.address || vout.type}</span><span class="io-val">${sats(vout.value)}</span>`;
+      voutEl.append(li);
+    }
+  } catch (e) {
+    $('tx-decoded-summary').innerHTML = '';
+    $('tx-decoded-vin').innerHTML = '';
+    $('tx-decoded-vout').innerHTML = '';
+    errEl.textContent = e.message || 'Decode failed.';
+    errEl.classList.remove('hidden');
+  }
 }
 
 async function lookup(txid) {
@@ -262,7 +323,8 @@ async function lookup(txid) {
     renderSummary(tx);
     renderIO(tx);
     if (!ready) await init().catch(() => {});
-    renderProse(hex);
+    const prose = renderProse(hex);
+    await renderDecoded(prose, hex, tx);
 
     $('tx-result').classList.remove('hidden');
     setStatus('');

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -99,7 +99,6 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
 
 .citation { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color: var(--accent); margin-bottom: 18px; }
 .citation a { color: var(--accent); text-decoration: underline; }
-.marginalia-entry { margin: 0 0 .6em; font: italic 400 15px/1.6 'Newsreader',serif; color: var(--ink-soft); }
 
 .prose-box {
   font-family: 'Newsreader', serif; font-size: 18px; line-height: 1.65; color: var(--ink-soft);
@@ -150,17 +149,13 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
           <button type="button" class="copy-btn" id="tx-witness-copy">Copy witness prose</button>
         </div>
       </div>
-      <div id="tx-marginalia-wrap" class="hidden" style="margin-top:22px; padding-top:20px; border-top:1px dashed var(--rule);">
-        <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">Marginalia</div>
-        <div id="tx-marginalia"></div>
-      </div>
     </div>
   </div>
 </div>
 
 <script type="module">
 import { init } from './glossia-msg.js';
-import { parseTransaction, findTransactionAscii } from './btc-tx.js';
+import { parseTransaction } from './btc-tx.js';
 import { describeTransaction, describeWitness } from './btc-prose.js';
 import { volumeBookChapter, PAGE_SIZE } from './btc-citation.js';
 
@@ -179,17 +174,13 @@ function setStatus(msg, kind) {
 
 const BEST_OF = 5;
 
-// Marginalia text comes directly from raw blockchain data -- a miner's
-// coinbase tag, an OP_RETURN message -- so unlike the Glossia-generated
-// prose (always built from our own wordlist), it's untrusted content and
-// must be escaped before it ever reaches innerHTML.
-function escapeHtml(s) {
-  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
-}
-
+// describeTransaction quotes any detected coinbase/OP_RETURN text inline,
+// with HTML entities already escaped so it's safe to render -- which means
+// this must go through innerHTML, not textContent (which would show the
+// escaped entities literally instead of decoding them).
 function renderProse(parsed) {
   const { prose, payloadWords } = describeTransaction(parsed, BEST_OF);
-  $('tx-prose').textContent = prose;
+  $('tx-prose').innerHTML = prose;
   $('tx-prose-stats').textContent = `${payloadWords.length.toLocaleString()} payload words`;
 
   const { prose: witProse, payloadWords: witWords } = describeWitness(parsed, BEST_OF);
@@ -199,22 +190,6 @@ function renderProse(parsed) {
     $('tx-witness-wrap').classList.remove('hidden');
   } else {
     $('tx-witness-wrap').classList.add('hidden');
-  }
-
-  const isCoinbase = parsed.vin.length === 1 && parsed.vin[0].txid === '00'.repeat(32);
-  const found = findTransactionAscii(parsed, isCoinbase);
-  const marginaliaEl = $('tx-marginalia');
-  marginaliaEl.innerHTML = '';
-  if (found.length) {
-    for (const text of found) {
-      const el = document.createElement('p');
-      el.className = 'marginalia-entry';
-      el.innerHTML = `“${escapeHtml(text)}”`;
-      marginaliaEl.append(el);
-    }
-    $('tx-marginalia-wrap').classList.remove('hidden');
-  } else {
-    $('tx-marginalia-wrap').classList.add('hidden');
   }
 }
 

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -99,6 +99,7 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
 
 .citation { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color: var(--accent); margin-bottom: 18px; }
 .citation a { color: var(--accent); text-decoration: underline; }
+.marginalia-entry { margin: 0 0 .6em; font: italic 400 15px/1.6 'Newsreader',serif; color: var(--ink-soft); }
 
 .prose-box {
   font-family: 'Newsreader', serif; font-size: 18px; line-height: 1.65; color: var(--ink-soft);
@@ -149,13 +150,17 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
           <button type="button" class="copy-btn" id="tx-witness-copy">Copy witness prose</button>
         </div>
       </div>
+      <div id="tx-marginalia-wrap" class="hidden" style="margin-top:22px; padding-top:20px; border-top:1px dashed var(--rule);">
+        <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">Marginalia</div>
+        <div id="tx-marginalia"></div>
+      </div>
     </div>
   </div>
 </div>
 
 <script type="module">
 import { init } from './glossia-msg.js';
-import { parseTransaction } from './btc-tx.js';
+import { parseTransaction, findTransactionAscii } from './btc-tx.js';
 import { describeTransaction, describeWitness } from './btc-prose.js';
 import { volumeBookChapter, PAGE_SIZE } from './btc-citation.js';
 
@@ -174,6 +179,14 @@ function setStatus(msg, kind) {
 
 const BEST_OF = 5;
 
+// Marginalia text comes directly from raw blockchain data -- a miner's
+// coinbase tag, an OP_RETURN message -- so unlike the Glossia-generated
+// prose (always built from our own wordlist), it's untrusted content and
+// must be escaped before it ever reaches innerHTML.
+function escapeHtml(s) {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
 function renderProse(parsed) {
   const { prose, payloadWords } = describeTransaction(parsed, BEST_OF);
   $('tx-prose').textContent = prose;
@@ -186,6 +199,22 @@ function renderProse(parsed) {
     $('tx-witness-wrap').classList.remove('hidden');
   } else {
     $('tx-witness-wrap').classList.add('hidden');
+  }
+
+  const isCoinbase = parsed.vin.length === 1 && parsed.vin[0].txid === '00'.repeat(32);
+  const found = findTransactionAscii(parsed, isCoinbase);
+  const marginaliaEl = $('tx-marginalia');
+  marginaliaEl.innerHTML = '';
+  if (found.length) {
+    for (const text of found) {
+      const el = document.createElement('p');
+      el.className = 'marginalia-entry';
+      el.innerHTML = `“${escapeHtml(text)}”`;
+      marginaliaEl.append(el);
+    }
+    $('tx-marginalia-wrap').classList.remove('hidden');
+  } else {
+    $('tx-marginalia-wrap').classList.add('hidden');
   }
 }
 

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -255,8 +255,10 @@ function renderIO(tx) {
   }
 }
 
+const BEST_OF = 5;
+
 function renderProse(hex) {
-  const { prose, payloadWords } = encodeSeedPhrase(hex, 'english');
+  const { prose, payloadWords } = encodeSeedPhrase(hex, 'english', BEST_OF);
   $('tx-prose').textContent = prose;
   const bytes = hex.length / 2;
   $('tx-prose-stats').textContent = `${bytes.toLocaleString()} bytes → ${payloadWords.length.toLocaleString()} payload words`;

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -197,7 +197,8 @@ function renderProse(parsed) {
 async function renderCitation(tx, txid) {
   const el = $('tx-citation');
   if (!tx.status.confirmed) {
-    el.textContent = '— Unknown';
+    const observedAt = new Date().toISOString().slice(0, 10);
+    el.textContent = `— Unknown, circa ${observedAt}`;
     return;
   }
   const height = tx.status.block_height;

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -109,6 +109,10 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
 .io-list li:last-child { border-bottom: none; }
 .io-addr { color: var(--ink-soft); word-break: break-all; }
 .io-val { color: var(--dim); white-space: nowrap; margin-left: 12px; }
+.io-list.stacked li { display: block; }
+.io-list.stacked .io-row { display:flex; justify-content:space-between; gap:12px; }
+.io-detail { font-size: 11.5px; color: var(--meta); margin-top: 5px; word-break: break-all; }
+.io-detail b { color: var(--dim); font-weight: 500; }
 .io-cols { display:flex; gap:24px; flex-wrap:wrap; margin-top: 4px; }
 .io-cols > div { flex: 1 1 280px; min-width: 240px; }
 
@@ -180,7 +184,7 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
       <div class="io-cols" style="margin-top:18px;">
         <div>
           <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">In (prevout refs)</div>
-          <ul class="io-list" id="tx-decoded-vin"></ul>
+          <ul class="io-list stacked" id="tx-decoded-vin"></ul>
         </div>
         <div>
           <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">Out</div>
@@ -284,7 +288,13 @@ async function renderDecoded(prose, expectedHex, esploraTx) {
     vinEl.innerHTML = ''; voutEl.innerHTML = '';
     for (const vin of parsed.vin) {
       const li = document.createElement('li');
-      li.innerHTML = `<span class="io-addr">${vin.txid}:${vin.vout}</span><span class="io-val">${vin.witness.length ? 'witness' : 'legacy'}</span>`;
+      const witnessLine = vin.witness.length
+        ? `<div class="io-detail"><b>witness</b> (${vin.witness.length} item${vin.witness.length === 1 ? '' : 's'}): ${vin.witness.join(' ')}</div>`
+        : '';
+      li.innerHTML = `
+        <div class="io-row"><span class="io-addr">${vin.txid}:${vin.vout}</span><span class="io-val">${vin.witness.length ? 'witness' : 'legacy'}</span></div>
+        <div class="io-detail"><b>scriptSig</b>: ${vin.scriptSig || '(empty)'}</div>
+        ${witnessLine}`;
       vinEl.append(li);
     }
     for (const vout of parsed.vout) {

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -197,7 +197,7 @@ function renderProse(parsed) {
 async function renderCitation(tx, txid) {
   const el = $('tx-citation');
   if (!tx.status.confirmed) {
-    el.textContent = 'Unconfirmed — not yet part of a chapter';
+    el.textContent = '— Unknown';
     return;
   }
   const height = tx.status.block_height;

--- a/web/bitcoin.html
+++ b/web/bitcoin.html
@@ -95,26 +95,10 @@ button:disabled { opacity: .5; cursor: not-allowed; }
 .status-line.err { color: var(--error); }
 .status-line.ok { color: var(--ok); }
 
-/* result table */
-.rows { display: grid; grid-template-columns: max-content 1fr; gap: 8px 18px; margin-top: 4px; }
-.rows dt { font: 500 11px/1.5 'IBM Plex Mono',monospace; letter-spacing: .04em; text-transform: uppercase; color: var(--dim); white-space: nowrap; }
-.rows dd { margin: 0; font: 400 13.5px/1.5 'IBM Plex Mono',monospace; color: var(--ink-soft); word-break: break-all; }
-.pill { display:inline-block; font:600 10.5px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; padding:4px 8px; border-radius:3px; }
-.pill.confirmed { background: rgba(127,185,138,.15); color: var(--ok); }
-.pill.pending { background: rgba(224,123,106,.15); color: var(--error); }
-
 h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color: var(--dim); margin: 0 0 14px; }
-.io-list { list-style: none; margin: 0; padding: 0; }
-.io-list li { display:flex; justify-content:space-between; gap:12px; padding: 7px 0; border-bottom: 1px solid var(--hair); font: 400 13px/1.4 'IBM Plex Mono',monospace; }
-.io-list li:last-child { border-bottom: none; }
-.io-addr { color: var(--ink-soft); word-break: break-all; }
-.io-val { color: var(--dim); white-space: nowrap; margin-left: 12px; }
-.io-list.stacked li { display: block; }
-.io-list.stacked .io-row { display:flex; justify-content:space-between; gap:12px; }
-.io-detail { font-size: 11.5px; color: var(--meta); margin-top: 5px; word-break: break-all; }
-.io-detail b { color: var(--dim); font-weight: 500; }
-.io-cols { display:flex; gap:24px; flex-wrap:wrap; margin-top: 4px; }
-.io-cols > div { flex: 1 1 280px; min-width: 240px; }
+
+.citation { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color: var(--accent); margin-bottom: 18px; }
+.citation a { color: var(--accent); text-decoration: underline; }
 
 .prose-box {
   font-family: 'Newsreader', serif; font-size: 18px; line-height: 1.65; color: var(--ink-soft);
@@ -149,25 +133,7 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
 
   <div id="tx-result" class="hidden">
     <div class="card">
-      <h2>Transaction</h2>
-      <dl class="rows" id="tx-summary"></dl>
-    </div>
-
-    <div class="card">
-      <h2>Inputs &amp; outputs</h2>
-      <div class="io-cols">
-        <div>
-          <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">In</div>
-          <ul class="io-list" id="tx-vin"></ul>
-        </div>
-        <div>
-          <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">Out</div>
-          <ul class="io-list" id="tx-vout"></ul>
-        </div>
-      </div>
-    </div>
-
-    <div class="card">
+      <div class="citation" id="tx-citation"></div>
       <h2>Encoded as Glossia prose</h2>
       <p class="muted" style="margin:0 0 4px; font-size:13px;">Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits; the genuinely opaque bytes — prevout references, scripts — are what's rendered in prose.</p>
       <div class="prose-box" id="tx-prose"></div>
@@ -184,30 +150,14 @@ h2 { font:600 12px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-trans
         </div>
       </div>
     </div>
-
-    <div class="card">
-      <h2>Parsed independently</h2>
-      <p class="muted" style="margin:0 0 4px; font-size:13px;">The same raw bytes fetched above, parsed by Glossia's own transaction parser rather than Esplora's JSON — its txid verified by hashing those bytes directly, no explorer API involved below this line. Input amounts and fee are absent on purpose: a transaction only references its inputs by <span class="mono">txid:vout</span>, not their value, so recovering those still requires chain context.</p>
-      <dl class="rows" id="tx-decoded-summary"></dl>
-      <div class="io-cols" style="margin-top:18px;">
-        <div>
-          <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">In (prevout refs)</div>
-          <ul class="io-list stacked" id="tx-decoded-vin"></ul>
-        </div>
-        <div>
-          <div class="muted" style="font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.05em; text-transform:uppercase; margin-bottom:8px;">Out</div>
-          <ul class="io-list" id="tx-decoded-vout"></ul>
-        </div>
-      </div>
-      <div id="tx-decoded-error" class="status-line err hidden" style="margin-top:14px;"></div>
-    </div>
   </div>
 </div>
 
 <script type="module">
 import { init } from './glossia-msg.js';
-import { parseTransaction, computeTxid, withAddresses } from './btc-tx.js';
+import { parseTransaction } from './btc-tx.js';
 import { describeTransaction, describeWitness } from './btc-prose.js';
+import { volumeBookChapter, PAGE_SIZE } from './btc-citation.js';
 
 const $ = (id) => document.getElementById(id);
 const ESPLORA = 'https://blockstream.info/api';
@@ -220,48 +170,6 @@ function setStatus(msg, kind) {
   el.className = 'status-line' + (kind ? ' ' + kind : '');
   el.innerHTML = msg;
   el.classList.toggle('hidden', !msg);
-}
-
-function sats(n) { return (n / 1e8).toFixed(8).replace(/0+$/, '').replace(/\.$/, '.0') + ' BTC'; }
-
-function row(dt, dd) {
-  const dtEl = document.createElement('dt'); dtEl.textContent = dt;
-  const ddEl = document.createElement('dd'); ddEl.innerHTML = dd;
-  return [dtEl, ddEl];
-}
-
-function renderSummary(tx) {
-  const dl = $('tx-summary');
-  dl.innerHTML = '';
-  const totalOut = tx.vout.reduce((s, o) => s + o.value, 0);
-  const pairs = [
-    ['TXID', `<span class="mono">${tx.txid}</span>`],
-    ['Status', tx.status.confirmed
-      ? `<span class="pill confirmed">confirmed</span> block ${tx.status.block_height} · ${new Date(tx.status.block_time * 1000).toISOString().replace('T', ' ').slice(0, 19)} UTC`
-      : `<span class="pill pending">unconfirmed</span>`],
-    ['Size / vsize / weight', `${tx.size} B / ${tx.vsize} vB / ${tx.weight} WU`],
-    ['Fee', `${tx.fee.toLocaleString()} sat (${sats(tx.fee)})`],
-    ['Inputs / outputs', `${tx.vin.length} / ${tx.vout.length}`],
-    ['Total output value', `${totalOut.toLocaleString()} sat (${sats(totalOut)})`],
-  ];
-  for (const [dt, dd] of pairs) dl.append(...row(dt, dd));
-}
-
-function renderIO(tx) {
-  const vinEl = $('tx-vin'), voutEl = $('tx-vout');
-  vinEl.innerHTML = ''; voutEl.innerHTML = '';
-  for (const vin of tx.vin) {
-    const li = document.createElement('li');
-    const addr = vin.is_coinbase ? '(coinbase)' : (vin.prevout?.scriptpubkey_address || vin.prevout?.scriptpubkey_type || 'unknown');
-    li.innerHTML = `<span class="io-addr">${addr}</span><span class="io-val">${vin.prevout ? sats(vin.prevout.value) : ''}</span>`;
-    vinEl.append(li);
-  }
-  for (const vout of tx.vout) {
-    const li = document.createElement('li');
-    const addr = vout.scriptpubkey_address || vout.scriptpubkey_type || 'unknown';
-    li.innerHTML = `<span class="io-addr">${addr}</span><span class="io-val">${sats(vout.value)}</span>`;
-    voutEl.append(li);
-  }
 }
 
 const BEST_OF = 5;
@@ -281,52 +189,33 @@ function renderProse(parsed) {
   }
 }
 
-async function renderVerified(parsed, txid, esploraTx) {
-  const errEl = $('tx-decoded-error');
-  errEl.classList.add('hidden');
-  try {
-    const withAddr = await withAddresses(parsed);
-    const verifiedTxid = await computeTxid(parsed.baseHex);
-    const txidMatch = verifiedTxid === txid;
-    const sizeMatch = parsed.size === esploraTx.size && parsed.vsize === esploraTx.vsize && parsed.weight === esploraTx.weight;
-
-    const dl = $('tx-decoded-summary');
-    dl.innerHTML = '';
-    const pairs = [
-      ['Version', String(parsed.version)],
-      ['Locktime', String(parsed.locktime)],
-      ['Segwit', parsed.segwit ? 'yes' : 'no'],
-      ['Txid', txidMatch ? '<span class="pill confirmed">independently verified</span>' : '<span class="pill pending">mismatch</span>'],
-      ['Size / vsize / weight', `${parsed.size} B / ${parsed.vsize} vB / ${parsed.weight} WU ` +
-        (sizeMatch ? '<span class="pill confirmed">matches explorer</span>' : '<span class="pill pending">mismatch</span>')],
-    ];
-    for (const [dt, dd] of pairs) dl.append(...row(dt, dd));
-
-    const vinEl = $('tx-decoded-vin'), voutEl = $('tx-decoded-vout');
-    vinEl.innerHTML = ''; voutEl.innerHTML = '';
-    for (const vin of withAddr.vin) {
-      const li = document.createElement('li');
-      const witnessLine = vin.witness.length
-        ? `<div class="io-detail"><b>witness</b> (${vin.witness.length} item${vin.witness.length === 1 ? '' : 's'}): ${vin.witness.join(' ')}</div>`
-        : '';
-      li.innerHTML = `
-        <div class="io-row"><span class="io-addr">${vin.txid}:${vin.vout}</span><span class="io-val">${vin.witness.length ? 'witness' : 'legacy'}</span></div>
-        <div class="io-detail"><b>scriptSig</b>: ${vin.scriptSig || '(empty)'}</div>
-        ${witnessLine}`;
-      vinEl.append(li);
-    }
-    for (const vout of withAddr.vout) {
-      const li = document.createElement('li');
-      li.innerHTML = `<span class="io-addr">${vout.address || vout.type}</span><span class="io-val">${sats(vout.value)}</span>`;
-      voutEl.append(li);
-    }
-  } catch (e) {
-    $('tx-decoded-summary').innerHTML = '';
-    $('tx-decoded-vin').innerHTML = '';
-    $('tx-decoded-vout').innerHTML = '';
-    errEl.textContent = e.message || 'Verification failed.';
-    errEl.classList.remove('hidden');
+// Volume/Book/Chapter come straight from the confirming block's height. Verse
+// -- the transaction's position within that chapter -- needs the block's
+// full ordered txid list (one Esplora call, regardless of block size) to
+// find where this txid falls; best-effort, since an unconfirmed tx has none
+// of this yet.
+async function renderCitation(tx, txid) {
+  const el = $('tx-citation');
+  if (!tx.status.confirmed) {
+    el.textContent = 'Unconfirmed — not yet part of a chapter';
+    return;
   }
+  const height = tx.status.block_height;
+  const { volume, book, chapter } = volumeBookChapter(height);
+  let verseHtml = '';
+  try {
+    const r = await fetch(`${ESPLORA}/block/${tx.status.block_hash}/txids`);
+    if (r.ok) {
+      const txids = await r.json();
+      const idx = txids.indexOf(txid);
+      if (idx >= 0) {
+        const page = Math.floor(idx / PAGE_SIZE);
+        const href = `bitcoin-book.html?block=${height}&page=${page}`;
+        verseHtml = ` · Verse <a href="${href}">${(idx + 1).toLocaleString()}</a>`;
+      }
+    }
+  } catch (e) { /* verse is a nice-to-have; the citation still stands without it */ }
+  el.innerHTML = `Volume ${volume.toLocaleString()} · Book ${book.toLocaleString()} · Chapter ${chapter.toLocaleString()}${verseHtml}`;
 }
 
 async function lookup(txid) {
@@ -348,12 +237,10 @@ async function lookup(txid) {
     const tx = await txRes.json();
     const hex = (await hexRes.text()).trim();
 
-    renderSummary(tx);
-    renderIO(tx);
     if (!ready) await init().catch(() => {});
     const parsed = parseTransaction(hex);
     renderProse(parsed);
-    await renderVerified(parsed, txid, tx);
+    await renderCitation(tx, txid);
 
     $('tx-result').classList.remove('hidden');
     setStatus('');

--- a/web/btc-citation.js
+++ b/web/btc-citation.js
@@ -29,9 +29,3 @@ export function volumeBookChapter(height) {
     chapterCount: bookLength,
   };
 }
-
-// The page size bitcoin-book.html paginates a chapter's transactions by --
-// matches Esplora's own /block/:hash/txs/:start_index granularity. Shared
-// here so a transaction's "Verse" citation can link straight to the page
-// of the chapter it actually appears on.
-export const PAGE_SIZE = 25;

--- a/web/btc-citation.js
+++ b/web/btc-citation.js
@@ -1,0 +1,37 @@
+// btc-citation.js — the book's three-tier block numbering. Volume = a
+// halving era (210,000 blocks -- the block subsidy halves at each
+// boundary). Book = a difficulty-adjustment window (2016 blocks -- Bitcoin
+// retargets every 2016 blocks) within that era. Chapter = a block's
+// position within its book.
+//
+// 210000 isn't a multiple of 2016 (210000/2016 ~= 104.17), so book
+// numbering restarts at 1 with each volume rather than counting real global
+// difficulty periods -- the last book of every era is a shorter, truncated
+// one (336 blocks instead of 2016).
+//
+// Shared by bitcoin-book.html (the chapter view) and bitcoin.html (a single
+// transaction's "verse" citation).
+
+const ERA_BLOCKS = 210000;
+const DIFFICULTY_BLOCKS = 2016;
+
+export function volumeBookChapter(height) {
+  const volumeIndex = Math.floor(height / ERA_BLOCKS);
+  const eraStart = volumeIndex * ERA_BLOCKS;
+  const offsetInEra = height - eraStart;
+  const bookIndex = Math.floor(offsetInEra / DIFFICULTY_BLOCKS);
+  const bookStart = eraStart + bookIndex * DIFFICULTY_BLOCKS;
+  const bookLength = Math.min(DIFFICULTY_BLOCKS, ERA_BLOCKS - bookIndex * DIFFICULTY_BLOCKS);
+  return {
+    volume: volumeIndex + 1,
+    book: bookIndex + 1,
+    chapter: height - bookStart + 1,
+    chapterCount: bookLength,
+  };
+}
+
+// The page size bitcoin-book.html paginates a chapter's transactions by --
+// matches Esplora's own /block/:hash/txs/:start_index granularity. Shared
+// here so a transaction's "Verse" citation can link straight to the page
+// of the chapter it actually appears on.
+export const PAGE_SIZE = 25;

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -11,7 +11,7 @@
 //
 // Two of those numerals get a symbol instead of a digit string when they
 // carry a specific conventional meaning: a coinbase's null prevout (∅) and
-// the sequence field's default "final" value (◼︎) -- see the constants below.
+// the sequence field's default "final" value (;) -- see the constants below.
 //
 // Shared by bitcoin.html (single transaction lookup) and bitcoin-book.html
 // (block chapters) so both pages render a transaction identically.
@@ -19,17 +19,17 @@
 import { encodeSeedPhrase } from './glossia-msg.js';
 import { findAsciiStrings } from './btc-tx.js';
 
-function endSentence(s) { s = s.trim(); return s.endsWith('.') ? s : s + '.'; }
+function endSentence(s) { s = s.trim(); return /[.;!?]$/.test(s) ? s : s + '.'; }
 
 // Two more conventional values worth a symbol instead of a digit string:
 // a coinbase's null prevout (txid all-zero, paired with vout = 0xffffffff --
 // together they mean "no real previous output", so shown once as ∅ rather
 // than as two separate numbers) and the sequence field's default "final, no
-// RBF" value 0xffffffff (shown as ◼︎, wherever it appears -- this isn't
+// RBF" value 0xffffffff (shown as ;, wherever it appears -- this isn't
 // coinbase-specific, ordinary transactions set it just as often).
 const FINAL_SEQUENCE = 4294967295;
 const NULL_PREVOUT_MARK = '∅';
-const FINAL_SEQUENCE_MARK = '◼︎';
+const FINAL_SEQUENCE_MARK = ';';
 
 // Quoted script text comes directly from raw blockchain data -- a miner's
 // coinbase tag, an OP_RETURN message -- not our own wordlist, so unlike the

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -1,0 +1,53 @@
+// btc-prose.js — compose a Bitcoin transaction's Glossia prose, field by
+// field, in wire order: small structural integers (version, counts, an
+// input's referenced output index and sequence, an output's value,
+// locktime) are spliced in as literal numerals -- they're small fixed-width
+// integers, not entropy, and routing them through the wordlist is exactly
+// what produces long zero-byte word runs (a version of 1 is stored as
+// 01 00 00 00; locktime is 0 in the overwhelming majority of transactions;
+// output values sit nowhere near the 8-byte field's ceiling). Only the
+// genuinely opaque bytes -- prevout txid, scriptSig, scriptPubKey, the
+// witness stack -- are still Glossia-encoded.
+//
+// Shared by bitcoin.html (single transaction lookup) and bitcoin-book.html
+// (block chapters) so both pages render a transaction identically.
+
+import { encodeSeedPhrase } from './glossia-msg.js';
+
+function endSentence(s) { s = s.trim(); return s.endsWith('.') ? s : s + '.'; }
+
+// A parsed transaction (btc-tx.js's parseTransaction) -> { prose, payloadWords }.
+// `bestOf` forwards to encodeSeedPhrase for cover-word quality (default 1).
+export function describeTransaction(parsed, bestOf = 1) {
+  const parts = [`${parsed.version}.`, `${parsed.vin.length}.`];
+  const payloadWords = [];
+  const collect = (hex) => {
+    if (!hex) return '';
+    const r = encodeSeedPhrase(hex, 'english', bestOf);
+    payloadWords.push(...r.payloadWords);
+    return r.prose;
+  };
+
+  for (const v of parsed.vin) {
+    const isNullPrevout = v.txid === '00'.repeat(32);
+    const txidPart = isNullPrevout ? '0' : collect(v.txid);
+    const scriptProse = collect(v.scriptSig);
+    parts.push(endSentence(`${txidPart} ${v.vout} ${scriptProse} ${v.sequence}`));
+  }
+
+  parts.push(`${parsed.vout.length}.`);
+  for (const o of parsed.vout) {
+    const scriptProse = collect(o.scriptPubKey);
+    parts.push(endSentence(`${o.value} ${scriptProse}`));
+  }
+
+  parts.push(`${parsed.locktime}.`);
+  return { prose: parts.join(' ').replace(/\s+/g, ' ').trim(), payloadWords };
+}
+
+// The witness section's raw hex (parsed.witnessHex) -> { prose, payloadWords },
+// or { prose: '', payloadWords: [] } when the transaction carries no witness data.
+export function describeWitness(parsed, bestOf = 1) {
+  if (!parsed.witnessHex) return { prose: '', payloadWords: [] };
+  return encodeSeedPhrase(parsed.witnessHex, 'english', bestOf);
+}

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -33,11 +33,6 @@ const NULL_PREVOUT_MARK = '∅';
 const FINAL_SEQUENCE_MARK = '·';
 const LOCKTIME_ZERO_MARK = '◼︎';
 
-// A clause is already "finished" if it ends in real punctuation or one of
-// the symbolic marks above -- either way, no redundant period gets appended.
-const TERMINAL_CHARS = new Set(['.', ';', '!', '?', FINAL_SEQUENCE_MARK]);
-function endSentence(s) { s = s.trim(); return TERMINAL_CHARS.has(s.slice(-1)) ? s : s + '.'; }
-
 // Quoted script text comes directly from raw blockchain data -- a miner's
 // coinbase tag, an OP_RETURN message -- not our own wordlist, so unlike the
 // Glossia-generated prose it's untrusted content and must be escaped before
@@ -49,7 +44,7 @@ function escapeHtml(s) {
 // A parsed transaction (btc-tx.js's parseTransaction) -> { prose, payloadWords }.
 // `bestOf` forwards to encodeSeedPhrase for cover-word quality (default 1).
 export function describeTransaction(parsed, bestOf = 1) {
-  const parts = [`${parsed.version}.`, `${parsed.vin.length}.`];
+  const parts = [`${parsed.version}`, `${parsed.vin.length}`];
   const payloadWords = [];
   const collect = (hex) => {
     if (!hex) return '';
@@ -78,17 +73,17 @@ export function describeTransaction(parsed, bestOf = 1) {
     const prevoutPart = isNullPrevout ? NULL_PREVOUT_MARK : `${collect(v.txid)} ${v.vout}`;
     const scriptProse = collectScript(v.scriptSig, isNullPrevout);
     const sequencePart = v.sequence === FINAL_SEQUENCE ? FINAL_SEQUENCE_MARK : String(v.sequence);
-    parts.push(endSentence(`${prevoutPart} ${scriptProse} ${sequencePart}`));
+    parts.push(`${prevoutPart} ${scriptProse} ${sequencePart}`);
   }
 
-  parts.push(`${parsed.vout.length}.`);
+  parts.push(`${parsed.vout.length}`);
   for (const o of parsed.vout) {
     const isOpReturn = o.scriptPubKey.slice(0, 2).toLowerCase() === '6a';
     const scriptProse = collectScript(o.scriptPubKey, isOpReturn);
-    parts.push(endSentence(`${o.value} ${scriptProse}`));
+    parts.push(`${o.value} ${scriptProse}`);
   }
 
-  parts.push(parsed.locktime === 0 ? `${LOCKTIME_ZERO_MARK}.` : `${parsed.locktime}.`);
+  parts.push(parsed.locktime === 0 ? LOCKTIME_ZERO_MARK : `${parsed.locktime}`);
   return { prose: parts.join(' ').replace(/\s+/g, ' ').trim(), payloadWords };
 }
 

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -9,6 +9,10 @@
 // genuinely opaque bytes -- prevout txid, scriptSig, scriptPubKey, the
 // witness stack -- are still Glossia-encoded.
 //
+// Two of those numerals get a symbol instead of a digit string when they
+// carry a specific conventional meaning: a coinbase's null prevout (∅) and
+// the sequence field's default "final" value (◼︎) -- see the constants below.
+//
 // Shared by bitcoin.html (single transaction lookup) and bitcoin-book.html
 // (block chapters) so both pages render a transaction identically.
 
@@ -16,6 +20,16 @@ import { encodeSeedPhrase } from './glossia-msg.js';
 import { findAsciiStrings } from './btc-tx.js';
 
 function endSentence(s) { s = s.trim(); return s.endsWith('.') ? s : s + '.'; }
+
+// Two more conventional values worth a symbol instead of a digit string:
+// a coinbase's null prevout (txid all-zero, paired with vout = 0xffffffff --
+// together they mean "no real previous output", so shown once as ∅ rather
+// than as two separate numbers) and the sequence field's default "final, no
+// RBF" value 0xffffffff (shown as ◼︎, wherever it appears -- this isn't
+// coinbase-specific, ordinary transactions set it just as often).
+const FINAL_SEQUENCE = 4294967295;
+const NULL_PREVOUT_MARK = '∅';
+const FINAL_SEQUENCE_MARK = '◼︎';
 
 // Quoted script text comes directly from raw blockchain data -- a miner's
 // coinbase tag, an OP_RETURN message -- not our own wordlist, so unlike the
@@ -54,9 +68,10 @@ export function describeTransaction(parsed, bestOf = 1) {
 
   for (const v of parsed.vin) {
     const isNullPrevout = v.txid === '00'.repeat(32);
-    const txidPart = isNullPrevout ? '0' : collect(v.txid);
+    const prevoutPart = isNullPrevout ? NULL_PREVOUT_MARK : `${collect(v.txid)} ${v.vout}`;
     const scriptProse = collectScript(v.scriptSig, isNullPrevout);
-    parts.push(endSentence(`${txidPart} ${v.vout} ${scriptProse} ${v.sequence}`));
+    const sequencePart = v.sequence === FINAL_SEQUENCE ? FINAL_SEQUENCE_MARK : String(v.sequence);
+    parts.push(endSentence(`${prevoutPart} ${scriptProse} ${sequencePart}`));
   }
 
   parts.push(`${parsed.vout.length}.`);

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -9,9 +9,10 @@
 // genuinely opaque bytes -- prevout txid, scriptSig, scriptPubKey, the
 // witness stack -- are still Glossia-encoded.
 //
-// Two of those numerals get a symbol instead of a digit string when they
-// carry a specific conventional meaning: a coinbase's null prevout (∅) and
-// the sequence field's default "final" value (;) -- see the constants below.
+// Some of those numerals get a symbol instead of a digit string when they
+// carry a specific conventional meaning -- a coinbase's null prevout (∅),
+// the sequence field's default "final" value (·), and locktime = 0, the
+// overwhelmingly common case (◼︎) -- see the constants below.
 //
 // Shared by bitcoin.html (single transaction lookup) and bitcoin-book.html
 // (block chapters) so both pages render a transaction identically.
@@ -19,17 +20,23 @@
 import { encodeSeedPhrase } from './glossia-msg.js';
 import { findAsciiStrings } from './btc-tx.js';
 
-function endSentence(s) { s = s.trim(); return /[.;!?]$/.test(s) ? s : s + '.'; }
-
-// Two more conventional values worth a symbol instead of a digit string:
-// a coinbase's null prevout (txid all-zero, paired with vout = 0xffffffff --
-// together they mean "no real previous output", so shown once as ∅ rather
-// than as two separate numbers) and the sequence field's default "final, no
-// RBF" value 0xffffffff (shown as ;, wherever it appears -- this isn't
-// coinbase-specific, ordinary transactions set it just as often).
+// Conventional values worth a symbol instead of a digit string: a coinbase's
+// null prevout (txid all-zero, paired with vout = 0xffffffff -- together
+// they mean "no real previous output", so shown once as ∅ rather than as
+// two separate numbers), the sequence field's default "final, no RBF" value
+// 0xffffffff (shown as ·, wherever it appears -- this isn't coinbase-
+// specific, ordinary transactions set it just as often), and locktime = 0
+// (shown as ◼︎ -- no timelock, the case for the overwhelming majority of
+// transactions).
 const FINAL_SEQUENCE = 4294967295;
 const NULL_PREVOUT_MARK = '∅';
-const FINAL_SEQUENCE_MARK = ';';
+const FINAL_SEQUENCE_MARK = '·';
+const LOCKTIME_ZERO_MARK = '◼︎';
+
+// A clause is already "finished" if it ends in real punctuation or one of
+// the symbolic marks above -- either way, no redundant period gets appended.
+const TERMINAL_CHARS = new Set(['.', ';', '!', '?', FINAL_SEQUENCE_MARK]);
+function endSentence(s) { s = s.trim(); return TERMINAL_CHARS.has(s.slice(-1)) ? s : s + '.'; }
 
 // Quoted script text comes directly from raw blockchain data -- a miner's
 // coinbase tag, an OP_RETURN message -- not our own wordlist, so unlike the
@@ -81,7 +88,7 @@ export function describeTransaction(parsed, bestOf = 1) {
     parts.push(endSentence(`${o.value} ${scriptProse}`));
   }
 
-  parts.push(`${parsed.locktime}.`);
+  parts.push(parsed.locktime === 0 ? `${LOCKTIME_ZERO_MARK}.` : `${parsed.locktime}.`);
   return { prose: parts.join(' ').replace(/\s+/g, ' ').trim(), payloadWords };
 }
 

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -41,10 +41,13 @@ function escapeHtml(s) {
   return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
 
-// A parsed transaction (btc-tx.js's parseTransaction) -> { prose, payloadWords }.
+// A parsed transaction (btc-tx.js's parseTransaction) -> a structured
+// breakdown of every field's rendered text, in wire order, plus the
+// payload words consumed. Both describeTransaction (the flat canonical
+// string) and bitcoin-book.html's margin layout are built from this, so
+// a field is only ever Glossia-encoded once.
 // `bestOf` forwards to encodeSeedPhrase for cover-word quality (default 1).
-export function describeTransaction(parsed, bestOf = 1) {
-  const parts = [`${parsed.version}`, `${parsed.vin.length}`];
+export function composeTransactionFields(parsed, bestOf = 1) {
   const payloadWords = [];
   const collect = (hex) => {
     if (!hex) return '';
@@ -68,23 +71,44 @@ export function describeTransaction(parsed, bestOf = 1) {
     return collect(hex);
   };
 
-  for (const v of parsed.vin) {
+  const inputs = parsed.vin.map((v) => {
     const isNullPrevout = v.txid === '00'.repeat(32);
-    const prevoutPart = isNullPrevout ? NULL_PREVOUT_MARK : `${collect(v.txid)} ${v.vout}`;
-    const scriptProse = collectScript(v.scriptSig, isNullPrevout);
-    const sequencePart = v.sequence === FINAL_SEQUENCE ? FINAL_SEQUENCE_MARK : String(v.sequence);
-    parts.push(`${prevoutPart} ${scriptProse} ${sequencePart}`);
-  }
+    const prevout = isNullPrevout ? NULL_PREVOUT_MARK : `${collect(v.txid)} ${v.vout}`;
+    const script = collectScript(v.scriptSig, isNullPrevout);
+    const sequence = v.sequence === FINAL_SEQUENCE ? FINAL_SEQUENCE_MARK : String(v.sequence);
+    return { prevout, script, sequence };
+  });
 
-  parts.push(`${parsed.vout.length}`);
-  for (const o of parsed.vout) {
+  const outputs = parsed.vout.map((o) => {
     const isOpReturn = o.scriptPubKey.slice(0, 2).toLowerCase() === '6a';
-    const scriptProse = collectScript(o.scriptPubKey, isOpReturn);
-    parts.push(`${o.value} ${scriptProse}`);
-  }
+    const script = collectScript(o.scriptPubKey, isOpReturn);
+    return { script, value: String(o.value) };
+  });
 
-  parts.push(parsed.locktime === 0 ? LOCKTIME_ZERO_MARK : `${parsed.locktime}`);
-  return { prose: parts.join(' ').replace(/\s+/g, ' ').trim(), payloadWords };
+  return {
+    version: String(parsed.version),
+    inputCount: String(parsed.vin.length),
+    inputs,
+    outputCount: String(parsed.vout.length),
+    outputs,
+    locktime: parsed.locktime === 0 ? LOCKTIME_ZERO_MARK : String(parsed.locktime),
+    payloadWords,
+  };
+}
+
+// A parsed transaction -> { prose, payloadWords }, prose being the flat
+// canonical text in exact wire order -- the linear, decodable form
+// (Copy buttons, filtering against the payload wordlist). Any renderer
+// (e.g. bitcoin-book.html's margin layout) is free to reposition these
+// same fields visually without touching this canonical order.
+export function describeTransaction(parsed, bestOf = 1) {
+  const f = composeTransactionFields(parsed, bestOf);
+  const parts = [f.version, f.inputCount];
+  for (const inp of f.inputs) parts.push(`${inp.prevout} ${inp.script} ${inp.sequence}`);
+  parts.push(f.outputCount);
+  for (const out of f.outputs) parts.push(`${out.value} ${out.script}`);
+  parts.push(f.locktime);
+  return { prose: parts.join(' ').replace(/\s+/g, ' ').trim(), payloadWords: f.payloadWords };
 }
 
 // The witness section's raw hex (parsed.witnessHex) -> { prose, payloadWords },

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -13,8 +13,17 @@
 // (block chapters) so both pages render a transaction identically.
 
 import { encodeSeedPhrase } from './glossia-msg.js';
+import { findAsciiStrings } from './btc-tx.js';
 
 function endSentence(s) { s = s.trim(); return s.endsWith('.') ? s : s + '.'; }
+
+// Quoted script text comes directly from raw blockchain data -- a miner's
+// coinbase tag, an OP_RETURN message -- not our own wordlist, so unlike the
+// Glossia-generated prose it's untrusted content and must be escaped before
+// it's spliced into a string callers render via innerHTML.
+function escapeHtml(s) {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
 
 // A parsed transaction (btc-tx.js's parseTransaction) -> { prose, payloadWords }.
 // `bestOf` forwards to encodeSeedPhrase for cover-word quality (default 1).
@@ -27,17 +36,33 @@ export function describeTransaction(parsed, bestOf = 1) {
     payloadWords.push(...r.payloadWords);
     return r.prose;
   };
+  // Two spots carry deliberate human-readable text rather than
+  // cryptographic material: a coinbase input's scriptSig (mining pool
+  // tags) and an OP_RETURN output's scriptPubKey (arbitrary embedded
+  // messages). When detected there, that text is quoted inline verbatim
+  // instead of Glossia-encoded -- it's already legible, so routing it
+  // through the wordlist would just swap real words for unrelated ones.
+  // See btc-tx.js's findAsciiStrings for why this stays scoped to just
+  // these two fields rather than scriptSig/scriptPubKey/witness generally.
+  const collectScript = (hex, eligible) => {
+    if (eligible) {
+      const found = findAsciiStrings(hex);
+      if (found.length) return found.map((s) => `“${escapeHtml(s)}”`).join(' ');
+    }
+    return collect(hex);
+  };
 
   for (const v of parsed.vin) {
     const isNullPrevout = v.txid === '00'.repeat(32);
     const txidPart = isNullPrevout ? '0' : collect(v.txid);
-    const scriptProse = collect(v.scriptSig);
+    const scriptProse = collectScript(v.scriptSig, isNullPrevout);
     parts.push(endSentence(`${txidPart} ${v.vout} ${scriptProse} ${v.sequence}`));
   }
 
   parts.push(`${parsed.vout.length}.`);
   for (const o of parsed.vout) {
-    const scriptProse = collect(o.scriptPubKey);
+    const isOpReturn = o.scriptPubKey.slice(0, 2).toLowerCase() === '6a';
+    const scriptProse = collectScript(o.scriptPubKey, isOpReturn);
     parts.push(endSentence(`${o.value} ${scriptProse}`));
   }
 

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -225,3 +225,85 @@ export async function withAddresses(tx) {
   for (const o of tx.vout) vout.push({ ...o, ...(await scriptToAddress(o.scriptPubKey)) });
   return { ...tx, vout };
 }
+
+// ─── embedded ASCII text ───────────────────────────────────────────────
+//
+// scriptSig and scriptPubKey bytes are usually cryptographic material --
+// signatures, pubkeys, hashes -- effectively random. But two spots
+// routinely carry deliberate human-readable text: a coinbase input's
+// scriptSig (mining pool tags like "/ViaBTC/") and OP_RETURN outputs
+// (arbitrary embedded messages). This scans any byte string for runs of
+// printable ASCII, so those can be surfaced instead of run through the
+// wordlist as if they were opaque.
+//
+// A minimum run length matters: a single random byte has roughly a 37%
+// chance of falling in the printable range (0x20-0x7E is 95 of 256 values),
+// so short "printable-looking" runs turn up by pure chance in genuine
+// cryptographic material. Requiring several consecutive printable bytes
+// keeps that noise out.
+const ASCII_MIN_RUN = 5;
+
+// Parse a script into its push-data segments, ignoring non-push opcodes
+// (OP_DUP, OP_HASH160, OP_CHECKSIG, the OP_RETURN marker itself, etc.).
+// Scanning each push independently -- rather than the whole script blob --
+// matters: a pushdata length-prefix byte is just as likely to fall in the
+// printable-ASCII range as any other, and scanning the raw blob glues it
+// onto the front of the real text (0x45 = 'E' preceding a 69-byte push,
+// for example). Returns null if the bytes don't parse as a clean sequence
+// of opcodes (some coinbase scriptSigs are arbitrary, not necessarily
+// well-formed script) so the caller can fall back to a raw scan.
+function scriptPushes(bytes) {
+  const pushes = [];
+  let i = 0;
+  while (i < bytes.length) {
+    const op = bytes[i];
+    let len, dataStart;
+    if (op >= 0x01 && op <= 0x4b) { len = op; dataStart = i + 1; }
+    else if (op === 0x4c) { if (i + 2 > bytes.length) return null; len = bytes[i + 1]; dataStart = i + 2; }
+    else if (op === 0x4d) { if (i + 3 > bytes.length) return null; len = bytes[i + 1] | (bytes[i + 2] << 8); dataStart = i + 3; }
+    else if (op === 0x4e) {
+      if (i + 5 > bytes.length) return null;
+      len = (bytes[i + 1] | (bytes[i + 2] << 8) | (bytes[i + 3] << 16) | (bytes[i + 4] << 24)) >>> 0;
+      dataStart = i + 5;
+    } else { i += 1; continue; }   // non-push opcode -- no associated data to extract
+    if (dataStart + len > bytes.length) return null;
+    pushes.push(bytes.subarray(dataStart, dataStart + len));
+    i = dataStart + len;
+  }
+  return pushes;
+}
+
+export function findAsciiStrings(hex, minRun = ASCII_MIN_RUN) {
+  const bytes = hexToBytes(hex);
+  const segments = scriptPushes(bytes) || [bytes];   // fall back to the raw blob if it isn't clean script
+  const found = [];
+  for (const seg of segments) {
+    let start = -1;
+    for (let i = 0; i <= seg.length; i++) {
+      const printable = i < seg.length && seg[i] >= 0x20 && seg[i] <= 0x7e;
+      if (printable) {
+        if (start === -1) start = i;
+      } else if (start !== -1) {
+        if (i - start >= minRun) found.push(String.fromCharCode(...seg.subarray(start, i)));
+        start = -1;
+      }
+    }
+  }
+  return found;
+}
+
+// Where to actually look for embedded text in a parsed transaction: a
+// coinbase input's scriptSig (mining pool tags), and any OP_RETURN output's
+// scriptPubKey (arbitrary embedded messages). Everywhere else -- ordinary
+// scriptSig/scriptPubKey/witness data -- is cryptographic material, where a
+// scan like this turns up "coincidental" printable-looking noise roughly
+// half the time (verified empirically at minRun=5 against random 140-byte
+// blobs), not genuine text, so it's deliberately skipped.
+export function findTransactionAscii(parsed, isCoinbase) {
+  const found = [];
+  if (isCoinbase && parsed.vin[0]) found.push(...findAsciiStrings(parsed.vin[0].scriptSig));
+  for (const o of parsed.vout) {
+    if (o.scriptPubKey.slice(0, 2).toLowerCase() === '6a') found.push(...findAsciiStrings(o.scriptPubKey));
+  }
+  return found;
+}

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -1,0 +1,206 @@
+// btc-tx.js — a small, dependency-free Bitcoin transaction wire-format
+// parser: raw tx hex -> structured fields (version, vin, vout, locktime,
+// witness, size/vsize/weight), plus address derivation from scriptPubKey.
+//
+// This exists to close the loop on Glossia's round trip: once prose decodes
+// back to the exact raw transaction bytes, this is what turns those bytes
+// into the same structured view a block explorer shows — no explorer API,
+// no external library, just the wire format (BIP144/BIP141) and address
+// encodings (base58check, bech32/bech32m per BIP173/BIP350).
+//
+// What this CANNOT recover from a single transaction's bytes: input values
+// (and therefore fee), and confirmation status. A transaction only
+// references its inputs by prevout txid:vout, not their amount — that value
+// lives in whichever earlier transaction created the output — and
+// confirmation/block-height is chain state, not transaction data.
+
+function hexToBytes(hex) {
+  const clean = hex.trim();
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.substr(i * 2, 2), 16);
+  return out;
+}
+function bytesToHex(bytes) { return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join(''); }
+function reverseBytes(bytes) { return Uint8Array.from(bytes).reverse(); }
+
+class Reader {
+  constructor(bytes) { this.bytes = bytes; this.pos = 0; }
+  bytesN(n) {
+    if (this.pos + n > this.bytes.length) throw new Error('unexpected end of transaction data');
+    const b = this.bytes.subarray(this.pos, this.pos + n);
+    this.pos += n;
+    return b;
+  }
+  u8() { return this.bytesN(1)[0]; }
+  u32le() { const b = this.bytesN(4); return (b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)) >>> 0; }
+  u64le() {
+    const b = this.bytesN(8);
+    const lo = (b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)) >>> 0;
+    const hi = (b[4] | (b[5] << 8) | (b[6] << 16) | (b[7] << 24)) >>> 0;
+    return hi * 0x100000000 + lo;   // safe for realistic sat amounts (< 2^53)
+  }
+  varint() {
+    const first = this.u8();
+    if (first < 0xfd) return first;
+    if (first === 0xfd) { const b = this.bytesN(2); return b[0] | (b[1] << 8); }
+    if (first === 0xfe) return this.u32le();
+    return this.u64le();
+  }
+}
+
+// Raw tx hex -> structured fields. Throws on malformed/truncated input
+// (including trailing bytes — the whole buffer must parse as one transaction).
+export function parseTransaction(hex) {
+  const bytes = hexToBytes(hex);
+  const r = new Reader(bytes);
+  const version = r.u32le();
+
+  let segwit = false;
+  if (bytes[r.pos] === 0x00 && bytes[r.pos + 1] === 0x01) { segwit = true; r.pos += 2; }
+
+  const vinCount = r.varint();
+  const vin = [];
+  for (let i = 0; i < vinCount; i++) {
+    const txid = bytesToHex(reverseBytes(r.bytesN(32)));   // wire order is internal (reversed) byte order
+    const vout = r.u32le();
+    const scriptSig = bytesToHex(r.bytesN(r.varint()));
+    const sequence = r.u32le();
+    vin.push({ txid, vout, scriptSig, sequence, witness: [] });
+  }
+
+  const voutCount = r.varint();
+  const vout = [];
+  for (let i = 0; i < voutCount; i++) {
+    const value = r.u64le();
+    const scriptPubKey = bytesToHex(r.bytesN(r.varint()));
+    vout.push({ value, scriptPubKey });
+  }
+
+  let witnessBytes = 0;
+  if (segwit) {
+    const witStart = r.pos;
+    for (let i = 0; i < vinCount; i++) {
+      const itemCount = r.varint();
+      const items = [];
+      for (let j = 0; j < itemCount; j++) items.push(bytesToHex(r.bytesN(r.varint())));
+      vin[i].witness = items;
+    }
+    witnessBytes = r.pos - witStart;
+  }
+
+  const locktime = r.u32le();
+  if (r.pos !== bytes.length) throw new Error(`trailing bytes after transaction (${bytes.length - r.pos} unparsed)`);
+
+  // BIP141 weight: base_size counts once, the segwit marker/flag/witness count 1/4x.
+  const size = bytes.length;
+  const baseSize = size - (segwit ? 2 + witnessBytes : 0);
+  const weight = baseSize * 3 + size;
+  const vsize = Math.ceil(weight / 4);
+
+  return { version, locktime, segwit, size, vsize, weight, vin, vout };
+}
+
+// ─── address derivation from scriptPubKey (no external library) ──────────
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+async function sha256(bytes) { return new Uint8Array(await crypto.subtle.digest('SHA-256', bytes)); }
+async function hash256(bytes) { return sha256(await sha256(bytes)); }
+
+async function base58checkEncode(versionByte, payload) {
+  const body = new Uint8Array(1 + payload.length);
+  body[0] = versionByte;
+  body.set(payload, 1);
+  const checksum = (await hash256(body)).subarray(0, 4);
+  const full = new Uint8Array(body.length + 4);
+  full.set(body, 0);
+  full.set(checksum, body.length);
+
+  let n = 0n;
+  for (const b of full) n = (n << 8n) | BigInt(b);
+  let out = '';
+  while (n > 0n) { out = BASE58_ALPHABET[Number(n % 58n)] + out; n /= 58n; }
+  for (const b of full) { if (b === 0) out = '1' + out; else break; }
+  return out || '1';
+}
+
+const BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+const BECH32_CONST = 1;
+const BECH32M_CONST = 0x2bc830a3;
+
+function bech32Polymod(values) {
+  const GEN = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+  let chk = 1;
+  for (const v of values) {
+    const top = chk >>> 25;
+    chk = ((chk & 0x1ffffff) << 5) ^ v;
+    for (let i = 0; i < 5; i++) if ((top >> i) & 1) chk ^= GEN[i];
+  }
+  return chk >>> 0;
+}
+function bech32HrpExpand(hrp) {
+  const out = [];
+  for (const c of hrp) out.push(c.charCodeAt(0) >> 5);
+  out.push(0);
+  for (const c of hrp) out.push(c.charCodeAt(0) & 31);
+  return out;
+}
+function convertBits(data, fromBits, toBits, pad) {
+  let acc = 0, bits = 0;
+  const out = [];
+  const maxv = (1 << toBits) - 1;
+  for (const value of data) {
+    acc = (acc << fromBits) | value;
+    bits += fromBits;
+    while (bits >= toBits) { bits -= toBits; out.push((acc >> bits) & maxv); }
+  }
+  if (pad && bits > 0) out.push((acc << (toBits - bits)) & maxv);
+  return out;
+}
+function segwitAddrEncode(hrp, witver, witprogBytes) {
+  const data5 = [witver, ...convertBits(Array.from(witprogBytes), 8, 5, true)];
+  const constant = witver === 0 ? BECH32_CONST : BECH32M_CONST;
+  const values = bech32HrpExpand(hrp).concat(data5, [0, 0, 0, 0, 0, 0]);
+  const mod = bech32Polymod(values) ^ constant;
+  const checksum = [];
+  for (let i = 0; i < 6; i++) checksum.push((mod >> (5 * (5 - i))) & 31);
+  return hrp + '1' + data5.concat(checksum).map((d) => BECH32_CHARSET[d]).join('');
+}
+
+// scriptPubKey hex -> { type, address }. address is null for scripts with no
+// standard address form (OP_RETURN, unrecognized templates).
+export async function scriptToAddress(scriptHex) {
+  const s = hexToBytes(scriptHex);
+
+  // P2PKH: OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG
+  if (s.length === 25 && s[0] === 0x76 && s[1] === 0xa9 && s[2] === 0x14 && s[23] === 0x88 && s[24] === 0xac) {
+    return { type: 'p2pkh', address: await base58checkEncode(0x00, s.subarray(3, 23)) };
+  }
+  // P2SH: OP_HASH160 <20> OP_EQUAL
+  if (s.length === 23 && s[0] === 0xa9 && s[1] === 0x14 && s[22] === 0x87) {
+    return { type: 'p2sh', address: await base58checkEncode(0x05, s.subarray(2, 22)) };
+  }
+  // OP_RETURN: no address, carries arbitrary data
+  if (s.length > 0 && s[0] === 0x6a) return { type: 'op_return', address: null };
+  // Witness programs: OP_0 / OP_1..OP_16 <push:2-40 bytes> <program>
+  if (s.length >= 4 && s.length <= 42) {
+    const op = s[0];
+    const witver = op === 0x00 ? 0 : (op >= 0x51 && op <= 0x60 ? op - 0x50 : -1);
+    if (witver >= 0) {
+      const pushLen = s[1];
+      if (s.length === 2 + pushLen && pushLen >= 2 && pushLen <= 40) {
+        const prog = s.subarray(2, 2 + pushLen);
+        const type = witver === 0 ? (pushLen === 20 ? 'p2wpkh' : 'p2wsh') : (witver === 1 ? 'p2tr' : `witness_v${witver}`);
+        return { type, address: segwitAddrEncode('bc', witver, prog) };
+      }
+    }
+  }
+  return { type: 'unknown', address: null };
+}
+
+// Attach a derived { type, address } to every output of a parsed transaction.
+export async function withAddresses(tx) {
+  const vout = [];
+  for (const o of tx.vout) vout.push({ ...o, ...(await scriptToAddress(o.scriptPubKey)) });
+  return { ...tx, vout };
+}

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -56,7 +56,10 @@ export function parseTransaction(hex) {
   const version = r.u32le();
 
   let segwit = false;
-  if (bytes[r.pos] === 0x00 && bytes[r.pos + 1] === 0x01) { segwit = true; r.pos += 2; }
+  const markerEnd = (() => {
+    if (bytes[r.pos] === 0x00 && bytes[r.pos + 1] === 0x01) { segwit = true; r.pos += 2; }
+    return r.pos;
+  })();
 
   const vinCount = r.varint();
   const vin = [];
@@ -75,10 +78,11 @@ export function parseTransaction(hex) {
     const scriptPubKey = bytesToHex(r.bytesN(r.varint()));
     vout.push({ value, scriptPubKey });
   }
+  const voutEnd = r.pos;
 
   let witnessBytes = 0;
+  const witStart = voutEnd;
   if (segwit) {
-    const witStart = r.pos;
     for (let i = 0; i < vinCount; i++) {
       const itemCount = r.varint();
       const items = [];
@@ -88,6 +92,7 @@ export function parseTransaction(hex) {
     witnessBytes = r.pos - witStart;
   }
 
+  const locktimeStart = r.pos;
   const locktime = r.u32le();
   if (r.pos !== bytes.length) throw new Error(`trailing bytes after transaction (${bytes.length - r.pos} unparsed)`);
 
@@ -97,7 +102,23 @@ export function parseTransaction(hex) {
   const weight = baseSize * 3 + size;
   const vsize = Math.ceil(weight / 4);
 
-  return { version, locktime, segwit, size, vsize, weight, vin, vout };
+  // The legacy (pre-segwit) serialization — version + vin/vout + locktime, with
+  // the marker/flag and witness stripped out. This is exactly what BIP141 hashes
+  // (double-SHA256, byte-reversed) to produce the txid, so it's also what
+  // computeTxid expects. witnessHex is the raw witness section verbatim, or
+  // empty when the transaction carries no witness data.
+  const baseHex = bytesToHex(bytes.subarray(0, 4)) + bytesToHex(bytes.subarray(markerEnd, voutEnd)) + bytesToHex(bytes.subarray(locktimeStart, locktimeStart + 4));
+  const witnessHex = segwit ? bytesToHex(bytes.subarray(witStart, witStart + witnessBytes)) : '';
+
+  return { version, locktime, segwit, size, vsize, weight, vin, vout, baseHex, witnessHex };
+}
+
+// The legacy-serialization bytes (parseTransaction's baseHex) hashed with
+// double-SHA256 and byte-reversed, per BIP141 — the transaction's txid,
+// computed with no explorer API involved. A mismatch against a claimed txid
+// means the bytes don't actually belong to that transaction.
+export async function computeTxid(baseHex) {
+  return bytesToHex(reverseBytes(await hash256(hexToBytes(baseHex))));
 }
 
 // ─── address derivation from scriptPubKey (no external library) ──────────

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -291,19 +291,3 @@ export function findAsciiStrings(hex, minRun = ASCII_MIN_RUN) {
   }
   return found;
 }
-
-// Where to actually look for embedded text in a parsed transaction: a
-// coinbase input's scriptSig (mining pool tags), and any OP_RETURN output's
-// scriptPubKey (arbitrary embedded messages). Everywhere else -- ordinary
-// scriptSig/scriptPubKey/witness data -- is cryptographic material, where a
-// scan like this turns up "coincidental" printable-looking noise roughly
-// half the time (verified empirically at minRun=5 against random 140-byte
-// blobs), not genuine text, so it's deliberately skipped.
-export function findTransactionAscii(parsed, isCoinbase) {
-  const found = [];
-  if (isCoinbase && parsed.vin[0]) found.push(...findAsciiStrings(parsed.vin[0].scriptSig));
-  for (const o of parsed.vout) {
-    if (o.scriptPubKey.slice(0, 2).toLowerCase() === '6a') found.push(...findAsciiStrings(o.scriptPubKey));
-  }
-  return found;
-}

--- a/web/glossia-msg.js
+++ b/web/glossia-msg.js
@@ -325,10 +325,17 @@ export function detectLang(prose) {
 // wordlist). Callers append a checksum to the key before encoding (see
 // glossia-nostr.js) so a mistyped word is caught on load.
 
-// hex string (any byte length) -> { prose, payloadWords, langId }.
-export function encodeSeedPhrase(hex, langId = 'english') {
+// hex string (any byte length) -> { prose, payloadWords, langId }. `bestOf`
+// (default 1) samples that many cover realizations and keeps the densest /
+// most coherent, same as renderArtifact -- it only changes cover words, never
+// the payload, so decoding is unaffected.
+export function encodeSeedPhrase(hex, langId = 'english', bestOf = 1) {
   const lang = msgLangById(langId);
-  const r = JSON.parse(wasmEncodeRawBaseN(hex, lang.language, lang.wordlist, lang.dialect, SEED));
+  const n = Math.max(1, Math.floor(bestOf));
+  const r = JSON.parse(
+    n > 1
+      ? wasmEncodeRawBaseNBestOf(hex, lang.language, lang.wordlist, lang.dialect, SEED, n)
+      : wasmEncodeRawBaseN(hex, lang.language, lang.wordlist, lang.dialect, SEED));
   if (r.error) throw new Error(r.error);
   return { prose: (r.encoded_text || '').trim(), payloadWords: r.payload_words || [], langId: lang.id };
 }

--- a/web/index.html
+++ b/web/index.html
@@ -1173,6 +1173,8 @@ footer a:hover { text-decoration: underline; }
       <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
       <a href="bulletin.html">Bulletins</a>
       <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
+      <a href="bitcoin.html">Bitcoin</a>
+      <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
       <a href="docs/">Documentation</a>
       <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
       <a href="https://github.com/asherp/glossia/issues" target="_blank">Report Issue</a>

--- a/web/index.html
+++ b/web/index.html
@@ -1175,6 +1175,8 @@ footer a:hover { text-decoration: underline; }
       <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
       <a href="bitcoin.html">Bitcoin</a>
       <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
+      <a href="bitcoin-book.html">Bitcoin Book</a>
+      <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
       <a href="docs/">Documentation</a>
       <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
       <a href="https://github.com/asherp/glossia/issues" target="_blank">Report Issue</a>


### PR DESCRIPTION
Looks up a transaction by txid via the Blockstream Esplora API and renders
the raw signed transaction hex as natural-language English prose, alongside
the usual explorer summary (status, fee, size, inputs/outputs).