### PR TITLE
Add Notation key to the Bitcoin book

### DIFF
--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -155,6 +155,8 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 /* Amounts and the closing locktime right-align to the page edge, like a ledger
    column, and the amount digits are grouped in threes (see btc-prose.js). */
 .tx-out-value  { grid-column: 2; text-align: right; }
+/* The output's payment-type tag, under its amount in the ledger margin. */
+.out-type { margin-top: .2em; font: 500 9.5px/1.3 'IBM Plex Mono',monospace; letter-spacing: .1em; text-transform: uppercase; color: var(--meta); font-variant-numeric: normal; }
 .tx-locktime { grid-column: right; grid-row: 3; text-align: right; font-style: normal; }
 .tx-note { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--dim); }
 /* The input's sequence mark, shown in the margin just after the reference:
@@ -323,7 +325,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Stack, comparison &amp; control</h4>
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">⧉</span><span class="m"><b>duplicate</b> the top item</span></div>
-          <div class="glyph-row"><span class="g">↧</span><span class="m"><b>drop</b> the top item</span></div>
+          <div class="glyph-row"><span class="g">⌄</span><span class="m"><b>drop</b> the top item</span></div>
           <div class="glyph-row"><span class="g">=</span><span class="m">equal?</span></div>
           <div class="glyph-row"><span class="g">≡</span><span class="m">equal, <b>else fail</b></span></div>
           <div class="glyph-row"><span class="g">✓</span><span class="m">assert true</span></div>
@@ -706,6 +708,14 @@ function renderChapter(para) {
     const valueCell = document.createElement('div');
     valueCell.className = 'tx-note tx-out-value';
     valueCell.textContent = out.value;
+    // The output's payment type (p2wpkh, p2tr, multisig, data …) sits under its
+    // amount, so a reader can tell the kinds of payment apart at a glance.
+    if (out.type) {
+      const t = document.createElement('div');
+      t.className = 'out-type';
+      t.textContent = out.type;
+      valueCell.append(t);
+    }
     outputsEl.append(scriptCell, valueCell);
   });
   const lock = document.createElement('div');

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -234,6 +234,11 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .glyph-row .m { font: 400 13px/1.45 'Public Sans', sans-serif; color: var(--dim); }
 .glyph-row .m b { color: var(--ink-soft); font-weight: 500; }
 .notation-note { margin: 9px 0 0; font-size: 12px; font-style: italic; color: var(--meta); }
+/* Common script patterns: a payment type -> the sequence of marks it reads as. */
+.pattern-list { display: grid; grid-template-columns: auto 1fr; gap: 9px 18px; align-items: baseline; }
+.pattern-list .pname { font: 600 10px/1.5 'IBM Plex Mono',monospace; letter-spacing: .06em; text-transform: uppercase; color: var(--meta); white-space: nowrap; }
+.pattern-list .seq { font: 400 16px/1.5 'Newsreader', system-ui, 'Segoe UI Symbol', serif; color: var(--ink-soft); }
+.pattern-list .seq .ph { color: var(--dim); font-style: italic; }
 @media (max-width: 480px) { .glyph-grid { grid-template-columns: 1fr; } }
 </style>
 </head>
@@ -330,6 +335,22 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">¶</span><span class="m"><b>data output</b> — provably unspendable</span></div>
           <div class="glyph-row"><span class="g">⟨ │ ⟩</span><span class="m">if … else … end</span></div>
         </div>
+      </div>
+
+      <div class="notation-group">
+        <h4>Common script patterns</h4>
+        <p class="notation-note">A payment's kind is legible in its sequence of marks — learn these and you can read a script's purpose at sight. <span class="ph" style="font-style:italic">‹…›</span> is pushed data (rendered as prose).</p>
+        <div class="pattern-list">
+          <span class="pname">P2PK</span><span class="seq"><span class="ph">‹key›</span> <span class="op">∇</span></span>
+          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">‹hash›</span> <span class="op">≡</span> <span class="op">∇</span></span>
+          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="ph">‹hash›</span> <span class="op">=</span></span>
+          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="ph">‹20-byte hash›</span></span>
+          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="ph">‹32-byte hash›</span></span>
+          <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="ph">‹key›</span></span>
+          <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="ph">‹key›‹key›‹key›</span> <span class="op">③</span> <span class="op">◇</span></span>
+          <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="ph">‹data›</span></span>
+        </div>
+        <p class="notation-note">P2WPKH and P2WSH share the mark <span class="op" style="font-style:normal">⓪</span> — a witness-v0 program — and differ only in the hashed length: a 20-byte HASH160 of a key, or a 32-byte SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. The scripts hidden inside P2SH / P2WSH — an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph" style="font-style:italic">‹hash›</span> <span class="op" style="font-style:normal">≡ … │ …</span> <span class="op" style="font-style:normal">τ ⌄ … ⟩</span> — are revealed in the same notation when spent.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -169,6 +169,9 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    we haven't given a glyph falls back to Bitcoin Core's OP_* name in small mono. */
 .op { color: var(--accent); font-style: normal; }
 .op-name { font: 600 .62em/1 'IBM Plex Mono',monospace; letter-spacing:.04em; color: var(--dim); font-style: normal; vertical-align: .14em; white-space: nowrap; }
+/* A witness footnote is a stack of items; a thin middot separates each, and an
+   empty stack item shows as ∅. */
+.wit-sep, .wit-empty { color: var(--meta); font-style: normal; }
 /* Verbatim human-readable text embedded in a script (a coinbase mining-pool
    tag, an OP_RETURN message) is a foreign voice quoted into the transaction,
    not part of its prose -- so it's set as a quote block (a marginal accent
@@ -363,7 +366,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 <script type="module">
 import { init, encodeSeedPhrase } from './glossia-msg.js';
 import { parseTransaction, computeTxid } from './btc-tx.js';
-import { composeTransactionFields, groupDigits } from './btc-prose.js';
+import { composeTransactionFields, groupDigits, renderWitness } from './btc-prose.js';
 import { volumeBookChapter } from './btc-citation.js';
 
 const $ = (id) => document.getElementById(id);
@@ -684,7 +687,7 @@ function renderChapter(para) {
     // witness-bearing input -- its footnote superscript, numbered in input order;
     // the amount of the output it spends sits underneath.
     cite.append(seqSpan(inp), ' ', citeBody);
-    if (inp.witnessHex) { footnotes.push({ n: footnotes.length + 1, hex: inp.witnessHex, zero: inp.witnessZero }); cite.append(witnessRef(footnotes.length)); }
+    if (inp.witnessHex) { footnotes.push({ n: footnotes.length + 1, items: inp.witnessItems, zero: inp.witnessZero }); cite.append(witnessRef(footnotes.length)); }
     if (amtEl) cite.append(amtEl);
     const scriptCell = document.createElement('div');
     scriptCell.className = 'tx-in-script';
@@ -739,7 +742,7 @@ async function renderFootnotes(gen) {
   for (const fn of currentFootnotes) {
     // An all-zero witness (coinbase reserved value, empty stack) shows ∅ instead
     // of a run of zero-words.
-    const prose = fn.zero ? '∅' : encodeSeedPhrase(fn.hex, 'english', BEST_OF).prose;
+    const prose = fn.zero ? '∅' : renderWitness(fn.items, (hex) => encodeSeedPhrase(hex, 'english', BEST_OF).prose);
     const p = document.createElement('p');
     p.className = 'footnote-entry';
     p.id = `fn-${fn.n}`;

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -238,7 +238,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .pattern-list { display: grid; grid-template-columns: auto 1fr; gap: 9px 18px; align-items: baseline; }
 .pattern-list .pname { font: 600 10px/1.5 'IBM Plex Mono',monospace; letter-spacing: .06em; text-transform: uppercase; color: var(--meta); white-space: nowrap; }
 .pattern-list .seq { font: 400 16px/1.5 'Newsreader', system-ui, 'Segoe UI Symbol', serif; color: var(--ink-soft); }
-.pattern-list .seq .ph { color: var(--dim); font-style: italic; }
+.ph { color: var(--dim); font-style: italic; }
 @media (max-width: 480px) { .glyph-grid { grid-template-columns: 1fr; } }
 </style>
 </head>
@@ -339,18 +339,18 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
       <div class="notation-group">
         <h4>Common script patterns</h4>
-        <p class="notation-note">A payment's kind is legible in its sequence of marks — learn these and you can read a script's purpose at sight. <span class="ph" style="font-style:italic">‹…›</span> is pushed data (rendered as prose).</p>
+        <p class="notation-note">A payment's kind is legible in its sequence of marks — learn these and you can read a script's purpose at sight. <span class="ph">…</span> stands for pushed data (a key, a hash, a signature), rendered as prose.</p>
         <div class="pattern-list">
-          <span class="pname">P2PK</span><span class="seq"><span class="ph">‹key›</span> <span class="op">∇</span></span>
-          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">‹…›</span> <span class="op">≡</span> <span class="op">∇</span></span>
-          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="ph">‹…›</span> <span class="op">=</span></span>
-          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="ph">‹20-byte …›</span></span>
-          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="ph">‹32-byte …›</span></span>
-          <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="ph">‹key›</span></span>
-          <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="ph">‹key›‹key›‹key›</span> <span class="op">③</span> <span class="op">◇</span></span>
-          <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="ph">‹data›</span></span>
+          <span class="pname">P2PK</span><span class="seq"><span class="ph">…</span> <span class="op">∇</span></span>
+          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">…</span> <span class="op">≡</span> <span class="op">∇</span></span>
+          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="ph">…</span> <span class="op">=</span></span>
+          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="ph">…</span></span>
+          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="ph">…</span></span>
+          <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="ph">…</span></span>
+          <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="ph">… … …</span> <span class="op">③</span> <span class="op">◇</span></span>
+          <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="ph">…</span></span>
         </div>
-        <p class="notation-note">P2WPKH and P2WSH share the mark <span class="op" style="font-style:normal">⓪</span> — a witness-v0 program — and differ only in the hashed length: a 20-byte HASH160 of a key, or a 32-byte SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. The scripts hidden inside P2SH / P2WSH — an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph" style="font-style:italic">‹…›</span> <span class="op" style="font-style:normal">≡ … │ …</span> <span class="op" style="font-style:normal">τ ⌄ … ⟩</span> — are revealed in the same notation when spent.</p>
+        <p class="notation-note">P2WPKH and P2WSH share the mark <span class="op" style="font-style:normal">⓪</span> — a witness-v0 program — and differ only in the hashed length: a 20-byte HASH160 of a key, or a 32-byte SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. The scripts hidden inside P2SH / P2WSH — an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">…</span> <span class="op" style="font-style:normal">≡ … │ …</span> <span class="op" style="font-style:normal">τ ⌄ … ⟩</span> — are revealed in the same notation when spent.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -197,6 +197,36 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .footnote-entry { margin: 0 0 1.1em; font: italic 400 14.5px/1.6 'Newsreader',serif; color: var(--meta); }
 .footnote-entry:target { color: var(--ink-soft); }
 .footnote-mark { font: 500 10.5px/1 'IBM Plex Mono',monospace; color: var(--accent); margin-right: .5em; font-style: normal; vertical-align: .35em; }
+
+/* ── Notation: a key to the manuscript's sigla — the glyphs that notate a
+   script's opcodes, and the marks drawn in each transaction's margins. ── */
+.notation { margin-top: 16px; }
+.notation summary {
+  cursor: pointer; font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.1em; text-transform:uppercase;
+  color: var(--dim); list-style: none;
+}
+.notation summary::-webkit-details-marker { display: none; }
+.notation summary::before { content: '+ '; color: var(--accent); }
+.notation[open] summary::before { content: '– '; }
+.notation-body { margin-top: 14px; }
+.notation-lede { margin: 0 0 22px; font-size: 12.5px; line-height: 1.5; color: var(--meta); }
+.notation-group { margin: 0 0 22px; }
+.notation-group > h4 {
+  margin: 0 0 11px; font: 600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.18em;
+  text-transform: uppercase; color: var(--accent);
+}
+.glyph-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(215px, 1fr)); gap: 7px 22px; }
+.glyph-row { display: flex; align-items: baseline; gap: 12px; }
+.glyph-row .g {
+  flex: 0 0 1.7em; text-align: center;
+  font: 400 17px/1.3 'Newsreader', system-ui, 'Segoe UI Symbol', 'Apple Symbols', serif;
+  color: var(--ink); font-variant-numeric: normal;
+}
+.glyph-row .g i { font-style: normal; opacity: .5; font-size: .82em; }
+.glyph-row .m { font: 400 13px/1.45 'Public Sans', sans-serif; color: var(--dim); }
+.glyph-row .m b { color: var(--ink-soft); font-weight: 500; }
+.notation-note { margin: 9px 0 0; font-size: 12px; font-style: italic; color: var(--meta); }
+@media (max-width: 480px) { .glyph-grid { grid-template-columns: 1fr; } }
 </style>
 </head>
 <body>
@@ -234,6 +264,90 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <div id="ch-footnotes"></div>
     </div>
   </article>
+
+  <details class="notation">
+    <summary>Notation</summary>
+    <div class="notation-body">
+      <p class="notation-lede">A key to the sigla used in the manuscript: the glyphs that notate a Bitcoin <b>script's opcodes</b>, and the <b>marks</b> drawn in each transaction's margins. Pushed data — keys, hashes, signatures — is rendered as prose between the glyphs.</p>
+
+      <div class="notation-group">
+        <h4>Signatures &amp; keys</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">∇</span><span class="m">check a <b>signature</b></span></div>
+          <div class="glyph-row"><span class="g">▼</span><span class="m">check a signature, <b>else fail</b></span></div>
+          <div class="glyph-row"><span class="g">◇</span><span class="m">check <b>m-of-n</b> signatures</span></div>
+          <div class="glyph-row"><span class="g">◆</span><span class="m">check m-of-n, <b>else fail</b></span></div>
+        </div>
+        <p class="notation-note">A triangle is one signer, a diamond is many; a filled shape must hold or the script fails.</p>
+      </div>
+
+      <div class="notation-group">
+        <h4>Hashes</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">⌖</span><span class="m"><b>address</b> hash · HASH160</span></div>
+          <div class="glyph-row"><span class="g">⌘</span><span class="m"><b>identity</b> hash · HASH256</span></div>
+          <div class="glyph-row"><span class="g">Σ</span><span class="m">SHA-256</span></div>
+          <div class="glyph-row"><span class="g">σ</span><span class="m">SHA-1</span></div>
+          <div class="glyph-row"><span class="g">ρ</span><span class="m">RIPEMD-160</span></div>
+        </div>
+        <p class="notation-note">Lower-case Greek is a 160-bit digest, upper-case a 256-bit one. ⌖ points to where value is sent; ⌘ marks what names a transaction.</p>
+      </div>
+
+      <div class="notation-group">
+        <h4>Timelocks</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">τ</span><span class="m"><b>absolute</b> — not before a fixed time or block</span></div>
+          <div class="glyph-row"><span class="g">Δ</span><span class="m"><b>relative</b> — a delay after this coin confirmed</span></div>
+        </div>
+        <p class="notation-note">τ is a fixed point in time; Δ is an interval measured from the moment the coin was received.</p>
+      </div>
+
+      <div class="notation-group">
+        <h4>Numbers</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">⓪</span><span class="m">push zero</span></div>
+          <div class="glyph-row"><span class="g">①–⑯</span><span class="m">push a small number (1–16)</span></div>
+          <div class="glyph-row"><span class="g">⊖</span><span class="m">push minus one</span></div>
+        </div>
+      </div>
+
+      <div class="notation-group">
+        <h4>Stack, comparison &amp; control</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">⧉</span><span class="m"><b>duplicate</b> the top item</span></div>
+          <div class="glyph-row"><span class="g">↧</span><span class="m"><b>drop</b> the top item</span></div>
+          <div class="glyph-row"><span class="g">=</span><span class="m">equal?</span></div>
+          <div class="glyph-row"><span class="g">≡</span><span class="m">equal, <b>else fail</b></span></div>
+          <div class="glyph-row"><span class="g">✓</span><span class="m">assert true</span></div>
+          <div class="glyph-row"><span class="g">¶</span><span class="m"><b>data output</b> — provably unspendable</span></div>
+          <div class="glyph-row"><span class="g">⟨ │ ⟩</span><span class="m">if … else … end</span></div>
+        </div>
+      </div>
+
+      <div class="notation-group">
+        <h4>Margin — an input's sequence</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">●</span><span class="m"><b>final</b></span></div>
+          <div class="glyph-row"><span class="g">○</span><span class="m">respects the locktime</span></div>
+          <div class="glyph-row"><span class="g">†</span><span class="m"><b>replaceable</b> (opt-in RBF)</span></div>
+          <div class="glyph-row"><span class="g">■<i>n</i></span><span class="m">relative: n blocks after confirmation</span></div>
+          <div class="glyph-row"><span class="g">⊥<i>n</i></span><span class="m">relative: n × 512 s after confirmation</span></div>
+        </div>
+      </div>
+
+      <div class="notation-group">
+        <h4>Margin — the transaction's locktime &amp; other marks</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">□</span><span class="m">no locktime</span></div>
+          <div class="glyph-row"><span class="g">■<i>n</i></span><span class="m">not before block n</span></div>
+          <div class="glyph-row"><span class="g">⊥<i>n</i></span><span class="m">not before time n</span></div>
+          <div class="glyph-row"><span class="g">∅</span><span class="m">a coinbase — no prior output</span></div>
+          <div class="glyph-row"><span class="g">§<i>n</i></span><span class="m">verse — the transaction's position</span></div>
+        </div>
+        <p class="notation-note">■ and ⊥ mean block-height and time in both places; a square reads as the whole transaction, a circle as one input.</p>
+      </div>
+    </div>
+  </details>
 
   <details class="about">
     <summary>About</summary>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -342,15 +342,15 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <p class="notation-note">A payment's kind is legible in its sequence of marks — learn these and you can read a script's purpose at sight. <span class="ph" style="font-style:italic">‹…›</span> is pushed data (rendered as prose).</p>
         <div class="pattern-list">
           <span class="pname">P2PK</span><span class="seq"><span class="ph">‹key›</span> <span class="op">∇</span></span>
-          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">‹hash›</span> <span class="op">≡</span> <span class="op">∇</span></span>
-          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="ph">‹hash›</span> <span class="op">=</span></span>
-          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="ph">‹20-byte hash›</span></span>
-          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="ph">‹32-byte hash›</span></span>
+          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">‹…›</span> <span class="op">≡</span> <span class="op">∇</span></span>
+          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="ph">‹…›</span> <span class="op">=</span></span>
+          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="ph">‹20-byte …›</span></span>
+          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="ph">‹32-byte …›</span></span>
           <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="ph">‹key›</span></span>
           <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="ph">‹key›‹key›‹key›</span> <span class="op">③</span> <span class="op">◇</span></span>
           <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="ph">‹data›</span></span>
         </div>
-        <p class="notation-note">P2WPKH and P2WSH share the mark <span class="op" style="font-style:normal">⓪</span> — a witness-v0 program — and differ only in the hashed length: a 20-byte HASH160 of a key, or a 32-byte SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. The scripts hidden inside P2SH / P2WSH — an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph" style="font-style:italic">‹hash›</span> <span class="op" style="font-style:normal">≡ … │ …</span> <span class="op" style="font-style:normal">τ ⌄ … ⟩</span> — are revealed in the same notation when spent.</p>
+        <p class="notation-note">P2WPKH and P2WSH share the mark <span class="op" style="font-style:normal">⓪</span> — a witness-v0 program — and differ only in the hashed length: a 20-byte HASH160 of a key, or a 32-byte SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. The scripts hidden inside P2SH / P2WSH — an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph" style="font-style:italic">‹…›</span> <span class="op" style="font-style:normal">≡ … │ …</span> <span class="op" style="font-style:normal">τ ⌄ … ⟩</span> — are revealed in the same notation when spent.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -164,6 +164,11 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .tx-seq-rbf { color: var(--accent-2); }
 .tx-seq-block, .tx-seq-time { color: var(--dim); font-variant-numeric: normal; }
 .tx-line { margin: 0 0 .55em; }
+/* Opcodes rendered inline in a script: a defined opcode shows as its Glossia
+   glyph (accent, so the grammar punctuates the prose data pushes); an opcode
+   we haven't given a glyph falls back to Bitcoin Core's OP_* name in small mono. */
+.op { color: var(--accent); font-style: normal; }
+.op-name { font: 600 .62em/1 'IBM Plex Mono',monospace; letter-spacing:.04em; color: var(--dim); font-style: normal; vertical-align: .14em; white-space: nowrap; }
 /* Verbatim human-readable text embedded in a script (a coinbase mining-pool
    tag, an OP_RETURN message) is a foreign voice quoted into the transaction,
    not part of its prose -- so it's set as a quote block (a marginal accent

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -359,7 +359,9 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
   <details class="about">
     <summary>About</summary>
-    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits; the genuinely opaque bytes — prevout references, scripts — are what's rendered in prose. Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
+    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above.</p>
+    <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and push/item length prefixes — is dropped, since it is reconstructable from structure. And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
+    <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
   </details>
 </div>
 

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -155,8 +155,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 /* Amounts and the closing locktime right-align to the page edge, like a ledger
    column, and the amount digits are grouped in threes (see btc-prose.js). */
 .tx-out-value  { grid-column: 2; text-align: right; }
-/* The output's payment-type tag, under its amount in the ledger margin. */
-.out-type { margin-top: .2em; font: 500 9.5px/1.3 'IBM Plex Mono',monospace; letter-spacing: .1em; text-transform: uppercase; color: var(--meta); font-variant-numeric: normal; }
 .tx-locktime { grid-column: right; grid-row: 3; text-align: right; font-style: normal; }
 .tx-note { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--dim); }
 /* The input's sequence mark, shown in the margin just after the reference:
@@ -708,14 +706,6 @@ function renderChapter(para) {
     const valueCell = document.createElement('div');
     valueCell.className = 'tx-note tx-out-value';
     valueCell.textContent = out.value;
-    // The output's payment type (p2wpkh, p2tr, multisig, data …) sits under its
-    // amount, so a reader can tell the kinds of payment apart at a glance.
-    if (out.type) {
-      const t = document.createElement('div');
-      t.className = 'out-type';
-      t.textContent = out.type;
-      valueCell.append(t);
-    }
     outputsEl.append(scriptCell, valueCell);
   });
   const lock = document.createElement('div');

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -17,7 +17,7 @@
 // margin layout.
 
 import { encodeSeedPhrase } from './glossia-msg.js';
-import { findAsciiStrings, tokenizeScript } from './btc-tx.js';
+import { findAsciiStrings, tokenizeScript, scriptType } from './btc-tx.js';
 
 // The timelock fields get symbols rather than digit strings, on a small grammar
 // that separates the whole transaction's status (nLockTime) from each input's
@@ -92,7 +92,7 @@ const OPCODE_SYMBOLS = {
   0x63: '⟨', 0x67: '│', 0x68: '⟩',                            // OP_IF / OP_ELSE / OP_ENDIF
   0x69: '✓',                                                  // OP_VERIFY
   0x6a: '¶',                                                  // OP_RETURN
-  0x75: '↧', 0x76: '⧉',                                       // OP_DROP / OP_DUP
+  0x75: '⌄', 0x76: '⧉',                                       // OP_DROP / OP_DUP
   0x87: '=', 0x88: '≡',                                       // OP_EQUAL / OP_EQUALVERIFY
   0xa6: 'ρ', 0xa7: 'σ', 0xa8: 'Σ', 0xa9: '⌖', 0xaa: '⌘',      // RIPEMD160 / SHA1 / SHA256 / HASH160 / HASH256
   0xac: '∇', 0xad: '▼', 0xae: '◇', 0xaf: '◆',                 // CHECKSIG(VERIFY) / CHECKMULTISIG(VERIFY)
@@ -354,7 +354,7 @@ export function composeTransactionFields(parsed, bestOf = 1) {
     // OP_RETURN (¶) payload is `eligible` for inline ASCII quoting, so an
     // embedded message reads verbatim rather than as prose.
     const isOpReturn = o.scriptPubKey.slice(0, 2).toLowerCase() === '6a';
-    return { script: renderScript(o.scriptPubKey, collect, { eligible: isOpReturn }), scriptAscii: null, value: groupDigits(String(o.value)) };
+    return { type: scriptType(o.scriptPubKey), script: renderScript(o.scriptPubKey, collect, { eligible: isOpReturn }), scriptAscii: null, value: groupDigits(String(o.value)) };
   });
 
   const lock = locktimeInfo(parsed.locktime);

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -154,6 +154,72 @@ function renderScript(hex, collect, eligible) {
   return parts.join(' ');
 }
 
+// ─── witness → per-item rendering ──────────────────────────────────────
+//
+// An input's witness is a stack of items. Rendering them individually (rather
+// than as one blob) lets a signature, a key and a script read as distinct
+// stack elements -- and the one item that is a script (a P2WSH witnessScript or
+// a Taproot tapscript) is rendered in opcode notation like any other script.
+
+const witHexLen = (h) => h.length / 2;
+const witFirst = (h) => parseInt(h.slice(0, 2), 16);
+
+// A witness item that is plainly data, never a script:
+function isPubkey(h) {
+  const n = witHexLen(h), b = witFirst(h);
+  return (n === 33 && (b === 0x02 || b === 0x03)) || (n === 65 && b === 0x04);
+}
+function isSignature(h) {
+  const n = witHexLen(h), b = witFirst(h);
+  return n === 64 || n === 65 || (b === 0x30 && n >= 68 && n <= 73);   // Schnorr, or DER (+sighash byte)
+}
+// A Taproot script-path control block: a 0xc0/0xc1 leaf byte, then a 32-byte
+// internal key and a merkle path of 32-byte hashes.
+function isControlBlock(h) {
+  const n = witHexLen(h);
+  return n >= 33 && (n - 33) % 32 === 0 && (witFirst(h) & 0xfe) === 0xc0;
+}
+// A signature check or a timelock is the hallmark of a spending script and
+// essentially never turns up by chance in a data item, so its presence (in an
+// item that parses cleanly as script) marks the item as a witnessScript.
+const SCRIPT_SIGNAL = new Set([0xac, 0xad, 0xae, 0xaf, 0xba, 0xb1, 0xb2]);
+function looksLikeScript(h) {
+  if (!h || isPubkey(h) || isSignature(h)) return false;
+  const toks = tokenizeScript(h);
+  if (!toks.length || toks.some((t) => t.trunc !== undefined)) return false;
+  return toks.some((t) => t.op !== undefined && SCRIPT_SIGNAL.has(t.op));
+}
+
+// Which witness item (if any) is the script to render as opcodes: a Taproot
+// tapscript (sitting just below its control block) or a P2WSH witnessScript
+// (the last item). Returns -1 when the witness is all data -- P2WPKH, a
+// key-path spend, a bare signature.
+function witnessScriptIndex(items) {
+  const n = items.length;
+  if (n === 0) return -1;
+  let last = n - 1;
+  if (n >= 2 && witFirst(items[last]) === 0x50) last -= 1;    // strip an optional annex
+  if (last >= 1 && isControlBlock(items[last])) return last - 1;
+  const tail = items[n - 1];
+  if (isPubkey(tail) || isSignature(tail)) return -1;
+  return looksLikeScript(tail) ? n - 1 : -1;
+}
+
+// An input's witness stack (hex items) -> its footnote display. `encode` turns
+// a data item's hex into Glossia prose; the one script item, if present,
+// becomes opcode notation. Items are separated so each reads as its own stack
+// element.
+export function renderWitness(items, encode) {
+  if (!items || !items.length) return '∅';
+  const scriptIdx = witnessScriptIndex(items);
+  return items
+    .map((hex, i) => {
+      if (!hex) return '<span class="wit-empty">∅</span>';    // an empty stack item
+      return i === scriptIdx ? renderScript(hex, encode, false) : encode(hex);
+    })
+    .join('<span class="wit-sep"> · </span>');
+}
+
 // A parsed transaction (btc-tx.js's parseTransaction) -> a structured
 // breakdown of every field's rendered text, in wire order, plus the payload
 // words consumed. bitcoin-book.html's margin layout is built from this, each
@@ -197,6 +263,7 @@ export function composeTransactionFields(parsed, bestOf = 1) {
       script, scriptAscii,
       sequence: seq.mark, sequenceKind: seq.kind, sequenceTitle: seq.title, sequenceRbf: seq.rbf,
       witnessHex: v.witnessHex || '',
+      witnessItems: v.witness || [],
       // An all-zero witness (a coinbase's reserved value, or an empty stack) is
       // shown as ∅ rather than encoded to a run of zero-words.
       witnessZero: (v.witness || []).every((it) => /^0*$/.test(it)),

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -279,11 +279,14 @@ export function composeTransactionFields(parsed, bestOf = 1) {
   });
 
   const lock = locktimeInfo(parsed.locktime);
+  // Serialization framing is never encoded -- the input/output counts, the
+  // witness item count and its per-item length prefixes, and a script's push
+  // length prefixes are all structural and reconstructable from the parse, so
+  // only genuine payload bytes become prose. (The counts are implicit in the
+  // number of input/output rows; witness items render individually.)
   return {
     version: String(parsed.version),
-    inputCount: String(parsed.vin.length),
     inputs,
-    outputCount: String(parsed.vout.length),
     outputs,
     locktime: lock.mark, locktimeTitle: lock.title,
     payloadWords,

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -17,7 +17,7 @@
 // margin layout.
 
 import { encodeSeedPhrase } from './glossia-msg.js';
-import { findAsciiStrings, tokenizeScript, scriptType } from './btc-tx.js';
+import { findAsciiStrings, tokenizeScript } from './btc-tx.js';
 
 // The timelock fields get symbols rather than digit strings, on a small grammar
 // that separates the whole transaction's status (nLockTime) from each input's
@@ -354,7 +354,7 @@ export function composeTransactionFields(parsed, bestOf = 1) {
     // OP_RETURN (¶) payload is `eligible` for inline ASCII quoting, so an
     // embedded message reads verbatim rather than as prose.
     const isOpReturn = o.scriptPubKey.slice(0, 2).toLowerCase() === '6a';
-    return { type: scriptType(o.scriptPubKey), script: renderScript(o.scriptPubKey, collect, { eligible: isOpReturn }), scriptAscii: null, value: groupDigits(String(o.value)) };
+    return { script: renderScript(o.scriptPubKey, collect, { eligible: isOpReturn }), scriptAscii: null, value: groupDigits(String(o.value)) };
   });
 
   const lock = locktimeInfo(parsed.locktime);

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -183,27 +183,47 @@ function derToCompact(hex) {
 }
 
 // A script (hex) -> its opcode-notation display string. `collect` encodes a
-// data push to Glossia prose; `eligible` (an OP_RETURN payload) turns on inline
-// ASCII quoting for legible pushes. Opcode glyphs and OP_* names are the only
+// data push to Glossia prose. Options: `eligible` (an OP_RETURN payload, or a
+// coinbase) turns on inline ASCII quoting for legible pushes; `nested` reveals a
+// script pushed as data -- a P2SH redeemScript, always the final push -- by
+// rendering it as opcodes in turn. Opcode glyphs and OP_* names are the only
 // HTML added here; pushed data is Glossia prose (safe) and quoted ASCII is
 // escaped, so the result is safe to render via innerHTML like before.
-function renderScript(hex, collect, eligible) {
+function renderScript(hex, collect, { eligible = false, nested = false } = {}) {
+  const toks = tokenizeScript(hex);
+  // A P2SH scriptSig ends with its redeemScript, pushed as data; reveal that
+  // final push as opcodes when it parses as a genuine script.
+  const redeemIdx = nested ? toks.map((t) => t.push !== undefined).lastIndexOf(true) : -1;
   const parts = [];
-  for (const t of tokenizeScript(hex)) {
+  toks.forEach((t, i) => {
     if (t.op !== undefined) {
       parts.push(opToken(t.op));
     } else if (t.push !== undefined) {
-      if (!t.push) continue;                                  // empty push -- nothing to show
+      if (!t.push) return;                                    // empty push -- nothing to show
+      if (i === redeemIdx && looksLikeScript(t.push)) {
+        parts.push(renderScript(t.push, collect));            // reveal the redeemScript
+        return;
+      }
       if (eligible) {
         const found = findAsciiStrings(t.push);
-        if (found.length) { parts.push(found.map((s) => `“${escapeHtml(s)}”`).join(' ')); continue; }
+        if (found.length) { parts.push(found.map((s) => `“${escapeHtml(s)}”`).join(' ')); return; }
       }
       parts.push(collect(derToCompact(t.push) || t.push));    // a DER signature is stripped to r‖s‖sighash
     } else {
       parts.push(collect(t.trunc));                           // malformed tail -- carry it as prose
     }
-  }
+  });
   return parts.join(' ');
+}
+
+// Every token is a data push or a defined opcode, with no malformed tail -- the
+// test for whether a coinbase scriptSig (otherwise arbitrary miner data) is a
+// clean script worth rendering as opcodes, as the earliest blocks' are.
+const isDefinedOp = (code) => OPCODE_SYMBOLS[code] !== undefined || OPCODE_NAMES[code] !== undefined;
+function isCleanScript(hex) {
+  const toks = tokenizeScript(hex);
+  return toks.length > 0 && toks.every((t) =>
+    t.trunc === undefined && (t.push !== undefined || isDefinedOp(t.op)));
 }
 
 // ─── witness → per-item rendering ──────────────────────────────────────
@@ -267,7 +287,7 @@ export function renderWitness(items, encode) {
   return items
     .map((hex, i) => {
       if (!hex) return '<span class="wit-empty">∅</span>';    // an empty stack item
-      if (i === scriptIdx) return renderScript(hex, encode, false);
+      if (i === scriptIdx) return renderScript(hex, encode);
       return encode(derToCompact(hex) || hex);                // a DER signature is stripped to r‖s‖sighash
     })
     .join('<span class="wit-sep"> · </span>');
@@ -288,21 +308,27 @@ export function composeTransactionFields(parsed, bestOf = 1) {
   };
   const inputs = parsed.vin.map((v) => {
     const isNullPrevout = v.txid === '00'.repeat(32);
-    // A coinbase scriptSig is arbitrary data, not valid script, so tokenizing
-    // it as opcodes would be noise -- it keeps the legible-text treatment,
-    // where a mining-pool tag is surfaced as a quote block (`scriptAscii`).
-    // Every other scriptSig is genuine script, rendered in opcode notation.
+    // A coinbase scriptSig is arbitrary miner data -- but the earliest blocks'
+    // are clean push-scripts, so render those in opcode notation (embedded text
+    // like the genesis headline is quoted inline). Messier ones keep the plain
+    // treatment, where a mining-pool tag is surfaced as a quote block
+    // (`scriptAscii`). Every other scriptSig is genuine script (with a P2SH
+    // redeemScript revealed as opcodes via `nested`).
     let script, scriptAscii = null;
     if (isNullPrevout) {
-      const found = findAsciiStrings(v.scriptSig);
-      if (found.length) {
-        scriptAscii = found.map((s) => escapeHtml(s)).join(' ');
-        script = found.map((s) => `“${escapeHtml(s)}”`).join(' ');
+      if (isCleanScript(v.scriptSig)) {
+        script = renderScript(v.scriptSig, collect, { eligible: true });
       } else {
-        script = collect(v.scriptSig);
+        const found = findAsciiStrings(v.scriptSig);
+        if (found.length) {
+          scriptAscii = found.map((s) => escapeHtml(s)).join(' ');
+          script = found.map((s) => `“${escapeHtml(s)}”`).join(' ');
+        } else {
+          script = collect(v.scriptSig);
+        }
       }
     } else {
-      script = renderScript(v.scriptSig, collect, false);
+      script = renderScript(v.scriptSig, collect, { nested: true });
     }
     const seq = sequenceInfo(v.sequence);
     // The prevout is carried as a reference (txid + output index), not encoded:
@@ -328,7 +354,7 @@ export function composeTransactionFields(parsed, bestOf = 1) {
     // OP_RETURN (¶) payload is `eligible` for inline ASCII quoting, so an
     // embedded message reads verbatim rather than as prose.
     const isOpReturn = o.scriptPubKey.slice(0, 2).toLowerCase() === '6a';
-    return { script: renderScript(o.scriptPubKey, collect, isOpReturn), scriptAscii: null, value: groupDigits(String(o.value)) };
+    return { script: renderScript(o.scriptPubKey, collect, { eligible: isOpReturn }), scriptAscii: null, value: groupDigits(String(o.value)) };
   });
 
   const lock = locktimeInfo(parsed.locktime);

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -17,7 +17,7 @@
 // margin layout.
 
 import { encodeSeedPhrase } from './glossia-msg.js';
-import { findAsciiStrings } from './btc-tx.js';
+import { findAsciiStrings, tokenizeScript } from './btc-tx.js';
 
 // The timelock fields get symbols rather than digit strings, on a small grammar
 // that separates the whole transaction's status (nLockTime) from each input's
@@ -73,6 +73,87 @@ function escapeHtml(s) {
   return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
 
+// ─── script → opcode notation ──────────────────────────────────────────
+//
+// A scriptSig / scriptPubKey is rendered as its sequence of opcodes and data
+// pushes. An opcode we've given a Glossia glyph renders as that glyph; every
+// other opcode falls back to Bitcoin Core's OP_* name. Data pushes stay
+// Glossia prose (or, for an OP_RETURN payload, inline-quoted when they're
+// legible ASCII) -- exactly what carried the whole script before opcodes had
+// their own marks.
+
+// Opcode byte -> Glossia glyph, for the opcodes we've defined so far.
+const OPCODE_SYMBOLS = {
+  0x00: '⓪',                                                  // OP_0
+  0x4f: '⊖',                                                  // OP_1NEGATE
+  0x51: '①', 0x52: '②', 0x53: '③', 0x54: '④', 0x55: '⑤',      // OP_1 …
+  0x56: '⑥', 0x57: '⑦', 0x58: '⑧', 0x59: '⑨', 0x5a: '⑩',
+  0x5b: '⑪', 0x5c: '⑫', 0x5d: '⑬', 0x5e: '⑭', 0x5f: '⑮', 0x60: '⑯',   // … OP_16
+  0x63: '⟨', 0x67: '│', 0x68: '⟩',                            // OP_IF / OP_ELSE / OP_ENDIF
+  0x69: '✓',                                                  // OP_VERIFY
+  0x6a: '¶',                                                  // OP_RETURN
+  0x75: '↧', 0x76: '⧉',                                       // OP_DROP / OP_DUP
+  0x87: '=', 0x88: '≡',                                       // OP_EQUAL / OP_EQUALVERIFY
+  0xa6: 'ρ', 0xa7: 'σ', 0xa8: 'Σ', 0xa9: '⌖', 0xaa: '⌘',      // RIPEMD160 / SHA1 / SHA256 / HASH160 / HASH256
+  0xac: '∇', 0xad: '▼', 0xae: '◇', 0xaf: '◆',                 // CHECKSIG(VERIFY) / CHECKMULTISIG(VERIFY)
+  0xb1: 'τ', 0xb2: 'Δ',                                       // CLTV (absolute) / CSV (relative)
+};
+
+// Opcode byte -> Bitcoin Core name, the fallback for opcodes without a glyph.
+// Data-push opcodes (0x01-0x4b, OP_PUSHDATA1/2/4) never reach this table --
+// tokenizeScript surfaces them as their pushed data, not as an opcode.
+const OPCODE_NAMES = {
+  0x50: 'OP_RESERVED',
+  0x61: 'OP_NOP', 0x62: 'OP_VER', 0x64: 'OP_NOTIF', 0x65: 'OP_VERIF', 0x66: 'OP_VERNOTIF',
+  0x6b: 'OP_TOALTSTACK', 0x6c: 'OP_FROMALTSTACK', 0x6d: 'OP_2DROP', 0x6e: 'OP_2DUP', 0x6f: 'OP_3DUP',
+  0x70: 'OP_2OVER', 0x71: 'OP_2ROT', 0x72: 'OP_2SWAP', 0x73: 'OP_IFDUP', 0x74: 'OP_DEPTH',
+  0x77: 'OP_NIP', 0x78: 'OP_OVER', 0x79: 'OP_PICK', 0x7a: 'OP_ROLL', 0x7b: 'OP_ROT', 0x7c: 'OP_SWAP', 0x7d: 'OP_TUCK',
+  0x7e: 'OP_CAT', 0x7f: 'OP_SUBSTR', 0x80: 'OP_LEFT', 0x81: 'OP_RIGHT', 0x82: 'OP_SIZE',
+  0x83: 'OP_INVERT', 0x84: 'OP_AND', 0x85: 'OP_OR', 0x86: 'OP_XOR',
+  0x89: 'OP_RESERVED1', 0x8a: 'OP_RESERVED2',
+  0x8b: 'OP_1ADD', 0x8c: 'OP_1SUB', 0x8d: 'OP_2MUL', 0x8e: 'OP_2DIV', 0x8f: 'OP_NEGATE',
+  0x90: 'OP_ABS', 0x91: 'OP_NOT', 0x92: 'OP_0NOTEQUAL',
+  0x93: 'OP_ADD', 0x94: 'OP_SUB', 0x95: 'OP_MUL', 0x96: 'OP_DIV', 0x97: 'OP_MOD', 0x98: 'OP_LSHIFT', 0x99: 'OP_RSHIFT',
+  0x9a: 'OP_BOOLAND', 0x9b: 'OP_BOOLOR', 0x9c: 'OP_NUMEQUAL', 0x9d: 'OP_NUMEQUALVERIFY', 0x9e: 'OP_NUMNOTEQUAL',
+  0x9f: 'OP_LESSTHAN', 0xa0: 'OP_GREATERTHAN', 0xa1: 'OP_LESSTHANOREQUAL', 0xa2: 'OP_GREATERTHANOREQUAL',
+  0xa3: 'OP_MIN', 0xa4: 'OP_MAX', 0xa5: 'OP_WITHIN',
+  0xab: 'OP_CODESEPARATOR',
+  0xb0: 'OP_NOP1', 0xb3: 'OP_NOP4', 0xb4: 'OP_NOP5', 0xb5: 'OP_NOP6', 0xb6: 'OP_NOP7',
+  0xb7: 'OP_NOP8', 0xb8: 'OP_NOP9', 0xb9: 'OP_NOP10', 0xba: 'OP_CHECKSIGADD',
+  0xff: 'OP_INVALIDOPCODE',
+};
+
+// One opcode -> its HTML: a defined glyph (accent-styled), else the OP_* name.
+function opToken(code) {
+  const sym = OPCODE_SYMBOLS[code];
+  if (sym) return `<span class="op">${sym}</span>`;
+  return `<span class="op-name">${OPCODE_NAMES[code] || 'OP_UNKNOWN'}</span>`;
+}
+
+// A script (hex) -> its opcode-notation display string. `collect` encodes a
+// data push to Glossia prose; `eligible` (an OP_RETURN payload) turns on inline
+// ASCII quoting for legible pushes. Opcode glyphs and OP_* names are the only
+// HTML added here; pushed data is Glossia prose (safe) and quoted ASCII is
+// escaped, so the result is safe to render via innerHTML like before.
+function renderScript(hex, collect, eligible) {
+  const parts = [];
+  for (const t of tokenizeScript(hex)) {
+    if (t.op !== undefined) {
+      parts.push(opToken(t.op));
+    } else if (t.push !== undefined) {
+      if (!t.push) continue;                                  // empty push -- nothing to show
+      if (eligible) {
+        const found = findAsciiStrings(t.push);
+        if (found.length) { parts.push(found.map((s) => `“${escapeHtml(s)}”`).join(' ')); continue; }
+      }
+      parts.push(collect(t.push));
+    } else {
+      parts.push(collect(t.trunc));                           // malformed tail -- carry it as prose
+    }
+  }
+  return parts.join(' ');
+}
+
 // A parsed transaction (btc-tx.js's parseTransaction) -> a structured
 // breakdown of every field's rendered text, in wire order, plus the payload
 // words consumed. bitcoin-book.html's margin layout is built from this, each
@@ -86,33 +167,24 @@ export function composeTransactionFields(parsed, bestOf = 1) {
     payloadWords.push(...r.payloadWords);
     return r.prose;
   };
-  // Two spots carry deliberate human-readable text rather than
-  // cryptographic material: a coinbase input's scriptSig (mining pool
-  // tags) and an OP_RETURN output's scriptPubKey (arbitrary embedded
-  // messages). When detected there, that text is quoted inline verbatim
-  // instead of Glossia-encoded -- it's already legible, so routing it
-  // through the wordlist would just swap real words for unrelated ones.
-  // See btc-tx.js's findAsciiStrings for why this stays scoped to just
-  // these two fields rather than scriptSig/scriptPubKey/witness generally.
-  // Returns both forms of a script: `script` is the display string --
-  // detected ASCII wrapped in inline curly quotes, otherwise Glossia prose --
-  // and `ascii` is the same detected text unquoted (still HTML-escaped), or
-  // null when the script wasn't legible ASCII. A flat renderer uses `script`
-  // as-is; a manuscript renderer can set `ascii` as a quote block instead.
-  const collectScript = (hex, eligible) => {
-    if (eligible) {
-      const found = findAsciiStrings(hex);
-      if (found.length) {
-        const ascii = found.map((s) => escapeHtml(s)).join(' ');
-        return { script: found.map((s) => `“${escapeHtml(s)}”`).join(' '), ascii };
-      }
-    }
-    return { script: collect(hex), ascii: null };
-  };
-
   const inputs = parsed.vin.map((v) => {
     const isNullPrevout = v.txid === '00'.repeat(32);
-    const { script, ascii } = collectScript(v.scriptSig, isNullPrevout);
+    // A coinbase scriptSig is arbitrary data, not valid script, so tokenizing
+    // it as opcodes would be noise -- it keeps the legible-text treatment,
+    // where a mining-pool tag is surfaced as a quote block (`scriptAscii`).
+    // Every other scriptSig is genuine script, rendered in opcode notation.
+    let script, scriptAscii = null;
+    if (isNullPrevout) {
+      const found = findAsciiStrings(v.scriptSig);
+      if (found.length) {
+        scriptAscii = found.map((s) => escapeHtml(s)).join(' ');
+        script = found.map((s) => `“${escapeHtml(s)}”`).join(' ');
+      } else {
+        script = collect(v.scriptSig);
+      }
+    } else {
+      script = renderScript(v.scriptSig, collect, false);
+    }
     const seq = sequenceInfo(v.sequence);
     // The prevout is carried as a reference (txid + output index), not encoded:
     // the book resolves it to a volume/book/chapter/verse citation for the left
@@ -122,7 +194,7 @@ export function composeTransactionFields(parsed, bestOf = 1) {
       isNullPrevout,
       prevTxid: isNullPrevout ? '' : v.txid,
       prevVout: v.vout,
-      script, scriptAscii: ascii,
+      script, scriptAscii,
       sequence: seq.mark, sequenceKind: seq.kind, sequenceTitle: seq.title, sequenceRbf: seq.rbf,
       witnessHex: v.witnessHex || '',
       // An all-zero witness (a coinbase's reserved value, or an empty stack) is
@@ -132,9 +204,11 @@ export function composeTransactionFields(parsed, bestOf = 1) {
   });
 
   const outputs = parsed.vout.map((o) => {
+    // A scriptPubKey is always genuine script, rendered in opcode notation. An
+    // OP_RETURN (¶) payload is `eligible` for inline ASCII quoting, so an
+    // embedded message reads verbatim rather than as prose.
     const isOpReturn = o.scriptPubKey.slice(0, 2).toLowerCase() === '6a';
-    const { script, ascii } = collectScript(o.scriptPubKey, isOpReturn);
-    return { script, scriptAscii: ascii, value: groupDigits(String(o.value)) };
+    return { script: renderScript(o.scriptPubKey, collect, isOpReturn), scriptAscii: null, value: groupDigits(String(o.value)) };
   });
 
   const lock = locktimeInfo(parsed.locktime);

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -130,6 +130,58 @@ function opToken(code) {
   return `<span class="op-name">${OPCODE_NAMES[code] || 'OP_UNKNOWN'}</span>`;
 }
 
+// ─── DER signature compaction ──────────────────────────────────────────
+//
+// A legacy / segwit-v0 ECDSA signature push is a DER envelope -- SEQUENCE and
+// INTEGER tags, length bytes, canonical leading-zero padding -- wrapped around
+// two 32-byte scalars, plus a trailing sighash byte. Only r, s and the sighash
+// carry information; the ~7 envelope bytes are pure framing. derToCompact
+// strips it to a fixed 65-byte r‖s‖sighash -- but ONLY when re-encoding those
+// scalars reproduces the input byte-for-byte. That guard leaves every
+// non-canonical signature (pre-BIP66 blocks) and every non-signature push
+// untouched, so the compact form is always a faithful stand-in.
+
+const SIGHASH_TYPES = new Set([0x01, 0x02, 0x03, 0x81, 0x82, 0x83]);
+const byteAt = (hex, i) => parseInt(hex.substr(i * 2, 2), 16);
+
+// Strip leading 0x00 bytes from a hex value, keeping at least one byte.
+function stripLeadZeros(h) {
+  let i = 0;
+  while (i + 2 < h.length && h.substr(i, 2) === '00') i += 2;
+  return h.slice(i);
+}
+// The canonical DER INTEGER *content* for a big-endian value: minimal length,
+// with a single 0x00 prepended when the top bit would otherwise read negative.
+function derInt(valHex) {
+  const v = stripLeadZeros(valHex);
+  return (byteAt(v, 0) & 0x80) ? '00' + v : v;
+}
+const lenByte = (h) => (h.length / 2).toString(16).padStart(2, '0');
+
+// A signature push (DER sig + sighash byte) -> 65-byte r‖s‖sighash, or null when
+// the bytes are not a strictly-canonical signature (so the caller keeps them).
+function derToCompact(hex) {
+  const n = hex.length / 2;
+  if (n < 9 || n > 73 || byteAt(hex, 0) !== 0x30) return null;         // SEQUENCE
+  if (2 + byteAt(hex, 1) + 1 !== n) return null;                       // header + body + sighash
+  if (byteAt(hex, 2) !== 0x02) return null;                           // INTEGER r
+  const rLen = byteAt(hex, 3);
+  if (rLen < 1 || 6 + rLen > n || byteAt(hex, 4 + rLen) !== 0x02) return null;   // INTEGER s
+  const sLen = byteAt(hex, 5 + rLen);
+  if (sLen < 1 || 7 + rLen + sLen !== n) return null;
+  const sighash = hex.substr((n - 1) * 2, 2);
+  if (!SIGHASH_TYPES.has(parseInt(sighash, 16))) return null;
+  const rVal = stripLeadZeros(hex.substr(8, rLen * 2));
+  const sVal = stripLeadZeros(hex.substr((6 + rLen) * 2, sLen * 2));
+  if (rVal.length > 64 || sVal.length > 64) return null;              // a scalar wider than 32 bytes
+  const r32 = rVal.padStart(64, '0'), s32 = sVal.padStart(64, '0');
+  // Re-encode the scalars as canonical DER and require an exact match -- the
+  // fidelity guard that rejects non-canonical framing.
+  const body = '02' + lenByte(derInt(r32)) + derInt(r32) + '02' + lenByte(derInt(s32)) + derInt(s32);
+  const rebuilt = '30' + lenByte(body) + body + sighash;
+  return rebuilt.toLowerCase() === hex.toLowerCase() ? r32 + s32 + sighash : null;
+}
+
 // A script (hex) -> its opcode-notation display string. `collect` encodes a
 // data push to Glossia prose; `eligible` (an OP_RETURN payload) turns on inline
 // ASCII quoting for legible pushes. Opcode glyphs and OP_* names are the only
@@ -146,7 +198,7 @@ function renderScript(hex, collect, eligible) {
         const found = findAsciiStrings(t.push);
         if (found.length) { parts.push(found.map((s) => `“${escapeHtml(s)}”`).join(' ')); continue; }
       }
-      parts.push(collect(t.push));
+      parts.push(collect(derToCompact(t.push) || t.push));    // a DER signature is stripped to r‖s‖sighash
     } else {
       parts.push(collect(t.trunc));                           // malformed tail -- carry it as prose
     }
@@ -215,7 +267,8 @@ export function renderWitness(items, encode) {
   return items
     .map((hex, i) => {
       if (!hex) return '<span class="wit-empty">∅</span>';    // an empty stack item
-      return i === scriptIdx ? renderScript(hex, encode, false) : encode(hex);
+      if (i === scriptIdx) return renderScript(hex, encode, false);
+      return encode(derToCompact(hex) || hex);                // a DER signature is stripped to r‖s‖sighash
     })
     .join('<span class="wit-sep"> · </span>');
 }

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -296,3 +296,43 @@ export function findAsciiStrings(hex, minRun = ASCII_MIN_RUN) {
   }
   return found;
 }
+
+// ─── script tokenizer ────────────────────────────────────────────────────
+//
+// A scriptSig / scriptPubKey (hex) -> an ordered list of tokens, so a caller
+// can render it as opcode notation. Each token is one of:
+//   { op }         a non-push opcode (its byte)
+//   { push }       a data push (the pushed bytes, hex) -- covers direct pushes
+//                  (0x01-0x4b) and OP_PUSHDATA1/2/4 alike; the push opcode
+//                  itself is implicit, surfaced as its data
+//   { trunc }      a malformed tail (a push claiming more bytes than remain),
+//                  carried verbatim so a caller never crashes on odd bytes
+// Byte-exact and lossless: concatenating the tokens back reproduces the script.
+export function tokenizeScript(hex) {
+  const bytes = hexToBytes(hex);
+  const toks = [];
+  const tail = (i) => toks.push({ trunc: bytesToHex(bytes.subarray(i)) });
+  let i = 0;
+  while (i < bytes.length) {
+    const op = bytes[i];
+    if (op >= 0x01 && op <= 0x4b) {                    // direct push of `op` bytes
+      const start = i + 1, end = start + op;
+      if (end > bytes.length) { tail(i); break; }
+      toks.push({ push: bytesToHex(bytes.subarray(start, end)) });
+      i = end;
+    } else if (op === 0x4c || op === 0x4d || op === 0x4e) {   // OP_PUSHDATA1/2/4
+      const nlen = op === 0x4c ? 1 : op === 0x4d ? 2 : 4;
+      if (i + 1 + nlen > bytes.length) { tail(i); break; }
+      let len = 0;
+      for (let k = 0; k < nlen; k++) len += bytes[i + 1 + k] * 2 ** (8 * k);
+      const start = i + 1 + nlen, end = start + len;
+      if (end > bytes.length) { tail(i); break; }
+      toks.push({ push: bytesToHex(bytes.subarray(start, end)) });
+      i = end;
+    } else {                                           // a non-push opcode
+      toks.push({ op });
+      i += 1;
+    }
+  }
+  return toks;
+}

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -224,6 +224,27 @@ export async function scriptToAddress(scriptHex) {
   return { type: 'unknown', address: null };
 }
 
+// scriptPubKey hex -> a short human label for its payment type ('p2pkh',
+// 'p2wsh', 'p2tr', 'multisig', 'data', …), or '' when it matches no standard
+// template. Lets a reader tell payment kinds apart at a glance; unlike
+// scriptToAddress this is synchronous and also names bare P2PK and multisig.
+export function scriptType(scriptHex) {
+  const s = hexToBytes(scriptHex);
+  const n = s.length, last = s[n - 1];
+  if (n === 25 && s[0] === 0x76 && s[1] === 0xa9 && s[2] === 0x14 && s[23] === 0x88 && last === 0xac) return 'p2pkh';
+  if (n === 23 && s[0] === 0xa9 && s[1] === 0x14 && last === 0x87) return 'p2sh';
+  if (n > 0 && s[0] === 0x6a) return 'data';                          // OP_RETURN
+  if (n === 22 && s[0] === 0x00 && s[1] === 0x14) return 'p2wpkh';
+  if (n === 34 && s[0] === 0x00 && s[1] === 0x20) return 'p2wsh';
+  if (n === 34 && s[0] === 0x51 && s[1] === 0x20) return 'p2tr';
+  if (((n === 35 && s[0] === 0x21) || (n === 67 && s[0] === 0x41)) && last === 0xac) return 'p2pk';
+  // bare multisig: OP_m <pubkeys…> OP_n OP_CHECKMULTISIG
+  if (n >= 37 && last === 0xae && s[0] >= 0x51 && s[0] <= 0x60 && s[n - 2] >= 0x51 && s[n - 2] <= 0x60) return 'multisig';
+  // any other witness program (v2+, or a non-standard length)
+  if (n >= 4 && n <= 42 && s[0] >= 0x51 && s[0] <= 0x60 && s[1] === n - 2 && s[1] >= 2) return `witness v${s[0] - 0x50}`;
+  return '';
+}
+
 // Attach a derived { type, address } to every output of a parsed transaction.
 export async function withAddresses(tx) {
   const vout = [];

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -224,27 +224,6 @@ export async function scriptToAddress(scriptHex) {
   return { type: 'unknown', address: null };
 }
 
-// scriptPubKey hex -> a short human label for its payment type ('p2pkh',
-// 'p2wsh', 'p2tr', 'multisig', 'data', …), or '' when it matches no standard
-// template. Lets a reader tell payment kinds apart at a glance; unlike
-// scriptToAddress this is synchronous and also names bare P2PK and multisig.
-export function scriptType(scriptHex) {
-  const s = hexToBytes(scriptHex);
-  const n = s.length, last = s[n - 1];
-  if (n === 25 && s[0] === 0x76 && s[1] === 0xa9 && s[2] === 0x14 && s[23] === 0x88 && last === 0xac) return 'p2pkh';
-  if (n === 23 && s[0] === 0xa9 && s[1] === 0x14 && last === 0x87) return 'p2sh';
-  if (n > 0 && s[0] === 0x6a) return 'data';                          // OP_RETURN
-  if (n === 22 && s[0] === 0x00 && s[1] === 0x14) return 'p2wpkh';
-  if (n === 34 && s[0] === 0x00 && s[1] === 0x20) return 'p2wsh';
-  if (n === 34 && s[0] === 0x51 && s[1] === 0x20) return 'p2tr';
-  if (((n === 35 && s[0] === 0x21) || (n === 67 && s[0] === 0x41)) && last === 0xac) return 'p2pk';
-  // bare multisig: OP_m <pubkeys…> OP_n OP_CHECKMULTISIG
-  if (n >= 37 && last === 0xae && s[0] >= 0x51 && s[0] <= 0x60 && s[n - 2] >= 0x51 && s[n - 2] <= 0x60) return 'multisig';
-  // any other witness program (v2+, or a non-standard length)
-  if (n >= 4 && n <= 42 && s[0] >= 0x51 && s[0] <= 0x60 && s[1] === n - 2 && s[1] >= 2) return `witness v${s[0] - 0x50}`;
-  return '';
-}
-
 // Attach a derived { type, address } to every output of a parsed transaction.
 export async function withAddresses(tx) {
   const vout = [];


### PR DESCRIPTION
Add a collapsible "Notation" section to web/bitcoin-book.html documenting
the manuscript's sigla: the Bitcoin script opcode glyphs (signatures,
hashes, timelocks, numbers, and stack/comparison/control) alongside the
transaction margin marks (sequence, locktime, coinbase, verse) that are
already drawn beside each transaction.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B156k86buQ5MYqunHps4VF