### PR TITLE
Parse and render the block header in the Bitcoin book

### DIFF
--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -171,6 +171,10 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .cite-verse-link:hover { color: var(--accent); text-decoration: underline; }
 /* The amount of the output this input spends, under its reference. */
 .cite-amount { margin-top: .1em; font: italic 400 12px/1.3 'Newsreader',serif; color: var(--meta); }
+/* An output's forward citation -- the verse that later spent it -- under its
+   amount in the right margin, mirroring the left margin's provenance cites.
+   Empty for an unspent output. */
+.fwd-cite { margin-top: .1em; font: 500 11.5px/1.3 'IBM Plex Mono',monospace; color: var(--dim); }
 .tx-in-script { grid-column: 2; min-width: 0; }
 .tx-outputs {
   grid-column: body / -1; grid-row: 2;
@@ -548,7 +552,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
   <details class="about">
     <summary>About</summary>
-    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above.</p>
+    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above. The margins carry the citation graph: each input cites the verse it spends from (that output's amount in parentheses beneath), and each spent output carries a forward citation — the verse that later consumed it — beneath its amount. An unspent output has none.</p>
     <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and witness items' length prefixes — is dropped, since it is reconstructable from structure; a script's push opcodes render as superscript byte counts (with ↧/⇊/⤋ arrows when the length rides in a 1/2/4-byte prefix). And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
     <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to β and η marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
     <p class="hint muted">Every Glossia-encoded hash — a block hash, a transaction id, the previous-block hash and merkle root above — hovers (or, on touch, taps) into a small selectable panel carrying the exact hex it encodes, and clicking it copies that hex to the clipboard.</p>
@@ -642,6 +646,49 @@ function toRoman(n) {
   let out = '';
   for (const [v, s] of map) while (n >= v) { out += s; n -= v; }
   return out || '0';
+}
+
+// txid -> the spending status of every output at once (Esplora /outspends):
+// [{ spent, txid, vin, status }] in output order. Memoized like citations.
+const outspendsCache = new Map();
+function loadOutspends(txid) {
+  if (!outspendsCache.has(txid)) {
+    outspendsCache.set(txid, (async () => {
+      const res = await fetch(`${ESPLORA}/tx/${txid}/outspends`);
+      if (!res.ok) throw new Error(`Esplora returned ${res.status}`);
+      return res.json();
+    })().catch((e) => { outspendsCache.delete(txid); throw e; }));
+  }
+  return outspendsCache.get(txid);
+}
+
+// Fill each output's forward-citation cell with the verse that spent it --
+// the mirror of the input margin's provenance cites: the left margin says
+// where value came from, the right margin says where it went next. One
+// outspends call covers every output; each confirmed spender then resolves
+// through the same memoized citation lookup as a prevout. An unspent (or
+// unconfirmed-spend) output leaves its cell empty, and any failure stays
+// silent -- a missing forward reference is absence, not an error.
+async function resolveForwardCitations(txid, cells, gen) {
+  try {
+    const spends = await loadOutspends(txid);
+    await Promise.all(cells.map(async (cell, i) => {
+      const sp = spends[i];
+      if (!sp || !sp.spent || !sp.txid || !sp.status || !sp.status.confirmed) return;
+      try {
+        const { height, pos } = await resolveCitation(sp.txid);
+        if (gen !== renderGen) return;
+        const { volume, book, chapter } = volumeBookChapter(height);
+        const link = document.createElement('a');
+        link.className = 'cite-verse-link';
+        link.href = `?block=${height}&index=${pos}`;
+        link.textContent = `${toRoman(volume)} ${book} ${chapter} §${pos + 1}`;
+        link.title = `spent by input ${sp.vin + 1} of ${sp.txid}`;
+        link.addEventListener('click', (e) => { e.preventDefault(); goToVerse(height, pos, null); });
+        cell.append(link);
+      } catch { /* unresolvable spender -- leave the cell empty */ }
+    }));
+  } catch { /* outspends unavailable -- every cell stays empty */ }
 }
 
 // Populate a citation cell with the scripture-style reference "volume(Roman)
@@ -868,6 +915,7 @@ function renderChapter(para) {
   outputsEl.className = 'tx-outputs';
   let leadUsed = false;
   const pendingCites = [];
+  const fwdCells = [];
 
   // A body line; the first one across the whole transaction claims the drop
   // cap -- unless it opens with a bare push count (⁶⁹ …), whose superscript's
@@ -968,6 +1016,13 @@ function renderChapter(para) {
     const valueCell = document.createElement('div');
     valueCell.className = 'tx-note tx-out-value';
     valueCell.textContent = out.value;
+    // Forward citation placeholder: filled with the verse that later spent
+    // this output, once the outspends resolve. An unspent output keeps it
+    // empty -- still-live value has no forward reference.
+    const fwd = document.createElement('div');
+    fwd.className = 'fwd-cite';
+    valueCell.append(fwd);
+    fwdCells.push(fwd);
     outputsEl.append(scriptCell, valueCell);
   });
   const lock = document.createElement('div');
@@ -979,6 +1034,7 @@ function renderChapter(para) {
   wrap.append(flow);
   body.append(wrap);
   resolveCitations(pendingCites, gen);
+  resolveForwardCitations(para.txid, fwdCells, gen);
 
   // Footnotes are reset, then expanded automatically once the transaction is on
   // screen (renderFootnotes runs async so the prose paints first).

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -224,14 +224,12 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 }
 @media (max-width: 560px) {
   /* Collapse every band into one column: each margin cell becomes a full-width
-     block stacked with the body it annotated, tagged with ← / → to keep the
-     sense. Citations lead their input; amounts follow their output. */
+     block stacked with the body it annotated. Citations lead their input;
+     amounts follow their output -- position alone carries the sense. */
   .tx-flow { grid-template-columns: 1fr; }
   .tx-inputs, .tx-outputs, .tx-locktime { grid-column: 1; grid-row: auto; display: block; }
   .tx-in-cite { text-align: left; margin: 0 0 .2em; }
-  .tx-in-cite::before { content: '← '; }
   .tx-out-value, .tx-locktime { text-align: left; margin: 0 0 .55em; }
-  .tx-out-value::before, .tx-locktime::before { content: '→ '; }
 }
 
 /* A witness-bearing input carries a small superscript index inline; the matching

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -312,7 +312,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <details class="notation">
     <summary>Notation</summary>
     <div class="notation-body">
-      <p class="notation-lede">A key to the sigla used in the manuscript: the glyphs that notate a Bitcoin <b>script's opcodes</b>, and the <b>marks</b> drawn in each transaction's margins. Pushed data — keys, hashes, signatures — is rendered as prose between the glyphs.</p>
+      <p class="notation-lede">A key to the sigla used in the manuscript: the glyphs that notate a Bitcoin <b>script's opcodes</b>, and the <b>marks</b> drawn in each transaction's margins. Pushed data — keys, hashes, signatures — is rendered as prose between the glyphs. (Push instructions — OP_PUSHBYTES_<i>n</i>, OP_PUSHDATA1/2/4 — are opcodes too; they surface as the data they carry rather than as marks, since their framing is reconstructable from it.)</p>
 
       <div class="notation-group">
         <h4>Signatures &amp; keys</h4>
@@ -358,10 +358,10 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <div class="notation-group">
         <h4>Coinbase — the mining preamble</h4>
         <div class="glyph-grid">
-          <div class="glyph-row"><span class="g">◎<i>t</i></span><span class="m">the <b>difficulty target</b> the block was mined against</span></div>
+          <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b> — a hash opening with 8+n zero digits</span></div>
           <div class="glyph-row"><span class="g">⊕<i>n</i></span><span class="m"><b>extranonce</b> — search space beyond the header's nonce</span></div>
         </div>
-        <p class="notation-note">The chain's earliest coinbases open with these two values — the miner's restatement of the header's difficulty target, and the counter it rolled once the header's 32-bit nonce ran out. Decoded to marks, so any embedded words (the genesis headline) lead the text.</p>
+        <p class="notation-note">β's subscript counts the target's leading zero hex digits beyond the eight genesis opens with, so β₀ is difficulty 1 and the subscript climbs as difficulty rises. Digits after β are the target's remaining significant digits; a bare β<i>n</i> stands for the baseline ffff. The chain's earliest coinbases open with this preamble — the miner's restatement of the header's target, then the counter it rolled once the header's 32-bit nonce ran out — decoded to marks so any embedded words (the genesis headline) lead the text.</p>
       </div>
 
       <div class="notation-group">
@@ -422,7 +422,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
     <summary>About</summary>
     <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above.</p>
     <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and push/item length prefixes — is dropped, since it is reconstructable from structure. And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
-    <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to ◎ and ⊕ marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
+    <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to β and ⊕ marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
     <p class="hint muted">Every Glossia-encoded hash — a block hash, a transaction id, the previous-block hash and merkle root above — hovers (or, on touch, taps) into a small selectable panel carrying the exact hex it encodes, and clicking it copies that hex to the clipboard.</p>
     <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
   </details>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -326,7 +326,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <div class="notation-group">
         <h4>Pushes</h4>
         <div class="glyph-grid">
-          <div class="glyph-row"><span class="g">₂₀</span><span class="m"><b>push</b> — the bare subscript is the byte count (₂₀ pushes twenty)</span></div>
+          <div class="glyph-row"><span class="g">²⁰</span><span class="m"><b>push</b> — the bare superscript is the byte count (²⁰ pushes twenty)</span></div>
           <div class="glyph-row"><span class="g">↧<i>n</i> ⇊<i>n</i> ⤋<i>n</i></span><span class="m">extended push — length in a 1 / 2 / 4-byte prefix</span></div>
         </div>
         <p class="notation-note">The pushed bytes follow the mark, as prose or an inline quote; arrow weight matches prefix width. The coinbase preamble's β<i>n</i> and η<i>n</i> fold their push in — the mark alone determines the exact bytes.</p>
@@ -380,7 +380,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b> — a hash opening with 8+n zero digits</span></div>
           <div class="glyph-row"><span class="g">η<i>n</i></span><span class="m"><b>extranonce</b> — search space beyond the header's η</span></div>
         </div>
-        <p class="notation-note">β's subscript counts the target's leading zero hex digits beyond the eight genesis opens with, so β₀ is difficulty 1 and the subscript climbs as difficulty rises. Digits after β are the target's remaining significant digits; a bare β<i>n</i> stands for the baseline ffff. The chain's earliest coinbases open with this preamble — the miner's restatement of the header's target, then the counter it rolled once the header's 32-bit nonce ran out — decoded to marks so any embedded words (the genesis headline) lead the text.</p>
+        <p class="notation-note">β's subscript counts the target's leading zero hex digits beyond the eight genesis opens with, so β₀ is difficulty 1 and the subscript climbs as difficulty rises. Hex digits after a middot (β₃·4864c) are the target's remaining significant digits; a bare β<i>n</i> stands for the baseline ffff. The chain's earliest coinbases open with this preamble — the miner's restatement of the header's target, then the counter it rolled once the header's 32-bit nonce ran out — decoded to marks so any embedded words (the genesis headline) lead the text.</p>
       </div>
 
       <div class="notation-group">
@@ -479,44 +479,44 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <div class="pattern-table">
           <span class="phead"></span><span class="phead">Input</span><span class="phead">Output</span><span class="phead">Witness</span>
           <span class="pname">P2PK</span>
-            <span class="seq"><span class="op op-push">₇₁</span><span class="ph">𝒮</span></span>
-            <span class="seq"><span class="op op-push">₆₅</span><span class="ph">𝒫</span> <span class="op">∇</span></span>
+            <span class="seq"><span class="op op-push">⁷¹</span><span class="ph">𝒮</span></span>
+            <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">𝒫</span> <span class="op">∇</span></span>
             <span class="seq none">—</span>
           <span class="pname">P2PKH</span>
-            <span class="seq"><span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span></span>
-            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span> <span class="op">≡</span> <span class="op">∇</span></span>
+            <span class="seq"><span class="op op-push">⁷¹</span><span class="ph">𝒮</span> <span class="op op-push">³³</span><span class="ph">𝒫</span></span>
+            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">ℋ</span> <span class="op">≡</span> <span class="op">∇</span></span>
             <span class="seq none">—</span>
           <span class="pname">Multisig</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span></span>
-            <span class="seq"><span class="op">②</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op">③</span> <span class="op">◇</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">⁷¹</span><span class="ph">𝒮</span> <span class="op op-push">⁷¹</span><span class="ph">𝒮</span></span>
+            <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝒫</span> <span class="op op-push">³³</span><span class="ph">𝒫</span> <span class="op op-push">³³</span><span class="ph">𝒫</span> <span class="op">③</span> <span class="op">◇</span></span>
             <span class="seq none">—</span>
           <span class="pname">P2SH</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">ₙ</span><span class="ph">ℛ</span></span>
-            <span class="seq"><span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span> <span class="op">=</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">⁷¹</span><span class="ph">𝒮</span> <span class="op op-push">⁷¹</span><span class="ph">𝒮</span> <span class="op op-push">ⁿ</span><span class="ph">ℛ</span></span>
+            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">ℋ</span> <span class="op">=</span></span>
             <span class="seq none">—</span>
           <span class="pname">P2WPKH</span>
             <span class="seq none">∅</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">ℋ</span></span>
             <span class="seq"><span class="ph">𝒮</span> · <span class="ph">𝒫</span></span>
           <span class="pname">P2WSH</span>
             <span class="seq none">∅</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">₃₂</span><span class="ph">ℋ</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">ℋ</span></span>
             <span class="seq">∅ · <span class="ph">𝒮</span> · <span class="ph">𝒮</span> · <span class="ph">𝒲</span></span>
           <span class="pname">P2TR key</span>
             <span class="seq none">∅</span>
-            <span class="seq"><span class="op">①</span> <span class="op op-push">₃₂</span><span class="ph">𝒫</span></span>
+            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝒫</span></span>
             <span class="seq"><span class="ph">𝒮</span></span>
           <span class="pname">P2TR script</span>
             <span class="seq none">∅</span>
-            <span class="seq"><span class="op">①</span> <span class="op op-push">₃₂</span><span class="ph">𝒫</span></span>
+            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝒫</span></span>
             <span class="seq"><span class="ph">𝒮</span> · <span class="ph">𝒯</span> · <span class="ph">…</span></span>
           <span class="pname">Data</span>
             <span class="seq none">—</span>
-            <span class="seq"><span class="op">¶</span> <span class="op op-push">ₙ</span><span class="ph">…</span></span>
+            <span class="seq"><span class="op">¶</span> <span class="op op-push">ⁿ</span><span class="ph">…</span></span>
             <span class="seq none">—</span>
         </div>
         </div>
-        <p class="notation-note">Read the proof's migration down the table: legacy types carry it in the input, segwit types leave the input empty (∅) and move it to the witness. The push subscripts are the patterns' fingerprints — P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length, ₂₀ a HASH160 of a key, ₃₂ a SHA-256 of a script. A script hidden behind a hash — ℛ, 𝒲, 𝒯 — is revealed in the same notation when spent: an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">ℋ</span> <span class="op" style="font-style:normal">≡</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">│</span> <span class="ph">n</span> <span class="op" style="font-style:normal">τ ⌄</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">⟩ ∇</span>. In witness cells, · separates stack items and ∅ is an empty item (the multisig dummy) — a witness is a stack, not a script, so ⓪ the opcode never appears there; in the P2SH spend's input, which IS script, the dummy is the real ⓪ byte. The Data output is provably unspendable, so it has no spend at all.</p>
+        <p class="notation-note">Read the proof's migration down the table: legacy types carry it in the input, segwit types leave the input empty (∅) and move it to the witness. The push superscripts are the patterns' fingerprints — P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length, ²⁰ a HASH160 of a key, ³² a SHA-256 of a script. A script hidden behind a hash — ℛ, 𝒲, 𝒯 — is revealed in the same notation when spent: an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">ℋ</span> <span class="op" style="font-style:normal">≡</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">│</span> <span class="ph">n</span> <span class="op" style="font-style:normal">τ ⌄</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">⟩ ∇</span>. In witness cells, · separates stack items and ∅ is an empty item (the multisig dummy) — a witness is a stack, not a script, so ⓪ the opcode never appears there; in the P2SH spend's input, which IS script, the dummy is the real ⓪ byte. The Data output is provably unspendable, so it has no spend at all.</p>
       </div>
 
       <div class="notation-group">
@@ -547,7 +547,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <details class="about">
     <summary>About</summary>
     <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above.</p>
-    <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and witness items' length prefixes — is dropped, since it is reconstructable from structure; a script's push opcodes render as subscript byte counts (with ↧/⇊/⤋ arrows when the length rides in a 1/2/4-byte prefix). And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
+    <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and witness items' length prefixes — is dropped, since it is reconstructable from structure; a script's push opcodes render as superscript byte counts (with ↧/⇊/⤋ arrows when the length rides in a 1/2/4-byte prefix). And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
     <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to β and η marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
     <p class="hint muted">Every Glossia-encoded hash — a block hash, a transaction id, the previous-block hash and merkle root above — hovers (or, on touch, taps) into a small selectable panel carrying the exact hex it encodes, and clicking it copies that hex to the clipboard.</p>
     <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
@@ -864,7 +864,7 @@ function renderChapter(para) {
   const pendingCites = [];
 
   // A body line; the first one across the whole transaction claims the drop
-  // cap -- unless it opens with a bare push count (₆₉ …), whose subscript's
+  // cap -- unless it opens with a bare push count (⁶⁹ …), whose superscript's
   // first digit would be blown up into a giant numeral, tearing the mark
   // apart. In that case the cap is forfeited for the transaction, not
   // deferred to a later line (an illuminated initial belongs at the top).

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -380,7 +380,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b> — a valid hash opens with n zero bits</span></div>
           <div class="glyph-row"><span class="g">η<i>n</i></span><span class="m"><b>extranonce</b> — search space beyond the header's η</span></div>
         </div>
-        <p class="notation-note">β's subscript is the target's demand in leading zero bits — β₃₂ at genesis (difficulty 1), climbing as difficulty rises; each +1 doubles the work. Hex digits after a middot (β₄₅·4864c) are the target's remaining significant digits; a bare β<i>n</i> stands for the baseline ffff. The chain's earliest coinbases open with this preamble — the miner's restatement of the header's target, then the counter it rolled once the header's 32-bit nonce ran out — decoded to marks so any embedded words (the genesis headline) lead the text.</p>
+        <p class="notation-note">β's subscript is the target's demand in leading zero bits — β₃₂ at genesis (difficulty 1), climbing as difficulty rises; each +1 doubles the work. The exact target rides in β's hover. The chain's earliest coinbases open with this preamble — the miner's restatement of the header's target, then the counter it rolled once the header's 32-bit nonce ran out — decoded to marks so any embedded words (the genesis headline) lead the text.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -195,6 +195,10 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    we haven't given a glyph falls back to Bitcoin Core's OP_* name in small mono. */
 .op { color: var(--accent); font-style: normal; }
 .op-name { font: 600 .62em/1 'IBM Plex Mono',monospace; letter-spacing:.04em; color: var(--dim); font-style: normal; vertical-align: .14em; white-space: nowrap; }
+/* A decoded value riding a mark (the coinbase preamble's ◎target and
+   ⊕extranonce): mono like an OP_ name, but a size up -- it's a number to
+   read, not a fallback label. */
+.op-num { font: 500 .72em/1 'IBM Plex Mono',monospace; color: var(--dim); font-style: normal; vertical-align: .1em; white-space: nowrap; margin-left: .08em; }
 /* A witness footnote is a stack of items; a thin middot separates each, and an
    empty stack item shows as ∅. */
 .wit-sep, .wit-empty { color: var(--meta); font-style: normal; }
@@ -352,6 +356,15 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       </div>
 
       <div class="notation-group">
+        <h4>Coinbase — the mining preamble</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">◎<i>t</i></span><span class="m">the <b>difficulty target</b> the block was mined against</span></div>
+          <div class="glyph-row"><span class="g">⊕<i>n</i></span><span class="m"><b>extranonce</b> — search space beyond the header's nonce</span></div>
+        </div>
+        <p class="notation-note">The chain's earliest coinbases open with these two values — the miner's restatement of the header's difficulty target, and the counter it rolled once the header's 32-bit nonce ran out. Decoded to marks, so any embedded words (the genesis headline) lead the text.</p>
+      </div>
+
+      <div class="notation-group">
         <h4>Stack, comparison &amp; control</h4>
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">⧉</span><span class="m"><b>duplicate</b> the top item</span></div>
@@ -409,7 +422,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
     <summary>About</summary>
     <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above.</p>
     <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and push/item length prefixes — is dropped, since it is reconstructable from structure. And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
-    <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover.</p>
+    <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to ◎ and ⊕ marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
     <p class="hint muted">Every Glossia-encoded hash — a block hash, a transaction id, the previous-block hash and merkle root above — hovers (or, on touch, taps) into a small selectable panel carrying the exact hex it encodes, and clicking it copies that hex to the clipboard.</p>
     <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
   </details>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -196,7 +196,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .op { color: var(--accent); font-style: normal; }
 .op-name { font: 600 .62em/1 'IBM Plex Mono',monospace; letter-spacing:.04em; color: var(--dim); font-style: normal; vertical-align: .14em; white-space: nowrap; }
 /* A decoded value riding a mark (the coinbase preamble's βtarget and
-   ⊕extranonce): mono like an OP_ name, but a size up -- it's a number to
+   ηextranonce): mono like an OP_ name, but a size up -- it's a number to
    read, not a fallback label. */
 .op-num { font: 500 .72em/1 'IBM Plex Mono',monospace; color: var(--dim); font-style: normal; vertical-align: .1em; white-space: nowrap; margin-left: .08em; }
 /* A push opcode's mark (↧ₙ and the OP_PUSHDATA variants): quieter than the
@@ -324,7 +324,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">₂₀</span><span class="m"><b>push</b> — the bare subscript is the byte count (₂₀ pushes twenty)</span></div>
           <div class="glyph-row"><span class="g">↧<i>n</i> ⇊<i>n</i> ⤋<i>n</i></span><span class="m">extended push — length in a 1 / 2 / 4-byte prefix</span></div>
         </div>
-        <p class="notation-note">The pushed bytes follow the mark, as prose or an inline quote; arrow weight matches prefix width. The coinbase preamble's β<i>n</i> and ⊕<i>n</i> fold their push in — the mark alone determines the exact bytes.</p>
+        <p class="notation-note">The pushed bytes follow the mark, as prose or an inline quote; arrow weight matches prefix width. The coinbase preamble's β<i>n</i> and η<i>n</i> fold their push in — the mark alone determines the exact bytes.</p>
       </div>
 
       <div class="notation-group">
@@ -373,7 +373,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Coinbase — the mining preamble</h4>
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b> — a hash opening with 8+n zero digits</span></div>
-          <div class="glyph-row"><span class="g">⊕<i>n</i></span><span class="m"><b>extranonce</b> — search space beyond the header's nonce</span></div>
+          <div class="glyph-row"><span class="g">η<i>n</i></span><span class="m"><b>extranonce</b> — search space beyond the header's η</span></div>
         </div>
         <p class="notation-note">β's subscript counts the target's leading zero hex digits beyond the eight genesis opens with, so β₀ is difficulty 1 and the subscript climbs as difficulty rises. Digits after β are the target's remaining significant digits; a bare β<i>n</i> stands for the baseline ffff. The chain's earliest coinbases open with this preamble — the miner's restatement of the header's target, then the counter it rolled once the header's 32-bit nonce ran out — decoded to marks so any embedded words (the genesis headline) lead the text.</p>
       </div>
@@ -384,9 +384,9 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">v<i>n</i></span><span class="m">block <b>version</b></span></div>
           <div class="glyph-row"><span class="g">∅</span><span class="m">no previous block — the genesis chapter</span></div>
           <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b>, as in the preamble</span></div>
-          <div class="glyph-row"><span class="g">ν<i>n</i></span><span class="m">the <b>nonce</b> the miner landed on</span></div>
+          <div class="glyph-row"><span class="g">η<i>n</i></span><span class="m">the <b>nonce</b> the miner landed on</span></div>
         </div>
-        <p class="notation-note">The chapter head runs the header's fields in wire order: version, the previous chapter's hash as prose (∅ for genesis), the merkle root as prose, the timestamp, β, ν. The header's ν and the coinbase's ⊕ together are the miner's full search space.</p>
+        <p class="notation-note">The chapter head runs the header's fields in wire order: version, the previous chapter's hash as prose (∅ for genesis), the merkle root as prose, the timestamp, β, η. The header's η and the coinbase preamble's extranonce together are the miner's full search space.</p>
       </div>
 
       <div class="notation-group">
@@ -455,19 +455,37 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       </div>
 
       <div class="notation-group">
-        <h4>Common script patterns</h4>
-        <p class="notation-note">A payment's kind is legible in its sequence of marks — learn these and you can read a script's purpose at sight. <span class="ph">…</span> stands for pushed data (a key, a hash, a signature), rendered as prose.</p>
-        <div class="pattern-list">
-          <span class="pname">P2PK</span><span class="seq"><span class="op op-push">₆₅</span><span class="ph">…</span> <span class="op">∇</span></span>
-          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">…</span> <span class="op">≡</span> <span class="op">∇</span></span>
-          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">…</span> <span class="op">=</span></span>
-          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">₂₀</span><span class="ph">…</span></span>
-          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">₃₂</span><span class="ph">…</span></span>
-          <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="op op-push">₃₂</span><span class="ph">…</span></span>
-          <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="op op-push">₃₃</span><span class="ph">…</span> <span class="op op-push">₃₃</span><span class="ph">…</span> <span class="op op-push">₃₃</span><span class="ph">…</span> <span class="op">③</span> <span class="op">◇</span></span>
-          <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="op op-push">ₙ</span><span class="ph">…</span></span>
+        <h4>Data</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">𝒫</span><span class="m"><b>public key</b></span></div>
+          <div class="glyph-row"><span class="g">𝒮</span><span class="m"><b>signature</b></span></div>
+          <div class="glyph-row"><span class="g">ℋ</span><span class="m"><b>hash</b></span></div>
+          <div class="glyph-row"><span class="g">ℛ</span><span class="m"><b>redeem script</b> (inside P2SH)</span></div>
+          <div class="glyph-row"><span class="g">𝒲</span><span class="m"><b>witness script</b> (inside P2WSH)</span></div>
+          <div class="glyph-row"><span class="g">𝒯</span><span class="m"><b>tapscript</b> (a Taproot leaf)</span></div>
         </div>
-        <p class="notation-note">The push subscripts are the patterns' fingerprints: P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length — ₂₀ a HASH160 of a key, ₃₂ a SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. The scripts hidden inside P2SH / P2WSH — an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">…</span> <span class="op" style="font-style:normal">≡ … │ …</span> <span class="op" style="font-style:normal">τ ⌄ … ⟩</span> — are revealed in the same notation when spent.</p>
+        <p class="notation-note">Type marks naming what a push carries, used in the pattern key below. On the page itself the bytes read as prose — the type is legible from the marks around them.</p>
+      </div>
+
+      <div class="notation-group">
+        <h4>Common script patterns</h4>
+        <p class="notation-note">A payment's kind is legible in its sequence of marks — learn these and you can read a script's purpose at sight.</p>
+        <div class="pattern-list">
+          <span class="pname">P2PK</span><span class="seq"><span class="op op-push">₆₅</span><span class="ph">𝒫</span> <span class="op">∇</span></span>
+          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span> <span class="op">≡</span> <span class="op">∇</span></span>
+          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span> <span class="op">=</span></span>
+          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span></span>
+          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">₃₂</span><span class="ph">ℋ</span></span>
+          <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="op op-push">₃₂</span><span class="ph">𝒫</span></span>
+          <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op">③</span> <span class="op">◇</span></span>
+          <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="op op-push">ₙ</span><span class="ph">…</span></span>
+          <span class="pname">P2PKH spend</span><span class="seq"><span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span></span>
+          <span class="pname">P2SH spend</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">ₙ</span><span class="ph">ℛ</span></span>
+          <span class="pname">P2WPKH wit.</span><span class="seq"><span class="ph">𝒮</span> · <span class="ph">𝒫</span></span>
+          <span class="pname">P2WSH wit.</span><span class="seq">∅ · <span class="ph">𝒮</span> · <span class="ph">𝒮</span> · <span class="ph">𝒲</span></span>
+          <span class="pname">P2TR script</span><span class="seq"><span class="ph">𝒮</span> · <span class="ph">𝒯</span> · <span class="ph">…</span></span>
+        </div>
+        <p class="notation-note">The push subscripts are the patterns' fingerprints: P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length — ₂₀ a HASH160 of a key, ₃₂ a SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. A script hidden behind a hash — ℛ, 𝒲, 𝒯 — is revealed in the same notation when spent: an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">ℋ</span> <span class="op" style="font-style:normal">≡</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">│</span> <span class="ph">n</span> <span class="op" style="font-style:normal">τ ⌄</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">⟩ ∇</span>. Witness rows read stack items left to right; ∅ is the multisig dummy.</p>
       </div>
 
       <div class="notation-group">
@@ -499,7 +517,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
     <summary>About</summary>
     <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above.</p>
     <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and witness items' length prefixes — is dropped, since it is reconstructable from structure; a script's push opcodes render as subscript byte counts (with ↧/⇊/⤋ arrows when the length rides in a 1/2/4-byte prefix). And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
-    <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to β and ⊕ marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
+    <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to β and η marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
     <p class="hint muted">Every Glossia-encoded hash — a block hash, a transaction id, the previous-block hash and merkle root above — hovers (or, on touch, taps) into a small selectable panel carrying the exact hex it encodes, and clicking it copies that hex to the clipboard.</p>
     <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
   </details>
@@ -742,7 +760,7 @@ function renderFrontispiece(header) {
     { text: merkleProse, copy: { hex: header.merkleRoot, label: 'merkle root' } },
     { text: hf.timestamp, title: hf.timestampTitle },
     { text: hf.bits, title: hf.bitsTitle },
-    { text: `ν${hf.nonce}`, title: `nonce ${hf.nonce} — the value the miner incremented while searching for a hash below the difficulty target` },
+    { text: `η${hf.nonce}`, title: `nonce ${hf.nonce} — the value the miner incremented while searching for a hash below the difficulty target` },
   ];
   for (const { text, title, copy } of items) {
     const span = document.createElement('span');

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -516,7 +516,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq none">—</span>
         </div>
         </div>
-        <p class="notation-note">Read the proof's migration down the table: legacy types carry it in the input, segwit types leave the input empty (∅) and move it to the witness. The push subscripts are the patterns' fingerprints — P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length, ₂₀ a HASH160 of a key, ₃₂ a SHA-256 of a script. A script hidden behind a hash — ℛ, 𝒲, 𝒯 — is revealed in the same notation when spent: an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">ℋ</span> <span class="op" style="font-style:normal">≡</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">│</span> <span class="ph">n</span> <span class="op" style="font-style:normal">τ ⌄</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">⟩ ∇</span>. In witness cells, · separates stack items and ∅ is the multisig dummy; the Data output is provably unspendable, so it has no spend at all.</p>
+        <p class="notation-note">Read the proof's migration down the table: legacy types carry it in the input, segwit types leave the input empty (∅) and move it to the witness. The push subscripts are the patterns' fingerprints — P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length, ₂₀ a HASH160 of a key, ₃₂ a SHA-256 of a script. A script hidden behind a hash — ℛ, 𝒲, 𝒯 — is revealed in the same notation when spent: an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">ℋ</span> <span class="op" style="font-style:normal">≡</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">│</span> <span class="ph">n</span> <span class="op" style="font-style:normal">τ ⌄</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">⟩ ∇</span>. In witness cells, · separates stack items and ∅ is an empty item (the multisig dummy) — a witness is a stack, not a script, so ⓪ the opcode never appears there; in the P2SH spend's input, which IS script, the dummy is the real ⓪ byte. The Data output is provably unspendable, so it has no spend at all.</p>
       </div>
 
       <div class="notation-group">
@@ -536,7 +536,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">□</span><span class="m">no locktime</span></div>
           <div class="glyph-row"><span class="g">■<i>n</i></span><span class="m">not before block n</span></div>
           <div class="glyph-row"><span class="g">⊥<i>n</i></span><span class="m">not before time n</span></div>
-          <div class="glyph-row"><span class="g">∅</span><span class="m">a coinbase — no prior output</span></div>
+          <div class="glyph-row"><span class="g">∅</span><span class="m"><b>empty</b> — a coinbase's absent prevout, a segwit input's zero-byte script, an empty witness item</span></div>
           <div class="glyph-row"><span class="g">§<i>n</i></span><span class="m">verse — the transaction's position</span></div>
         </div>
         <p class="notation-note">■ and ⊥ mean block-height and time in both places; a square reads as the whole transaction, a circle as one input.</p>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -108,6 +108,12 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .chapter-num { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.3em; text-transform:uppercase; color: var(--accent); margin-bottom: 14px; }
 .chapter-title { font: 500 34px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 12px; letter-spacing: -.01em; }
 .chapter-hash { font: italic 400 15px/1.5 'Newsreader',serif; color: var(--meta); margin: 0 auto 16px; max-width: 46ch; }
+/* The block header's own fields -- version, previous-block hash, merkle
+   root, timestamp, difficulty target, nonce -- in wire order, under the
+   chapter hash. A small mono line, like the manuscript's other margin notes;
+   each field carries its decoded form in `title` (a tooltip). */
+.chapter-frontispiece { margin: 0 auto 4px; max-width: 46ch; font: 500 11.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
+.chapter-frontispiece .cfx + .cfx::before { content: ' · '; }
 
 /* Per-verse navigation: Previous / Next flanking the verse title -- the
    transaction's position within its block, rendered as "Verse N". */
@@ -263,6 +269,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span id="ch-book"></span><span id="ch-chapter-inline"></span></div>
       <h1 class="chapter-title" id="ch-title"></h1>
       <div class="chapter-hash" id="ch-hash-short"></div>
+      <div class="chapter-frontispiece" id="ch-frontispiece"></div>
       <nav class="verse-nav">
         <button type="button" id="page-prev">← Previous</button>
         <h2 class="verse-title" id="verse-title"></h2>
@@ -382,14 +389,15 @@ button:disabled { opacity: .4; cursor: not-allowed; }
     <summary>About</summary>
     <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above.</p>
     <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and push/item length prefixes — is dropped, since it is reconstructable from structure. And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
+    <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover.</p>
     <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
   </details>
 </div>
 
 <script type="module">
 import { init, encodeSeedPhrase } from './glossia-msg.js';
-import { parseTransaction, computeTxid } from './btc-tx.js';
-import { composeTransactionFields, groupDigits, renderWitness } from './btc-prose.js';
+import { parseTransaction, computeTxid, parseBlockHeader, computeBlockHash } from './btc-tx.js';
+import { composeTransactionFields, composeBlockHeaderFields, groupDigits, renderWitness } from './btc-prose.js';
 import { volumeBookChapter } from './btc-citation.js';
 
 const $ = (id) => document.getElementById(id);
@@ -523,15 +531,22 @@ async function resolveCitations(pending, gen) {
 }
 
 async function loadBlockMeta(hash) {
-  const [blockRes, txidsRes] = await Promise.all([
+  const [blockRes, txidsRes, headerRes] = await Promise.all([
     fetch(`${ESPLORA}/block/${hash}`),
     fetch(`${ESPLORA}/block/${hash}/txids`),
+    fetch(`${ESPLORA}/block/${hash}/header`),
   ]);
   if (!blockRes.ok) throw new Error(`Esplora returned ${blockRes.status} fetching block info.`);
   if (!txidsRes.ok) throw new Error(`Esplora returned ${txidsRes.status} fetching the transaction list.`);
+  if (!headerRes.ok) throw new Error(`Esplora returned ${headerRes.status} fetching the block header.`);
   const block = await blockRes.json();
   const txids = await txidsRes.json();
-  return { hash, height: block.height, block, txids };
+  const headerHex = (await headerRes.text()).trim();
+  // Parsed from the raw 80-byte header, not trusted from the JSON above --
+  // same self-parsed, self-verified stance as a transaction's txid.
+  const header = parseBlockHeader(headerHex);
+  const headerVerified = (await computeBlockHash(headerHex)) === hash;
+  return { hash, height: block.height, block, txids, header, headerVerified };
 }
 
 async function loadBlockByHeight(height) {
@@ -576,6 +591,37 @@ async function showCurrentTx() {
   setStatus('');
 }
 
+// The block header itself, in wire order, as a small mono line under the
+// chapter hash: version, previous-block hash, merkle root, timestamp,
+// difficulty target, nonce. The two hashes are Glossia-encoded here (like
+// the chapter/verse hash above); the rest come pre-decoded from
+// composeBlockHeaderFields. Genesis has no previous block, shown as ∅.
+function renderFrontispiece(header) {
+  const el = $('ch-frontispiece');
+  el.innerHTML = '';
+  const hf = composeBlockHeaderFields(header);
+  const isGenesisPrev = header.prevBlockHash === '00'.repeat(32);
+  const prevProse = isGenesisPrev ? '∅' : encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(header.prevBlockHash)), 'english', BEST_OF).prose;
+  // The merkle root isn't proof-of-work-constrained, so unlike a block hash
+  // it has no expected run of zero bytes worth trimming.
+  const merkleProse = encodeSeedPhrase(reverseHex(header.merkleRoot), 'english', BEST_OF).prose;
+  const items = [
+    { text: `v${hf.version}`, title: 'block version' },
+    { text: prevProse, title: isGenesisPrev ? 'no earlier block — this is the genesis block' : `previous block: ${header.prevBlockHash}` },
+    { text: merkleProse, title: `merkle root of this block's transactions: ${header.merkleRoot}` },
+    { text: hf.timestamp, title: hf.timestampTitle },
+    { text: hf.bits, title: hf.bitsTitle },
+    { text: hf.nonce, title: 'nonce — the value the miner incremented while searching for a hash below the difficulty target' },
+  ];
+  for (const { text, title } of items) {
+    const span = document.createElement('span');
+    span.className = 'cfx';
+    span.textContent = text;
+    span.title = title;
+    el.append(span);
+  }
+}
+
 function renderChapter(para) {
   const { volume, book, chapter } = volumeBookChapter(state.height);
   $('ch-volume').textContent = volume.toLocaleString();
@@ -599,6 +645,8 @@ function renderChapter(para) {
   const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(state.hash)), 'english', BEST_OF);
   $('ch-hash-short').textContent = hashProse;
   $('ch-hash-short').title = state.hash;
+  $('ch-frontispiece').classList.toggle('hidden', !onFirstTx);
+  if (onFirstTx) renderFrontispiece(state.header);
 
   // This verse's own txid, encoded as prose beneath the verse title. Reversed
   // to internal byte order first (like the block hash) so it carries the txid's

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -268,10 +268,15 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .glyph-row .m { font: 400 13px/1.45 'Public Sans', sans-serif; color: var(--dim); }
 .glyph-row .m b { color: var(--ink-soft); font-weight: 500; }
 .notation-note { margin: 9px 0 0; font-size: 12px; font-style: italic; color: var(--meta); }
-/* Common script patterns: a payment type -> the sequence of marks it reads as. */
-.pattern-list { display: grid; grid-template-columns: auto 1fr; gap: 9px 18px; align-items: baseline; }
-.pattern-list .pname { font: 600 10px/1.5 'IBM Plex Mono',monospace; letter-spacing: .06em; text-transform: uppercase; color: var(--meta); white-space: nowrap; }
-.pattern-list .seq { font: 400 16px/1.5 'Newsreader', system-ui, 'Segoe UI Symbol', serif; color: var(--ink-soft); }
+/* Common script patterns: one row per payment type, its marks split across
+   where they live on the wire -- input (scriptSig), output (scriptPubKey),
+   witness. Wide, so it scrolls in its own container on narrow screens. */
+.pattern-scroll { overflow-x: auto; }
+.pattern-table { display: grid; grid-template-columns: repeat(4, max-content); gap: 9px 22px; align-items: baseline; }
+.pattern-table .phead, .pattern-table .pname { font: 600 10px/1.5 'IBM Plex Mono',monospace; letter-spacing: .06em; text-transform: uppercase; color: var(--meta); white-space: nowrap; }
+.pattern-table .phead { color: var(--accent); }
+.pattern-table .seq { font: 400 16px/1.5 'Newsreader', system-ui, 'Segoe UI Symbol', serif; color: var(--ink-soft); white-space: nowrap; }
+.pattern-table .none { color: var(--meta); }
 .ph { color: var(--dim); font-style: italic; }
 @media (max-width: 480px) { .glyph-grid { grid-template-columns: 1fr; } }
 </style>
@@ -469,23 +474,49 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
       <div class="notation-group">
         <h4>Common script patterns</h4>
-        <p class="notation-note">A payment's kind is legible in its sequence of marks — learn these and you can read a script's purpose at sight.</p>
-        <div class="pattern-list">
-          <span class="pname">P2PK</span><span class="seq"><span class="op op-push">₆₅</span><span class="ph">𝒫</span> <span class="op">∇</span></span>
-          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span> <span class="op">≡</span> <span class="op">∇</span></span>
-          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span> <span class="op">=</span></span>
-          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span></span>
-          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">₃₂</span><span class="ph">ℋ</span></span>
-          <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="op op-push">₃₂</span><span class="ph">𝒫</span></span>
-          <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op">③</span> <span class="op">◇</span></span>
-          <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="op op-push">ₙ</span><span class="ph">…</span></span>
-          <span class="pname">P2PKH spend</span><span class="seq"><span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span></span>
-          <span class="pname">P2SH spend</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">ₙ</span><span class="ph">ℛ</span></span>
-          <span class="pname">P2WPKH wit.</span><span class="seq"><span class="ph">𝒮</span> · <span class="ph">𝒫</span></span>
-          <span class="pname">P2WSH wit.</span><span class="seq">∅ · <span class="ph">𝒮</span> · <span class="ph">𝒮</span> · <span class="ph">𝒲</span></span>
-          <span class="pname">P2TR script</span><span class="seq"><span class="ph">𝒮</span> · <span class="ph">𝒯</span> · <span class="ph">…</span></span>
+        <p class="notation-note">A payment's kind is legible in its marks — one row per type, split across where its pieces live on the wire. The output column is the lock; the input and witness columns are the spend that opens it.</p>
+        <div class="pattern-scroll">
+        <div class="pattern-table">
+          <span class="phead"></span><span class="phead">Input</span><span class="phead">Output</span><span class="phead">Witness</span>
+          <span class="pname">P2PK</span>
+            <span class="seq"><span class="op op-push">₇₁</span><span class="ph">𝒮</span></span>
+            <span class="seq"><span class="op op-push">₆₅</span><span class="ph">𝒫</span> <span class="op">∇</span></span>
+            <span class="seq none">—</span>
+          <span class="pname">P2PKH</span>
+            <span class="seq"><span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span></span>
+            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span> <span class="op">≡</span> <span class="op">∇</span></span>
+            <span class="seq none">—</span>
+          <span class="pname">Multisig</span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span></span>
+            <span class="seq"><span class="op">②</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op op-push">₃₃</span><span class="ph">𝒫</span> <span class="op">③</span> <span class="op">◇</span></span>
+            <span class="seq none">—</span>
+          <span class="pname">P2SH</span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">₇₁</span><span class="ph">𝒮</span> <span class="op op-push">ₙ</span><span class="ph">ℛ</span></span>
+            <span class="seq"><span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span> <span class="op">=</span></span>
+            <span class="seq none">—</span>
+          <span class="pname">P2WPKH</span>
+            <span class="seq none">∅</span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">₂₀</span><span class="ph">ℋ</span></span>
+            <span class="seq"><span class="ph">𝒮</span> · <span class="ph">𝒫</span></span>
+          <span class="pname">P2WSH</span>
+            <span class="seq none">∅</span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">₃₂</span><span class="ph">ℋ</span></span>
+            <span class="seq">∅ · <span class="ph">𝒮</span> · <span class="ph">𝒮</span> · <span class="ph">𝒲</span></span>
+          <span class="pname">P2TR key</span>
+            <span class="seq none">∅</span>
+            <span class="seq"><span class="op">①</span> <span class="op op-push">₃₂</span><span class="ph">𝒫</span></span>
+            <span class="seq"><span class="ph">𝒮</span></span>
+          <span class="pname">P2TR script</span>
+            <span class="seq none">∅</span>
+            <span class="seq"><span class="op">①</span> <span class="op op-push">₃₂</span><span class="ph">𝒫</span></span>
+            <span class="seq"><span class="ph">𝒮</span> · <span class="ph">𝒯</span> · <span class="ph">…</span></span>
+          <span class="pname">Data</span>
+            <span class="seq none">—</span>
+            <span class="seq"><span class="op">¶</span> <span class="op op-push">ₙ</span><span class="ph">…</span></span>
+            <span class="seq none">—</span>
         </div>
-        <p class="notation-note">The push subscripts are the patterns' fingerprints: P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length — ₂₀ a HASH160 of a key, ₃₂ a SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. A script hidden behind a hash — ℛ, 𝒲, 𝒯 — is revealed in the same notation when spent: an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">ℋ</span> <span class="op" style="font-style:normal">≡</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">│</span> <span class="ph">n</span> <span class="op" style="font-style:normal">τ ⌄</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">⟩ ∇</span>. Witness rows read stack items left to right; ∅ is the multisig dummy.</p>
+        </div>
+        <p class="notation-note">Read the proof's migration down the table: legacy types carry it in the input, segwit types leave the input empty (∅) and move it to the witness. The push subscripts are the patterns' fingerprints — P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length, ₂₀ a HASH160 of a key, ₃₂ a SHA-256 of a script. A script hidden behind a hash — ℛ, 𝒲, 𝒯 — is revealed in the same notation when spent: an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">ℋ</span> <span class="op" style="font-style:normal">≡</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">│</span> <span class="ph">n</span> <span class="op" style="font-style:normal">τ ⌄</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">⟩ ∇</span>. In witness cells, · separates stack items and ∅ is the multisig dummy; the Data output is provably unspendable, so it has no spend at all.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -321,10 +321,10 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <div class="notation-group">
         <h4>Pushes</h4>
         <div class="glyph-grid">
-          <div class="glyph-row"><span class="g">↧<i>n</i></span><span class="m"><b>push</b> the next n bytes</span></div>
-          <div class="glyph-row"><span class="g">↡<i>n</i> ⇊<i>n</i> ⤋<i>n</i></span><span class="m">extended push — length in a 1 / 2 / 4-byte prefix</span></div>
+          <div class="glyph-row"><span class="g">₂₀</span><span class="m"><b>push</b> — the bare subscript is the byte count (₂₀ pushes twenty)</span></div>
+          <div class="glyph-row"><span class="g">↧<i>n</i> ⇊<i>n</i> ⤋<i>n</i></span><span class="m">extended push — length in a 1 / 2 / 4-byte prefix</span></div>
         </div>
-        <p class="notation-note">The pushed bytes follow the mark, as prose or an inline quote. The coinbase preamble's β<i>n</i> and ⊕<i>n</i> fold their push in — the mark alone determines the exact bytes.</p>
+        <p class="notation-note">The pushed bytes follow the mark, as prose or an inline quote; arrow weight matches prefix width. The coinbase preamble's β<i>n</i> and ⊕<i>n</i> fold their push in — the mark alone determines the exact bytes.</p>
       </div>
 
       <div class="notation-group">
@@ -376,6 +376,17 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">⊕<i>n</i></span><span class="m"><b>extranonce</b> — search space beyond the header's nonce</span></div>
         </div>
         <p class="notation-note">β's subscript counts the target's leading zero hex digits beyond the eight genesis opens with, so β₀ is difficulty 1 and the subscript climbs as difficulty rises. Digits after β are the target's remaining significant digits; a bare β<i>n</i> stands for the baseline ffff. The chain's earliest coinbases open with this preamble — the miner's restatement of the header's target, then the counter it rolled once the header's 32-bit nonce ran out — decoded to marks so any embedded words (the genesis headline) lead the text.</p>
+      </div>
+
+      <div class="notation-group">
+        <h4>Chapter head — the block header</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">v<i>n</i></span><span class="m">block <b>version</b></span></div>
+          <div class="glyph-row"><span class="g">∅</span><span class="m">no previous block — the genesis chapter</span></div>
+          <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b>, as in the preamble</span></div>
+          <div class="glyph-row"><span class="g">ν<i>n</i></span><span class="m">the <b>nonce</b> the miner landed on</span></div>
+        </div>
+        <p class="notation-note">The chapter head runs the header's fields in wire order: version, the previous chapter's hash as prose (∅ for genesis), the merkle root as prose, the timestamp, β, ν. The header's ν and the coinbase's ⊕ together are the miner's full search space.</p>
       </div>
 
       <div class="notation-group">
@@ -447,16 +458,16 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Common script patterns</h4>
         <p class="notation-note">A payment's kind is legible in its sequence of marks — learn these and you can read a script's purpose at sight. <span class="ph">…</span> stands for pushed data (a key, a hash, a signature), rendered as prose.</p>
         <div class="pattern-list">
-          <span class="pname">P2PK</span><span class="seq"><span class="op op-push">↧</span><span class="ph">…</span> <span class="op">∇</span></span>
-          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">↧</span><span class="ph">…</span> <span class="op">≡</span> <span class="op">∇</span></span>
-          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="op op-push">↧</span><span class="ph">…</span> <span class="op">=</span></span>
-          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">↧</span><span class="ph">…</span></span>
-          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">↧</span><span class="ph">…</span></span>
-          <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="op op-push">↧</span><span class="ph">…</span></span>
-          <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="op op-push">↧</span><span class="ph">…</span> <span class="op op-push">↧</span><span class="ph">…</span> <span class="op op-push">↧</span><span class="ph">…</span> <span class="op">③</span> <span class="op">◇</span></span>
-          <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="op op-push">↧</span><span class="ph">…</span></span>
+          <span class="pname">P2PK</span><span class="seq"><span class="op op-push">₆₅</span><span class="ph">…</span> <span class="op">∇</span></span>
+          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">…</span> <span class="op">≡</span> <span class="op">∇</span></span>
+          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="op op-push">₂₀</span><span class="ph">…</span> <span class="op">=</span></span>
+          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">₂₀</span><span class="ph">…</span></span>
+          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">₃₂</span><span class="ph">…</span></span>
+          <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="op op-push">₃₂</span><span class="ph">…</span></span>
+          <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="op op-push">₃₃</span><span class="ph">…</span> <span class="op op-push">₃₃</span><span class="ph">…</span> <span class="op op-push">₃₃</span><span class="ph">…</span> <span class="op">③</span> <span class="op">◇</span></span>
+          <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="op op-push">ₙ</span><span class="ph">…</span></span>
         </div>
-        <p class="notation-note">P2WPKH and P2WSH share the mark <span class="op" style="font-style:normal">⓪</span> — a witness-v0 program — and differ only in the hashed length: a 20-byte HASH160 of a key, or a 32-byte SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. The scripts hidden inside P2SH / P2WSH — an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">…</span> <span class="op" style="font-style:normal">≡ … │ …</span> <span class="op" style="font-style:normal">τ ⌄ … ⟩</span> — are revealed in the same notation when spent.</p>
+        <p class="notation-note">The push subscripts are the patterns' fingerprints: P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length — ₂₀ a HASH160 of a key, ₃₂ a SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. The scripts hidden inside P2SH / P2WSH — an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">…</span> <span class="op" style="font-style:normal">≡ … │ …</span> <span class="op" style="font-style:normal">τ ⌄ … ⟩</span> — are revealed in the same notation when spent.</p>
       </div>
 
       <div class="notation-group">
@@ -487,7 +498,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <details class="about">
     <summary>About</summary>
     <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above.</p>
-    <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and witness items' length prefixes — is dropped, since it is reconstructable from structure; a script's push opcodes render as ↧ marks, their subscript the byte count. And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
+    <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and witness items' length prefixes — is dropped, since it is reconstructable from structure; a script's push opcodes render as subscript byte counts (with ↧/⇊/⤋ arrows when the length rides in a 1/2/4-byte prefix). And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
     <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to β and ⊕ marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
     <p class="hint muted">Every Glossia-encoded hash — a block hash, a transaction id, the previous-block hash and merkle root above — hovers (or, on touch, taps) into a small selectable panel carrying the exact hex it encodes, and clicking it copies that hex to the clipboard.</p>
     <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
@@ -731,7 +742,7 @@ function renderFrontispiece(header) {
     { text: merkleProse, copy: { hex: header.merkleRoot, label: 'merkle root' } },
     { text: hf.timestamp, title: hf.timestampTitle },
     { text: hf.bits, title: hf.bitsTitle },
-    { text: hf.nonce, title: 'nonce — the value the miner incremented while searching for a hash below the difficulty target' },
+    { text: `ν${hf.nonce}`, title: `nonce ${hf.nonce} — the value the miner incremented while searching for a hash below the difficulty target` },
   ];
   for (const { text, title, copy } of items) {
     const span = document.createElement('span');
@@ -803,11 +814,17 @@ function renderChapter(para) {
   let leadUsed = false;
   const pendingCites = [];
 
-  // A body line; the first one across the whole transaction claims the drop cap.
+  // A body line; the first one across the whole transaction claims the drop
+  // cap -- unless it opens with a bare push count (₆₉ …), whose subscript's
+  // first digit would be blown up into a giant numeral, tearing the mark
+  // apart. In that case the cap is forfeited for the transaction, not
+  // deferred to a later line (an illuminated initial belongs at the top).
   const addLine = (container, html) => {
     if (!html) return null;
     const p = document.createElement('p');
-    p.className = 'tx-line' + (!leadUsed ? (leadUsed = true, ' tx-body-lead') : '');
+    const lead = !leadUsed && !html.startsWith('<span class="op op-push"');
+    leadUsed = true;
+    p.className = 'tx-line' + (lead ? ' tx-body-lead' : '');
     p.innerHTML = html;
     container.append(p);
     return p;

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -527,7 +527,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">○</span><span class="m">respects the locktime</span></div>
           <div class="glyph-row"><span class="g">†</span><span class="m"><b>replaceable</b> (opt-in RBF)</span></div>
           <div class="glyph-row"><span class="g">■<i>N</i></span><span class="m">relative: N blocks after confirmation (Roman — a count of chapters)</span></div>
-          <div class="glyph-row"><span class="g">⊥<i>n</i></span><span class="m">relative: n × 512 s after confirmation</span></div>
+          <div class="glyph-row"><span class="g">⊥<i>Δt</i></span><span class="m">relative: a duration after confirmation (d h m s)</span></div>
           <div class="glyph-row"><span class="g">(<i>n</i>)</span><span class="m">the <b>amount spent</b> by this input — value flowing in; an output's amount stands bare</span></div>
         </div>
       </div>
@@ -537,11 +537,11 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">□</span><span class="m">no locktime</span></div>
           <div class="glyph-row"><span class="g">■ <i>v b c</i></span><span class="m">not before the cited chapter (volume book chapter)</span></div>
-          <div class="glyph-row"><span class="g">⊥<i>n</i></span><span class="m">not before time n</span></div>
+          <div class="glyph-row"><span class="g">⊥<i>t</i></span><span class="m">not before a UTC date</span></div>
           <div class="glyph-row"><span class="g">∅</span><span class="m"><b>empty</b> — a coinbase's absent prevout, a segwit input's zero-byte script, an empty witness item</span></div>
           <div class="glyph-row"><span class="g">§<i>n</i></span><span class="m">verse — the transaction's position</span></div>
         </div>
-        <p class="notation-note">■ and ⊥ mean block-height and time in both places; a square reads as the whole transaction, a circle as one input. An absolute height is a place in the book, so it is cited; a relative delay is a count of chapters, so it is a Roman numeral.</p>
+        <p class="notation-note">■ and ⊥ mean block-height and time in both places; a square reads as the whole transaction, a circle as one input. An absolute height is a place in the book, so it is cited; a relative block delay is a count of chapters, so it is a Roman numeral. Time renders physically: an absolute lock as its UTC date, a relative one as a duration.</p>
       </div>
     </div>
   </details>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -184,7 +184,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .tx-locktime { grid-column: right; grid-row: 3; text-align: right; font-style: normal; }
 .tx-note { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--dim); }
 /* The input's sequence mark, shown in the margin just after the reference:
-   ●/○ final/respects-locktime, † replaceable (a shade warmer), ■n / ⊥n a
+   ●/○ final/respects-locktime, † replaceable (a shade warmer), ■n / Τn a
    relative block / time delay. */
 .tx-seq { font-style: normal; color: var(--meta); }
 .tx-seq-rbf { color: var(--accent-2); }
@@ -527,7 +527,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">○</span><span class="m">respects the locktime</span></div>
           <div class="glyph-row"><span class="g">†</span><span class="m"><b>replaceable</b> (opt-in RBF)</span></div>
           <div class="glyph-row"><span class="g">■<i>N</i></span><span class="m">relative: N blocks after confirmation (Roman — a count of chapters)</span></div>
-          <div class="glyph-row"><span class="g">⊥<i>Δt</i></span><span class="m">relative: a duration after confirmation (d h m s)</span></div>
+          <div class="glyph-row"><span class="g">Τ<i>Δt</i></span><span class="m">relative: a duration after confirmation (d h m s)</span></div>
           <div class="glyph-row"><span class="g">(<i>n</i>)</span><span class="m">the <b>amount spent</b> by this input — value flowing in; an output's amount stands bare</span></div>
         </div>
       </div>
@@ -537,11 +537,11 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">□</span><span class="m">no locktime</span></div>
           <div class="glyph-row"><span class="g">■ <i>v b c</i></span><span class="m">not before the cited chapter (volume book chapter)</span></div>
-          <div class="glyph-row"><span class="g">⊥<i>t</i></span><span class="m">not before a UTC date</span></div>
+          <div class="glyph-row"><span class="g">Τ<i>t</i></span><span class="m">not before a UTC date</span></div>
           <div class="glyph-row"><span class="g">∅</span><span class="m"><b>empty</b> — a coinbase's absent prevout, a segwit input's zero-byte script, an empty witness item</span></div>
           <div class="glyph-row"><span class="g">§<i>n</i></span><span class="m">verse — the transaction's position</span></div>
         </div>
-        <p class="notation-note">■ and ⊥ mean block-height and time in both places; a square reads as the whole transaction, a circle as one input. An absolute height is a place in the book, so it is cited; a relative block delay is a count of chapters, so it is a Roman numeral. Time renders physically: an absolute lock as its UTC date, a relative one as a duration.</p>
+        <p class="notation-note">■ marks block-height and Τ marks time, in both places; a square reads as the whole transaction, a circle as one input. An absolute height is a place in the book, so it is cited; a relative block delay is a count of chapters, so it is a Roman numeral. Time renders physically: an absolute lock as its UTC date, a relative one as a duration.</p>
       </div>
     </div>
   </details>
@@ -894,7 +894,7 @@ function renderChapter(para) {
     container.append(q);
   };
   // The input's sequence mark, shown in the margin just after its reference:
-  // ● final · ○ respects locktime · † replaceable · † ■n / † ⊥n replaceable with
+  // ● final · ○ respects locktime · † replaceable · † ■n / † Τn replaceable with
   // a relative block / time delay. The † is kept a shade warmer than the delay
   // it precedes, so it reads as its own mark.
   const seqSpan = (inp) => {

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -528,6 +528,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">†</span><span class="m"><b>replaceable</b> (opt-in RBF)</span></div>
           <div class="glyph-row"><span class="g">■<i>n</i></span><span class="m">relative: n blocks after confirmation</span></div>
           <div class="glyph-row"><span class="g">⊥<i>n</i></span><span class="m">relative: n × 512 s after confirmation</span></div>
+          <div class="glyph-row"><span class="g">(<i>n</i>)</span><span class="m">the <b>amount spent</b> by this input — value flowing in; an output's amount stands bare</span></div>
         </div>
       </div>
 
@@ -679,8 +680,12 @@ async function resolveCitations(pending, gen) {
       cite.classList.remove('resolving');
       cite.title = `${txid}:${vout}`;
       // The amount of the referenced output -- what this input spends -- sits
-      // under the reference.
-      if (amtEl && outputs && outputs[vout]) amtEl.textContent = groupDigits(String(outputs[vout].value));
+      // under the reference, in parentheses: the mark for value flowing IN,
+      // where an output's amount (value flowing out) stands bare.
+      if (amtEl && outputs && outputs[vout]) {
+        amtEl.textContent = `(${groupDigits(String(outputs[vout].value))})`;
+        amtEl.title = 'the amount this input spends, in satoshis';
+      }
     } catch (e) {
       if (gen !== renderGen) return;
       citeBody.textContent = `${txid.slice(0, 8)}… .${vout}`;

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -203,7 +203,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    operational opcodes -- it frames the data that follows rather than acting
    on the stack, so it shouldn't compete with the prose it introduces. */
 .op-push { color: var(--meta); }
-/* A data type mark (𝒫 𝒮 ℋ ℛ 𝒲 𝒯): names what the prose after it carries.
+/* A data type mark (𝓅 𝓈 𝒽 𝓇 𝓌 𝓉): names what the prose after it carries.
    Dim like the push count it rides with -- annotation, not instruction. */
 .dt { color: var(--dim); font-style: normal; }
 /* A witness footnote is a stack of items; a thin middot separates each, and an
@@ -463,14 +463,14 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <div class="notation-group">
         <h4>Data</h4>
         <div class="glyph-grid">
-          <div class="glyph-row"><span class="g">𝒫</span><span class="m"><b>public key</b></span></div>
-          <div class="glyph-row"><span class="g">𝒮</span><span class="m"><b>signature</b></span></div>
-          <div class="glyph-row"><span class="g">ℋ</span><span class="m"><b>hash</b></span></div>
-          <div class="glyph-row"><span class="g">ℛ</span><span class="m"><b>redeem script</b> (inside P2SH)</span></div>
-          <div class="glyph-row"><span class="g">𝒲</span><span class="m"><b>witness script</b> (inside P2WSH)</span></div>
-          <div class="glyph-row"><span class="g">𝒯</span><span class="m"><b>tapscript</b> (a Taproot leaf)</span></div>
+          <div class="glyph-row"><span class="g">𝓅</span><span class="m"><b>public key</b></span></div>
+          <div class="glyph-row"><span class="g">𝓈</span><span class="m"><b>signature</b></span></div>
+          <div class="glyph-row"><span class="g">𝒽</span><span class="m"><b>hash</b></span></div>
+          <div class="glyph-row"><span class="g">𝓇</span><span class="m"><b>redeem script</b> (inside P2SH)</span></div>
+          <div class="glyph-row"><span class="g">𝓌</span><span class="m"><b>witness script</b> (inside P2WSH)</span></div>
+          <div class="glyph-row"><span class="g">𝓉</span><span class="m"><b>tapscript</b> (a Taproot leaf)</span></div>
         </div>
-        <p class="notation-note">Type marks naming what a push carries. On the page they sit between the push count and the prose (⁶⁵𝒫 …), wherever the kind is recognizable from the bytes and their context; a push that could be anything stays unmarked.</p>
+        <p class="notation-note">Type marks naming what a push carries. On the page they sit between the push count and the prose (⁶⁵𝓅 …), wherever the kind is recognizable from the bytes and their context; a push that could be anything stays unmarked.</p>
       </div>
 
       <div class="notation-group">
@@ -480,44 +480,44 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <div class="pattern-table">
           <span class="phead"></span><span class="phead">Input</span><span class="phead">Output</span><span class="phead">Witness</span>
           <span class="pname">P2PK</span>
-            <span class="seq"><span class="op op-push">⁷¹</span><span class="ph">𝒮</span></span>
-            <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">𝒫</span> <span class="op">∇</span></span>
+            <span class="seq"><span class="op op-push">⁷¹</span><span class="ph">𝓈</span></span>
+            <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">𝓅</span> <span class="op">∇</span></span>
             <span class="seq none">—</span>
           <span class="pname">P2PKH</span>
-            <span class="seq"><span class="op op-push">⁷¹</span><span class="ph">𝒮</span> <span class="op op-push">³³</span><span class="ph">𝒫</span></span>
-            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">ℋ</span> <span class="op">≡</span> <span class="op">∇</span></span>
+            <span class="seq"><span class="op op-push">⁷¹</span><span class="ph">𝓈</span> <span class="op op-push">³³</span><span class="ph">𝓅</span></span>
+            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
             <span class="seq none">—</span>
           <span class="pname">Multisig</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">⁷¹</span><span class="ph">𝒮</span> <span class="op op-push">⁷¹</span><span class="ph">𝒮</span></span>
-            <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝒫</span> <span class="op op-push">³³</span><span class="ph">𝒫</span> <span class="op op-push">³³</span><span class="ph">𝒫</span> <span class="op">③</span> <span class="op">◇</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">⁷¹</span><span class="ph">𝓈</span> <span class="op op-push">⁷¹</span><span class="ph">𝓈</span></span>
+            <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
             <span class="seq none">—</span>
           <span class="pname">P2SH</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">⁷¹</span><span class="ph">𝒮</span> <span class="op op-push">⁷¹</span><span class="ph">𝒮</span> <span class="op op-push">ⁿ</span><span class="ph">ℛ</span></span>
-            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">ℋ</span> <span class="op">=</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">⁷¹</span><span class="ph">𝓈</span> <span class="op op-push">⁷¹</span><span class="ph">𝓈</span> <span class="op op-push">ⁿ</span><span class="ph">𝓇</span></span>
+            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
             <span class="seq none">—</span>
           <span class="pname">P2WPKH</span>
             <span class="seq none">∅</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">ℋ</span></span>
-            <span class="seq"><span class="ph">𝒮</span> · <span class="ph">𝒫</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span></span>
+            <span class="seq"><span class="ph">𝓈</span> · <span class="ph">𝓅</span></span>
           <span class="pname">P2WSH</span>
             <span class="seq none">∅</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">ℋ</span></span>
-            <span class="seq">∅ · <span class="ph">𝒮</span> · <span class="ph">𝒮</span> · <span class="ph">𝒲</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
+            <span class="seq">∅ · <span class="ph">𝓈</span> · <span class="ph">𝓈</span> · <span class="ph">𝓌</span></span>
           <span class="pname">P2TR key</span>
             <span class="seq none">∅</span>
-            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝒫</span></span>
-            <span class="seq"><span class="ph">𝒮</span></span>
+            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
+            <span class="seq"><span class="ph">𝓈</span></span>
           <span class="pname">P2TR script</span>
             <span class="seq none">∅</span>
-            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝒫</span></span>
-            <span class="seq"><span class="ph">𝒮</span> · <span class="ph">𝒯</span> · <span class="ph">…</span></span>
+            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
+            <span class="seq"><span class="ph">𝓈</span> · <span class="ph">𝓉</span> · <span class="ph">…</span></span>
           <span class="pname">Data</span>
             <span class="seq none">—</span>
             <span class="seq"><span class="op">¶</span> <span class="op op-push">ⁿ</span><span class="ph">…</span></span>
             <span class="seq none">—</span>
         </div>
         </div>
-        <p class="notation-note">Read the proof's migration down the table: legacy types carry it in the input, segwit types leave the input empty (∅) and move it to the witness. The push superscripts are the patterns' fingerprints — P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length, ²⁰ a HASH160 of a key, ³² a SHA-256 of a script. A script hidden behind a hash — ℛ, 𝒲, 𝒯 — is revealed in the same notation when spent: an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">ℋ</span> <span class="op" style="font-style:normal">≡</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">│</span> <span class="ph">n</span> <span class="op" style="font-style:normal">τ ⌄</span> <span class="ph">𝒫</span> <span class="op" style="font-style:normal">⟩ ∇</span>. In witness cells, · separates stack items and ∅ is an empty item (the multisig dummy) — a witness is a stack, not a script, so ⓪ the opcode never appears there; in the P2SH spend's input, which IS script, the dummy is the real ⓪ byte. The Data output is provably unspendable, so it has no spend at all.</p>
+        <p class="notation-note">Read the proof's migration down the table: legacy types carry it in the input, segwit types leave the input empty (∅) and move it to the witness. The push superscripts are the patterns' fingerprints — P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length, ²⁰ a HASH160 of a key, ³² a SHA-256 of a script. A script hidden behind a hash — 𝓇, 𝓌, 𝓉 — is revealed in the same notation when spent: an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">𝒽</span> <span class="op" style="font-style:normal">≡</span> <span class="ph">𝓅</span> <span class="op" style="font-style:normal">│</span> <span class="ph">n</span> <span class="op" style="font-style:normal">τ ⌄</span> <span class="ph">𝓅</span> <span class="op" style="font-style:normal">⟩ ∇</span>. In witness cells, · separates stack items and ∅ is an empty item (the multisig dummy) — a witness is a stack, not a script, so ⓪ the opcode never appears there; in the P2SH spend's input, which IS script, the dummy is the real ⓪ byte. The Data output is provably unspendable, so it has no spend at all.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -115,6 +115,26 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .chapter-frontispiece { margin: 0 auto 4px; max-width: 46ch; font: 500 11.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
 .chapter-frontispiece .cfx + .cfx::before { content: ' · '; }
 
+/* A copyable hover tooltip for a Glossia-encoded hash (a block hash, a
+   txid, a merkle root): the prose is the visible text; hovering it reveals
+   the exact hex it encodes in a small selectable panel -- unlike a native
+   `title` tooltip, which can't be selected and vanishes before a pointer
+   can reach it -- and clicking anywhere on it copies that hex to the
+   clipboard, since a hex string this long is impractical to select by hand
+   on a touch device. */
+.hash-copy { position: relative; cursor: pointer; }
+.hash-tip {
+  display: none; position: absolute; left: 50%; top: 100%; transform: translateX(-50%);
+  width: max-content; max-width: min(90vw, 30em); margin-top: 0; padding: 7px 11px 6px;
+  background: var(--card); border: 1px solid var(--card-bd); border-radius: 5px;
+  font: 400 11.5px/1.4 'IBM Plex Mono', monospace; font-style: normal; letter-spacing: 0;
+  color: var(--ink-soft); word-break: break-all; user-select: all; z-index: 5;
+  box-shadow: 0 14px 34px -18px rgba(0,0,0,.75);
+}
+.hash-copy:hover .hash-tip, .hash-copy:focus-visible .hash-tip { display: block; }
+.hash-tip::after { content: ' — click to copy'; color: var(--meta); }
+.hash-tip.copied::after { content: ' — copied'; color: var(--ok); }
+
 /* Per-verse navigation: Previous / Next flanking the verse title -- the
    transaction's position within its block, rendered as "Verse N". */
 .verse-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin: 22px 0 0; }
@@ -390,6 +410,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
     <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above.</p>
     <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and push/item length prefixes — is dropped, since it is reconstructable from structure. And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
     <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover.</p>
+    <p class="hint muted">Every Glossia-encoded hash — a block hash, a transaction id, the previous-block hash and merkle root above — hovers (or, on touch, taps) into a small selectable panel carrying the exact hex it encodes, and clicking it copies that hex to the clipboard.</p>
     <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>
   </details>
 </div>
@@ -591,6 +612,26 @@ async function showCurrentTx() {
   setStatus('');
 }
 
+// Attach a copyable hover tooltip to an element already showing a
+// Glossia-encoded hash as prose: `hex` is the exact raw value that prose
+// encodes. Hovering (or focusing, via keyboard) reveals it in a selectable
+// panel; clicking anywhere on the element copies it to the clipboard.
+function attachHashCopy(el, hex, label) {
+  el.classList.add('hash-copy');
+  el.tabIndex = 0;
+  el.setAttribute('aria-label', `${label}: ${hex} — click to copy`);
+  const tip = document.createElement('span');
+  tip.className = 'hash-tip mono';
+  tip.textContent = hex;
+  el.append(tip);
+  el.addEventListener('click', () => {
+    navigator.clipboard.writeText(hex).then(() => {
+      tip.classList.add('copied');
+      setTimeout(() => tip.classList.remove('copied'), 1400);
+    }).catch(() => {});
+  });
+}
+
 // The block header itself, in wire order, as a small mono line under the
 // chapter hash: version, previous-block hash, merkle root, timestamp,
 // difficulty target, nonce. The two hashes are Glossia-encoded here (like
@@ -607,17 +648,18 @@ function renderFrontispiece(header) {
   const merkleProse = encodeSeedPhrase(reverseHex(header.merkleRoot), 'english', BEST_OF).prose;
   const items = [
     { text: `v${hf.version}`, title: 'block version' },
-    { text: prevProse, title: isGenesisPrev ? 'no earlier block — this is the genesis block' : `previous block: ${header.prevBlockHash}` },
-    { text: merkleProse, title: `merkle root of this block's transactions: ${header.merkleRoot}` },
+    { text: prevProse, title: isGenesisPrev ? 'no earlier block — this is the genesis block' : null, copy: isGenesisPrev ? null : { hex: header.prevBlockHash, label: 'previous block hash' } },
+    { text: merkleProse, copy: { hex: header.merkleRoot, label: 'merkle root' } },
     { text: hf.timestamp, title: hf.timestampTitle },
     { text: hf.bits, title: hf.bitsTitle },
     { text: hf.nonce, title: 'nonce — the value the miner incremented while searching for a hash below the difficulty target' },
   ];
-  for (const { text, title } of items) {
+  for (const { text, title, copy } of items) {
     const span = document.createElement('span');
     span.className = 'cfx';
     span.textContent = text;
-    span.title = title;
+    if (copy) attachHashCopy(span, copy.hex, copy.label);
+    else if (title) span.title = title;
     el.append(span);
   }
 }
@@ -644,7 +686,7 @@ function renderChapter(para) {
   $('ch-hash-short').classList.toggle('hidden', !onFirstTx);
   const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(state.hash)), 'english', BEST_OF);
   $('ch-hash-short').textContent = hashProse;
-  $('ch-hash-short').title = state.hash;
+  attachHashCopy($('ch-hash-short'), state.hash, 'block hash');
   $('ch-frontispiece').classList.toggle('hidden', !onFirstTx);
   if (onFirstTx) renderFrontispiece(state.header);
 
@@ -653,7 +695,7 @@ function renderChapter(para) {
   // actual bytes; every byte kept, since a txid has no droppable leading zeros.
   const { prose: txidProse } = encodeSeedPhrase(reverseHex(para.txid), 'english', BEST_OF);
   $('verse-hash').textContent = txidProse;
-  $('verse-hash').title = para.txid;
+  attachHashCopy($('verse-hash'), para.txid, 'transaction id');
 
   const body = $('ch-paragraphs');
   body.innerHTML = '';

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -203,6 +203,9 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    operational opcodes -- it frames the data that follows rather than acting
    on the stack, so it shouldn't compete with the prose it introduces. */
 .op-push { color: var(--meta); }
+/* A data type mark (𝒫 𝒮 ℋ ℛ 𝒲 𝒯): names what the prose after it carries.
+   Dim like the push count it rides with -- annotation, not instruction. */
+.dt { color: var(--dim); font-style: normal; }
 /* A witness footnote is a stack of items; a thin middot separates each, and an
    empty stack item shows as ∅. */
 .wit-sep, .wit-empty { color: var(--meta); font-style: normal; }
@@ -469,7 +472,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">𝒲</span><span class="m"><b>witness script</b> (inside P2WSH)</span></div>
           <div class="glyph-row"><span class="g">𝒯</span><span class="m"><b>tapscript</b> (a Taproot leaf)</span></div>
         </div>
-        <p class="notation-note">Type marks naming what a push carries, used in the pattern key below. On the page itself the bytes read as prose — the type is legible from the marks around them.</p>
+        <p class="notation-note">Type marks naming what a push carries. On the page they sit between the push count and the prose (⁶⁵𝒫 …), wherever the kind is recognizable from the bytes and their context; a push that could be anything stays unmarked.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -377,10 +377,10 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <div class="notation-group">
         <h4>Coinbase — the mining preamble</h4>
         <div class="glyph-grid">
-          <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b> — a hash opening with 8+n zero digits</span></div>
+          <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b> — a valid hash opens with n zero bits</span></div>
           <div class="glyph-row"><span class="g">η<i>n</i></span><span class="m"><b>extranonce</b> — search space beyond the header's η</span></div>
         </div>
-        <p class="notation-note">β's subscript counts the target's leading zero hex digits beyond the eight genesis opens with, so β₀ is difficulty 1 and the subscript climbs as difficulty rises. Hex digits after a middot (β₃·4864c) are the target's remaining significant digits; a bare β<i>n</i> stands for the baseline ffff. The chain's earliest coinbases open with this preamble — the miner's restatement of the header's target, then the counter it rolled once the header's 32-bit nonce ran out — decoded to marks so any embedded words (the genesis headline) lead the text.</p>
+        <p class="notation-note">β's subscript is the target's demand in leading zero bits — β₃₂ at genesis (difficulty 1), climbing as difficulty rises; each +1 doubles the work. Hex digits after a middot (β₄₅·4864c) are the target's remaining significant digits; a bare β<i>n</i> stands for the baseline ffff. The chain's earliest coinbases open with this preamble — the miner's restatement of the header's target, then the counter it rolled once the header's 32-bit nonce ran out — decoded to marks so any embedded words (the genesis headline) lead the text.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -526,7 +526,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">●</span><span class="m"><b>final</b></span></div>
           <div class="glyph-row"><span class="g">○</span><span class="m">respects the locktime</span></div>
           <div class="glyph-row"><span class="g">†</span><span class="m"><b>replaceable</b> (opt-in RBF)</span></div>
-          <div class="glyph-row"><span class="g">■<i>n</i></span><span class="m">relative: n blocks after confirmation</span></div>
+          <div class="glyph-row"><span class="g">■<i>N</i></span><span class="m">relative: N blocks after confirmation (Roman — a count of chapters)</span></div>
           <div class="glyph-row"><span class="g">⊥<i>n</i></span><span class="m">relative: n × 512 s after confirmation</span></div>
           <div class="glyph-row"><span class="g">(<i>n</i>)</span><span class="m">the <b>amount spent</b> by this input — value flowing in; an output's amount stands bare</span></div>
         </div>
@@ -536,12 +536,12 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Margin — the transaction's locktime &amp; other marks</h4>
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">□</span><span class="m">no locktime</span></div>
-          <div class="glyph-row"><span class="g">■<i>n</i></span><span class="m">not before block n</span></div>
+          <div class="glyph-row"><span class="g">■ <i>v b c</i></span><span class="m">not before the cited chapter (volume book chapter)</span></div>
           <div class="glyph-row"><span class="g">⊥<i>n</i></span><span class="m">not before time n</span></div>
           <div class="glyph-row"><span class="g">∅</span><span class="m"><b>empty</b> — a coinbase's absent prevout, a segwit input's zero-byte script, an empty witness item</span></div>
           <div class="glyph-row"><span class="g">§<i>n</i></span><span class="m">verse — the transaction's position</span></div>
         </div>
-        <p class="notation-note">■ and ⊥ mean block-height and time in both places; a square reads as the whole transaction, a circle as one input.</p>
+        <p class="notation-note">■ and ⊥ mean block-height and time in both places; a square reads as the whole transaction, a circle as one input. An absolute height is a place in the book, so it is cited; a relative delay is a count of chapters, so it is a Roman numeral.</p>
       </div>
     </div>
   </details>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -195,10 +195,14 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    we haven't given a glyph falls back to Bitcoin Core's OP_* name in small mono. */
 .op { color: var(--accent); font-style: normal; }
 .op-name { font: 600 .62em/1 'IBM Plex Mono',monospace; letter-spacing:.04em; color: var(--dim); font-style: normal; vertical-align: .14em; white-space: nowrap; }
-/* A decoded value riding a mark (the coinbase preamble's ◎target and
+/* A decoded value riding a mark (the coinbase preamble's βtarget and
    ⊕extranonce): mono like an OP_ name, but a size up -- it's a number to
    read, not a fallback label. */
 .op-num { font: 500 .72em/1 'IBM Plex Mono',monospace; color: var(--dim); font-style: normal; vertical-align: .1em; white-space: nowrap; margin-left: .08em; }
+/* A push opcode's mark (↧ₙ and the OP_PUSHDATA variants): quieter than the
+   operational opcodes -- it frames the data that follows rather than acting
+   on the stack, so it shouldn't compete with the prose it introduces. */
+.op-push { color: var(--meta); }
 /* A witness footnote is a stack of items; a thin middot separates each, and an
    empty stack item shows as ∅. */
 .wit-sep, .wit-empty { color: var(--meta); font-style: normal; }
@@ -312,7 +316,16 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <details class="notation">
     <summary>Notation</summary>
     <div class="notation-body">
-      <p class="notation-lede">A key to the sigla used in the manuscript: the glyphs that notate a Bitcoin <b>script's opcodes</b>, and the <b>marks</b> drawn in each transaction's margins. Pushed data — keys, hashes, signatures — is rendered as prose between the glyphs. (Push instructions — OP_PUSHBYTES_<i>n</i>, OP_PUSHDATA1/2/4 — are opcodes too; they surface as the data they carry rather than as marks, since their framing is reconstructable from it.)</p>
+      <p class="notation-lede">A key to the sigla used in the manuscript: the glyphs that notate a Bitcoin <b>script's opcodes</b>, and the <b>marks</b> drawn in each transaction's margins. Every defined opcode has a glyph, push instructions included; pushed data — keys, hashes, signatures — is rendered as prose after its push mark. Hovering any glyph names its opcode.</p>
+
+      <div class="notation-group">
+        <h4>Pushes</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">↧<i>n</i></span><span class="m"><b>push</b> the next n bytes</span></div>
+          <div class="glyph-row"><span class="g">↡<i>n</i> ⇊<i>n</i> ⤋<i>n</i></span><span class="m">extended push — length in a 1 / 2 / 4-byte prefix</span></div>
+        </div>
+        <p class="notation-note">The pushed bytes follow the mark, as prose or an inline quote. The coinbase preamble's β<i>n</i> and ⊕<i>n</i> fold their push in — the mark alone determines the exact bytes.</p>
+      </div>
 
       <div class="notation-group">
         <h4>Signatures &amp; keys</h4>
@@ -321,6 +334,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">▼</span><span class="m">check a signature, <b>else fail</b></span></div>
           <div class="glyph-row"><span class="g">◇</span><span class="m">check <b>m-of-n</b> signatures</span></div>
           <div class="glyph-row"><span class="g">◆</span><span class="m">check m-of-n, <b>else fail</b></span></div>
+          <div class="glyph-row"><span class="g">∇₊</span><span class="m">check a signature, <b>tallying</b> (tapscript multisig)</span></div>
         </div>
         <p class="notation-note">A triangle is one signer, a diamond is many; a filled shape must hold or the script fails.</p>
       </div>
@@ -365,15 +379,67 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       </div>
 
       <div class="notation-group">
-        <h4>Stack, comparison &amp; control</h4>
+        <h4>Stack</h4>
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">⧉</span><span class="m"><b>duplicate</b> the top item</span></div>
           <div class="glyph-row"><span class="g">⌄</span><span class="m"><b>drop</b> the top item</span></div>
-          <div class="glyph-row"><span class="g">=</span><span class="m">equal?</span></div>
-          <div class="glyph-row"><span class="g">≡</span><span class="m">equal, <b>else fail</b></span></div>
+          <div class="glyph-row"><span class="g">⧉?</span><span class="m">duplicate <b>if nonzero</b></span></div>
+          <div class="glyph-row"><span class="g">⇄</span><span class="m"><b>swap</b> the top two</span></div>
+          <div class="glyph-row"><span class="g">↻</span><span class="m"><b>rotate</b> the top three</span></div>
+          <div class="glyph-row"><span class="g">⇗</span><span class="m"><b>over</b> — copy the second to the top</span></div>
+          <div class="glyph-row"><span class="g">⌦</span><span class="m"><b>nip</b> out the second</span></div>
+          <div class="glyph-row"><span class="g">⇘</span><span class="m"><b>tuck</b> the top beneath the second</span></div>
+          <div class="glyph-row"><span class="g">⇡</span><span class="m"><b>pick</b> — copy the nth item up</span></div>
+          <div class="glyph-row"><span class="g">⥀</span><span class="m"><b>roll</b> — move the nth item up</span></div>
+          <div class="glyph-row"><span class="g">↕</span><span class="m"><b>depth</b> of the stack</span></div>
+          <div class="glyph-row"><span class="g">⇥ ⇤</span><span class="m"><b>shelve / retrieve</b> via the alt stack</span></div>
+        </div>
+        <p class="notation-note">A subscript doubles or triples the choreography: ⧉₂ ⧉₃ duplicate pairs and triples, ⌄₂ drops a pair, ⇄₂ ↻₂ ⇗₂ work on pairs.</p>
+      </div>
+
+      <div class="notation-group">
+        <h4>Arithmetic &amp; comparison</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">+ − × ÷ %</span><span class="m">arithmetic on numbers</span></div>
+          <div class="glyph-row"><span class="g">+₁ −₁ ×₂ ÷₂</span><span class="m">by one · by two</span></div>
+          <div class="glyph-row"><span class="g">∓</span><span class="m"><b>negate</b></span></div>
+          <div class="glyph-row"><span class="g">|·|</span><span class="m"><b>absolute value</b></span></div>
+          <div class="glyph-row"><span class="g">⊓ ⊔</span><span class="m"><b>min</b> · <b>max</b></span></div>
+          <div class="glyph-row"><span class="g">∈</span><span class="m"><b>within</b> a range</span></div>
+          <div class="glyph-row"><span class="g">&lt; &gt; ≤ ≥</span><span class="m">comparisons</span></div>
+          <div class="glyph-row"><span class="g">≐ ≑</span><span class="m">numbers equal? · equal, <b>else fail</b></span></div>
+          <div class="glyph-row"><span class="g">≠ ≠₀</span><span class="m">numbers differ · <b>nonzero?</b></span></div>
+          <div class="glyph-row"><span class="g">¬ ∧ ∨</span><span class="m">not · and · or</span></div>
+          <div class="glyph-row"><span class="g">« »</span><span class="m">shift left · right</span></div>
+          <div class="glyph-row"><span class="g">= ≡</span><span class="m">bytes equal? · equal, <b>else fail</b></span></div>
+        </div>
+        <p class="notation-note">= compares raw bytes; ≐ compares as numbers. The doubled form is the else-fail variant, as everywhere in this notation.</p>
+      </div>
+
+      <div class="notation-group">
+        <h4>Bytes</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">⧺</span><span class="m"><b>concatenate</b></span></div>
+          <div class="glyph-row"><span class="g">⊂</span><span class="m"><b>substring</b></span></div>
+          <div class="glyph-row"><span class="g">↤ ↦</span><span class="m">keep the <b>left</b> · <b>right</b> part</span></div>
+          <div class="glyph-row"><span class="g">∼ ∩ ∪ ⊻</span><span class="m">bitwise invert · and · or · xor</span></div>
+          <div class="glyph-row"><span class="g">ℓ</span><span class="m"><b>length</b> of the top item</span></div>
+        </div>
+        <p class="notation-note">The splice and bitwise family (and × ÷ % « » above) has been disabled since 2010 — but a script is notation whether or not the network would still run it.</p>
+      </div>
+
+      <div class="notation-group">
+        <h4>Control</h4>
+        <div class="glyph-grid">
+          <div class="glyph-row"><span class="g">⟨ │ ⟩</span><span class="m">if … else … end</span></div>
+          <div class="glyph-row"><span class="g">¬⟨</span><span class="m"><b>if not</b></span></div>
           <div class="glyph-row"><span class="g">✓</span><span class="m">assert true</span></div>
           <div class="glyph-row"><span class="g">¶</span><span class="m"><b>data output</b> — provably unspendable</span></div>
-          <div class="glyph-row"><span class="g">⟨ │ ⟩</span><span class="m">if … else … end</span></div>
+          <div class="glyph-row"><span class="g">° °<i>n</i></span><span class="m"><b>no-op</b> · numbered no-ops</span></div>
+          <div class="glyph-row"><span class="g">‖</span><span class="m"><b>section divider</b> for signature coverage</span></div>
+          <div class="glyph-row"><span class="g">⊘ ⊘₁ ⊘₂</span><span class="m"><b>reserved</b> — invalid if executed</span></div>
+          <div class="glyph-row"><span class="g">⊘ᵛ ⊘⟨ ⊘¬⟨</span><span class="m">reserved VER family</span></div>
+          <div class="glyph-row"><span class="g">☒</span><span class="m"><b>invalid opcode</b></span></div>
         </div>
       </div>
 
@@ -381,14 +447,14 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Common script patterns</h4>
         <p class="notation-note">A payment's kind is legible in its sequence of marks — learn these and you can read a script's purpose at sight. <span class="ph">…</span> stands for pushed data (a key, a hash, a signature), rendered as prose.</p>
         <div class="pattern-list">
-          <span class="pname">P2PK</span><span class="seq"><span class="ph">…</span> <span class="op">∇</span></span>
-          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">…</span> <span class="op">≡</span> <span class="op">∇</span></span>
-          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="ph">…</span> <span class="op">=</span></span>
-          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="ph">…</span></span>
-          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="ph">…</span></span>
-          <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="ph">…</span></span>
-          <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="ph">… … …</span> <span class="op">③</span> <span class="op">◇</span></span>
-          <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="ph">…</span></span>
+          <span class="pname">P2PK</span><span class="seq"><span class="op op-push">↧</span><span class="ph">…</span> <span class="op">∇</span></span>
+          <span class="pname">P2PKH</span><span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">↧</span><span class="ph">…</span> <span class="op">≡</span> <span class="op">∇</span></span>
+          <span class="pname">P2SH</span><span class="seq"><span class="op">⌖</span> <span class="op op-push">↧</span><span class="ph">…</span> <span class="op">=</span></span>
+          <span class="pname">P2WPKH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">↧</span><span class="ph">…</span></span>
+          <span class="pname">P2WSH</span><span class="seq"><span class="op">⓪</span> <span class="op op-push">↧</span><span class="ph">…</span></span>
+          <span class="pname">P2TR</span><span class="seq"><span class="op">①</span> <span class="op op-push">↧</span><span class="ph">…</span></span>
+          <span class="pname">Multisig</span><span class="seq"><span class="op">②</span> <span class="op op-push">↧</span><span class="ph">…</span> <span class="op op-push">↧</span><span class="ph">…</span> <span class="op op-push">↧</span><span class="ph">…</span> <span class="op">③</span> <span class="op">◇</span></span>
+          <span class="pname">Data</span><span class="seq"><span class="op">¶</span> <span class="op op-push">↧</span><span class="ph">…</span></span>
         </div>
         <p class="notation-note">P2WPKH and P2WSH share the mark <span class="op" style="font-style:normal">⓪</span> — a witness-v0 program — and differ only in the hashed length: a 20-byte HASH160 of a key, or a 32-byte SHA-256 of a script. P2TR opens with <span class="op" style="font-style:normal">①</span> instead. The scripts hidden inside P2SH / P2WSH — an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">…</span> <span class="op" style="font-style:normal">≡ … │ …</span> <span class="op" style="font-style:normal">τ ⌄ … ⟩</span> — are revealed in the same notation when spent.</p>
       </div>
@@ -421,7 +487,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <details class="about">
     <summary>About</summary>
     <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above.</p>
-    <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and push/item length prefixes — is dropped, since it is reconstructable from structure. And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
+    <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and witness items' length prefixes — is dropped, since it is reconstructable from structure; a script's push opcodes render as ↧ marks, their subscript the byte count. And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
     <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to β and ⊕ marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
     <p class="hint muted">Every Glossia-encoded hash — a block hash, a transaction id, the previous-block hash and merkle root above — hovers (or, on touch, taps) into a small selectable panel carrying the exact hex it encodes, and clicking it copies that hex to the clipboard.</p>
     <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet).</p>

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -65,27 +65,31 @@ const toSuperscript = (n) => String(n).split('').map((d) => SUPERSCRIPT_DIGITS[+
 
 // nBits (a compact difficulty target) -> { sym, num, title }. The target is
 // rendered as the thing it is -- the ceiling a mined hash must dip under --
-// via its leading zero run: β's subscript counts the zero hex digits beyond
-// the eight the genesis target opens with, so β₀ is difficulty 1 and the
-// subscript climbs as difficulty rises. `num` carries the target's remaining
-// significant digits; empty for the baseline mantissa ffff, so every
-// difficulty-1 block reads as a bare β₀ -- and when digits are shown they
-// are set off with a middot (β₃·4864c) so the hex mantissa can't read as
-// part of the decimal subscript. Exact both ways: zeros + digits
-// rebuild the full 256-bit target, which re-packs to the compact form. A
-// target looser than the genesis baseline (never on mainnet) falls back to
-// the raw compact hex. The title keeps the raw nBits, the full target and
-// the difficulty ratio for hover.
+// and β's subscript is that demand in its physical unit: the number of
+// leading zero BITS a valid hash must open with. Genesis (difficulty 1) is
+// β₃₂, and the subscript climbs as difficulty rises -- each +1 is a
+// doubling of the work. `num` carries the target's remaining significant
+// hex digits, set off with a middot (β₄₅·4864c) so they can't read as part
+// of the decimal subscript; empty for the baseline mantissa ffff, so every
+// difficulty-1 block reads as a bare β₃₂. Exact both ways: the digits fix
+// the zero bits inside their own first digit, so n + digits rebuild the
+// full 256-bit target, which re-packs to the compact form. A target looser
+// than the genesis baseline (never on mainnet) falls back to the raw
+// compact hex. The title keeps the raw nBits, the full target and the
+// difficulty ratio for hover.
 function bitsInfo(bits) {
   const targetHex = bitsToTargetHex(bits);
   const difficulty = bitsToDifficulty(bits);
   const diffStr = difficulty.toLocaleString(undefined, { maximumFractionDigits: difficulty < 1000 ? 2 : 0 });
   const compact = bits.toString(16).padStart(8, '0');
-  const title = `nBits ${compact} — a valid block hash must read below ${targetHex} — difficulty ${diffStr} (relative to the genesis block)`;
   const zeros = targetHex.length - targetHex.replace(/^0+/, '').length;
-  if (zeros < 8) return { sym: compact, num: '', title };
+  const baseTitle = (extra) => `nBits ${compact} — a valid block hash must read below ${targetHex}${extra} — difficulty ${diffStr} (relative to the genesis block)`;
+  if (zeros < 8) return { sym: compact, num: '', title: baseTitle('') };
   const digits = targetHex.slice(zeros).replace(/0+$/, '') || '0';
-  return { sym: `β${toSubscript(zeros - 8)}`, num: digits === 'ffff' ? '' : '·' + digits, title };
+  // Zero bits inside the first significant hex digit: 1 -> 3, 2-3 -> 2, 4-7 -> 1, 8-f -> 0.
+  const first = parseInt(digits[0], 16);
+  const lz = zeros * 4 + (first >= 8 ? 0 : first >= 4 ? 1 : first >= 2 ? 2 : 3);
+  return { sym: `β${toSubscript(lz)}`, num: digits === 'ffff' ? '' : '·' + digits, title: baseTitle(` (${lz} leading zero bits)`) };
 }
 
 // A block header's nTime -> { mark, title }: the mark is the human date --

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -227,7 +227,7 @@ function opToken(code) {
 // whose length rides in a separate prefix -- arrow weight matching prefix
 // width: ↧ₙ (1-byte), ⇊ₙ (2-byte), ⤋ₙ (4-byte). The pushed data itself
 // follows the mark, as prose or an inline quote. (The coinbase preamble's
-// βₙ and ⊕n marks fold their push opcode in -- the mark alone determines
+// βₙ and ηn marks fold their push opcode in -- the mark alone determines
 // the exact bytes.)
 const PUSH_GLYPHS = { 0: '', 1: '↧', 2: '⇊', 4: '⤋' };
 function pushToken(form, byteLen) {
@@ -297,7 +297,7 @@ function derToCompact(hex) {
 // restating the block's compact difficulty target (the header's nBits,
 // byte for byte), then a small-integer push -- the extranonce, the counter
 // a miner rolled once the header's 32-bit nonce was exhausted. Both are
-// numbers, not entropy, so they render as decoded marks (βₙ, ⊕n) rather
+// numbers, not entropy, so they render as decoded marks (βₙ, ηn) rather
 // than payload words -- which also lets embedded text (the genesis
 // headline) stand as the coinbase's first words instead of trailing runs
 // of bytes-as-prose.
@@ -336,7 +336,7 @@ const markToken = (glyph, text, title) => `<span class="op" title="${title}">${g
 // coinbase) turns on inline ASCII quoting for legible pushes; `nested` reveals a
 // script pushed as data -- a P2SH redeemScript, always the final push -- by
 // rendering it as opcodes in turn; `preamble` (a coinbase) decodes the early
-// mining preamble's leading pushes into β/⊕ marks. Opcode glyphs, OP_* names
+// mining preamble's leading pushes into β/η marks. Opcode glyphs, OP_* names
 // and the preamble marks are the only HTML added here; pushed data is Glossia
 // prose (safe) and quoted ASCII is escaped, so the result is safe to render
 // via innerHTML like before.
@@ -368,7 +368,7 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
         pre = 'done';
         const n = extranonceFromPush(t.push);
         if (n !== null) {
-          parts.push(markToken('⊕', n, `extranonce ${n} — the counter the miner rolled once the header's 32-bit nonce was exhausted`));
+          parts.push(markToken('η', n, `extranonce ${n} — the counter the miner rolled once the header's 32-bit nonce (η) was exhausted`));
           return;
         }
       }

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -339,9 +339,9 @@ const markToken = (glyph, text, title) => `<span class="op" title="${title}">${g
 // ─── data type marks ───────────────────────────────────────────────────
 //
 // A pushed datum whose kind is recognizable carries its type mark from the
-// Notation key -- 𝒫 public key, 𝒮 signature, ℋ hash, ℛ redeem script,
-// 𝒲 witness script, 𝒯 tapscript -- set just before its prose, so a script
-// reads as its pattern (⁶⁵𝒫 ∇) without consulting the key. Classification
+// Notation key -- 𝓅 public key, 𝓈 signature, 𝒽 hash, 𝓇 redeem script,
+// 𝓌 witness script, 𝓉 tapscript -- set just before its prose, so a script
+// reads as its pattern (⁶⁵𝓅 ∇) without consulting the key. Classification
 // is display-only annotation: it never changes what gets encoded.
 const dataMark = (sym, title) => `<span class="dt" title="${title}">${sym}</span>`;
 
@@ -350,15 +350,15 @@ const dataMark = (sym, title) => `<span class="dt" title="${title}">${sym}</span
 // push in script context is a HASH160; a 32-byte one is a hash -- except
 // directly after ① (a witness-v1 program: Taproot's tweaked output key), or
 // directly before a signature check (an x-only key inside a tapscript).
-// Non-canonical DER (0x30-led, signature-sized) still marks 𝒮.
+// Non-canonical DER (0x30-led, signature-sized) still marks 𝓈.
 const SIG_CHECK_OPS = new Set([0xac, 0xad, 0xba]);
 function scriptDataMark(push, compact, prevOp, nextOp) {
   const n = push.length / 2;
-  if (compact || (push.slice(0, 2) === '30' && n >= 68 && n <= 73)) return dataMark('𝒮', 'signature');
-  if (isPubkey(push)) return dataMark('𝒫', 'public key');
-  if (n === 32 && prevOp === 0x51) return dataMark('𝒫', 'public key — Taproot tweaked output key');
-  if (n === 32 && SIG_CHECK_OPS.has(nextOp)) return dataMark('𝒫', 'public key — x-only');
-  if (n === 20 || n === 32) return dataMark('ℋ', 'hash');
+  if (compact || (push.slice(0, 2) === '30' && n >= 68 && n <= 73)) return dataMark('𝓈', 'signature');
+  if (isPubkey(push)) return dataMark('𝓅', 'public key');
+  if (n === 32 && prevOp === 0x51) return dataMark('𝓅', 'public key — Taproot tweaked output key');
+  if (n === 32 && SIG_CHECK_OPS.has(nextOp)) return dataMark('𝓅', 'public key — x-only');
+  if (n === 20 || n === 32) return dataMark('𝒽', 'hash');
   return '';
 }
 
@@ -407,8 +407,8 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
       const mark = pushToken(t.pushForm || 0, t.push.length / 2);
       if (!t.push) { parts.push(mark); return; }              // a zero-length extended push -- the mark alone
       if (i === redeemIdx && looksLikeScript(t.push)) {
-        // reveal the redeemScript, typed ℛ
-        parts.push(mark + dataMark('ℛ', 'redeem script — revealed as opcodes'), renderScript(t.push, collect));
+        // reveal the redeemScript, typed 𝓇
+        parts.push(mark + dataMark('𝓇', 'redeem script — revealed as opcodes'), renderScript(t.push, collect));
         return;
       }
       if (eligible) {
@@ -488,9 +488,9 @@ function witnessScriptIndex(items) {
 
 // An input's witness stack (hex items) -> its footnote display. `encode` turns
 // a data item's hex into Glossia prose; the one script item, if present,
-// becomes opcode notation, typed 𝒲 (a P2WSH witnessScript) or 𝒯 (a Taproot
+// becomes opcode notation, typed 𝓌 (a P2WSH witnessScript) or 𝓉 (a Taproot
 // tapscript, identified by the control block above it). Data items carry
-// their own type marks -- 𝒮 a signature, 𝒫 a key -- and items are separated
+// their own type marks -- 𝓈 a signature, 𝓅 a key -- and items are separated
 // so each reads as its own stack element.
 export function renderWitness(items, encode) {
   if (!items || !items.length) return '∅';
@@ -500,12 +500,12 @@ export function renderWitness(items, encode) {
     .map((hex, i) => {
       if (!hex) return '<span class="wit-empty">∅</span>';    // an empty stack item
       if (i === scriptIdx) {
-        return (isTapscript ? dataMark('𝒯', 'tapscript — a Taproot leaf, revealed as opcodes') : dataMark('𝒲', 'witness script — revealed as opcodes'))
+        return (isTapscript ? dataMark('𝓉', 'tapscript — a Taproot leaf, revealed as opcodes') : dataMark('𝓌', 'witness script — revealed as opcodes'))
           + ' ' + renderScript(hex, encode);
       }
       const compact = derToCompact(hex);                      // a DER signature is stripped to r‖s‖sighash
-      const dm = (compact || isSignature(hex)) ? dataMark('𝒮', 'signature')
-        : isPubkey(hex) ? dataMark('𝒫', 'public key') : '';
+      const dm = (compact || isSignature(hex)) ? dataMark('𝓈', 'signature')
+        : isPubkey(hex) ? dataMark('𝓅', 'public key') : '';
       return (dm ? dm + ' ' : '') + encode(compact || hex);
     })
     .join('<span class="wit-sep"> · </span>');

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -225,23 +225,88 @@ function derToCompact(hex) {
 }
 
 // A script (hex) -> its opcode-notation display string. `collect` encodes a
+// ─── the early coinbase mining preamble ────────────────────────────────
+//
+// For the chain's first years, a coinbase scriptSig opened not with
+// arbitrary tag data but with a small mining preamble: a 4-byte push
+// restating the block's compact difficulty target (the header's nBits,
+// byte for byte), then a small-integer push -- the extranonce, the counter
+// a miner rolled once the header's 32-bit nonce was exhausted. Both are
+// numbers, not entropy, so they render as decoded marks (◎target, ⊕n)
+// rather than payload words -- which also lets embedded text (the genesis
+// headline) stand as the coinbase's first words instead of trailing runs
+// of bytes-as-prose.
+
+const reverseHexStr = (hex) => (hex.match(/../g) || []).reverse().join('');
+
+// A 4-byte push -> its u32le value, when that value is a plausible compact
+// difficulty target: a byte-length exponent in the range real targets
+// occupy, and a positive nonzero mantissa. The exponent is the push's LAST
+// byte, so printable-ASCII tag data (every byte ≥ 0x20) can never match;
+// nor can a BIP34 height push, whose most-significant byte is far below
+// 0x03 for any realistic height. Fixed-width, so the mark reconstructs the
+// wire bytes exactly.
+function compactBitsFromPush(push) {
+  if (push.length !== 8) return null;
+  const bits = parseInt(reverseHexStr(push), 16);
+  const exponent = bits >>> 24, mantissa = bits & 0x00ffffff;
+  if (exponent < 0x03 || exponent > 0x20 || mantissa === 0 || (mantissa & 0x800000) !== 0) return null;
+  return bits;
+}
+
+// An extranonce push -> its decimal string: up to 8 little-endian bytes,
+// minimally encoded (no most-significant zero byte), so the number alone
+// reconstructs the exact bytes. A non-minimal encoding falls back to prose
+// rather than risk a lossy round trip.
+function extranonceFromPush(push) {
+  if (push.length < 2 || push.length > 16 || push.slice(-2) === '00') return null;
+  return BigInt('0x' + reverseHexStr(push)).toString();
+}
+
+// A decoded mark: glyph + value, both carrying the same explanatory title.
+const markToken = (glyph, text, title) => `<span class="op" title="${title}">${glyph}</span><span class="op-num" title="${title}">${text}</span>`;
+
 // data push to Glossia prose. Options: `eligible` (an OP_RETURN payload, or a
 // coinbase) turns on inline ASCII quoting for legible pushes; `nested` reveals a
 // script pushed as data -- a P2SH redeemScript, always the final push -- by
-// rendering it as opcodes in turn. Opcode glyphs and OP_* names are the only
-// HTML added here; pushed data is Glossia prose (safe) and quoted ASCII is
-// escaped, so the result is safe to render via innerHTML like before.
-function renderScript(hex, collect, { eligible = false, nested = false } = {}) {
+// rendering it as opcodes in turn; `preamble` (a coinbase) decodes the early
+// mining preamble's leading pushes into ◎/⊕ marks. Opcode glyphs, OP_* names
+// and the preamble marks are the only HTML added here; pushed data is Glossia
+// prose (safe) and quoted ASCII is escaped, so the result is safe to render
+// via innerHTML like before.
+function renderScript(hex, collect, { eligible = false, nested = false, preamble = false } = {}) {
   const toks = tokenizeScript(hex);
   // A P2SH scriptSig ends with its redeemScript, pushed as data; reveal that
   // final push as opcodes when it parses as a genuine script.
   const redeemIdx = nested ? toks.map((t) => t.push !== undefined).lastIndexOf(true) : -1;
   const parts = [];
+  // The preamble is strictly positional -- the target must open the script,
+  // the extranonce must directly follow it; anything else ends the hunt and
+  // the push falls through to the ordinary treatment.
+  let pre = preamble ? 'target' : 'done';
   toks.forEach((t, i) => {
     if (t.op !== undefined) {
+      pre = 'done';
       parts.push(opToken(t.op));
     } else if (t.push !== undefined) {
       if (!t.push) return;                                    // empty push -- nothing to show
+      if (pre === 'target') {
+        pre = 'done';
+        const bits = compactBitsFromPush(t.push);
+        if (bits !== null) {
+          const info = bitsInfo(bits);
+          parts.push(markToken('◎', info.mark, `the difficulty target this block was mined against — ${info.title}`));
+          pre = 'extranonce';
+          return;
+        }
+      } else if (pre === 'extranonce') {
+        pre = 'done';
+        const n = extranonceFromPush(t.push);
+        if (n !== null) {
+          parts.push(markToken('⊕', n, `extranonce ${n} — the counter the miner rolled once the header's 32-bit nonce was exhausted`));
+          return;
+        }
+      }
       if (i === redeemIdx && looksLikeScript(t.push)) {
         parts.push(renderScript(t.push, collect));            // reveal the redeemScript
         return;
@@ -252,6 +317,7 @@ function renderScript(hex, collect, { eligible = false, nested = false } = {}) {
       }
       parts.push(collect(derToCompact(t.push) || t.push));    // a DER signature is stripped to r‖s‖sighash
     } else {
+      pre = 'done';
       parts.push(collect(t.trunc));                           // malformed tail -- carry it as prose
     }
   });
@@ -351,15 +417,17 @@ export function composeTransactionFields(parsed, bestOf = 1) {
   const inputs = parsed.vin.map((v) => {
     const isNullPrevout = v.txid === '00'.repeat(32);
     // A coinbase scriptSig is arbitrary miner data -- but the earliest blocks'
-    // are clean push-scripts, so render those in opcode notation (embedded text
-    // like the genesis headline is quoted inline). Messier ones keep the plain
-    // treatment, where a mining-pool tag is surfaced as a quote block
-    // (`scriptAscii`). Every other scriptSig is genuine script (with a P2SH
-    // redeemScript revealed as opcodes via `nested`).
+    // are clean push-scripts, so render those in opcode notation, with the
+    // mining preamble (restated difficulty target + extranonce) decoded to
+    // marks and embedded text like the genesis headline quoted inline.
+    // Messier ones keep the plain treatment, where a mining-pool tag is
+    // surfaced as a quote block (`scriptAscii`). Every other scriptSig is
+    // genuine script (with a P2SH redeemScript revealed as opcodes via
+    // `nested`).
     let script, scriptAscii = null;
     if (isNullPrevout) {
       if (isCleanScript(v.scriptSig)) {
-        script = renderScript(v.scriptSig, collect, { eligible: true });
+        script = renderScript(v.scriptSig, collect, { eligible: true, preamble: true });
       } else {
         const found = findAsciiStrings(v.scriptSig);
         if (found.length) {

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -29,10 +29,10 @@ function toRoman(n) {
 
 // The timelock fields get symbols rather than digit strings, on a small grammar
 // that separates the whole transaction's status (nLockTime) from each input's
-// (nSequence), sharing ■/⊥ for the block/time distinction:
-//   Transaction (nLockTime):  □ none · ■n absolute block height · ⊥n absolute unix time
+// (nSequence), sharing ■ (block) / Τ (temporal) for the block/time distinction:
+//   Transaction (nLockTime):  □ none · ■n absolute block height · Τn absolute unix time
 //   Input (nSequence):        ○ final · † replaceable (opt-in RBF) ·
-//                             ■n relative block delay · ⊥n relative time delay
+//                             ■n relative block delay · Τn relative time delay
 // The square reads as the whole document, the circle as one input. A coinbase's
 // null prevout is flagged with isNullPrevout so the renderer can mark it (∅);
 // other prevouts are carried as references and resolved to a citation
@@ -54,7 +54,7 @@ function durationFrom512s(n) {
 
 // nLockTime -> { mark, title }: □ (none), ■ + citation (absolute block --
 // the block is a chapter of the book, so it's cited as volume book chapter
-// rather than a bare height), ⊥ + UTC date (absolute time -- rendered
+// rather than a bare height), Τ + UTC date (absolute time -- rendered
 // physically, the raw unix value in the hover).
 function locktimeInfo(locktime) {
   if (locktime === 0) return { mark: '□', title: 'no locktime — final with respect to time' };
@@ -63,7 +63,7 @@ function locktimeInfo(locktime) {
     return { mark: `■ ${toRoman(volume)} ${book} ${chapter}`, title: `locktime: not before block ${locktime} — volume ${volume}, book ${book}, chapter ${chapter}` };
   }
   const date = new Date(locktime * 1000).toISOString().slice(0, 16).replace('T', ' ');
-  return { mark: `⊥${date}`, title: `locktime: not before ${date} UTC (unix ${locktime})` };
+  return { mark: `Τ${date}`, title: `locktime: not before ${date} UTC (unix ${locktime})` };
 }
 
 // nSequence -> { rbf, mark, kind, title }. BIP68 relative locktime is enabled
@@ -78,9 +78,9 @@ function sequenceInfo(seq) {
     const n = seq & 0x0000ffff;
     // A relative block delay counts chapters, so it reads in Roman numerals
     // (■CXLIV = 144 blocks); a time delay is physical time, so it reads as
-    // an exact duration (⊥20h28m48s), the wire units kept in the hover.
+    // an exact duration (Τ20h28m48s), the wire units kept in the hover.
     return (seq & 0x00400000)
-      ? { rbf: true, mark: `⊥${durationFrom512s(n)}`, kind: 'time', title: `replaceable; relative locktime ${durationFrom512s(n)} (${n} × 512 s) after the input's confirmation` }
+      ? { rbf: true, mark: `Τ${durationFrom512s(n)}`, kind: 'time', title: `replaceable; relative locktime ${durationFrom512s(n)} (${n} × 512 s) after the input's confirmation` }
       : { rbf: true, mark: `■${toRoman(n)}`, kind: 'block', title: `replaceable; relative locktime ${n} block${n === 1 ? '' : 's'} after the input's confirmation` };
   }
   if (seq === 0xffffffff) return { rbf: false, mark: '●', kind: 'final', title: 'final — disables the transaction locktime for this input' };

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -221,17 +221,20 @@ function opToken(code) {
   return `<span class="op-name">${name}</span>`;
 }
 
-// A push opcode's mark: ↧ₙ for a direct push (OP_PUSHBYTES_n), ↡ₙ / ⇊ₙ / ⤋ₙ
-// for OP_PUSHDATA1/2/4, whose length rides in a 1/2/4-byte prefix. The
-// subscript is the byte count; the pushed data itself follows the mark, as
-// prose or an inline quote. (The coinbase preamble's βₙ and ⊕n marks fold
-// their push opcode in -- the mark alone determines the exact bytes.)
-const PUSH_GLYPHS = { 0: '↧', 1: '↡', 2: '⇊', 4: '⤋' };
+// A push opcode's mark. A direct push (OP_PUSHBYTES_n) is the quietest
+// instruction in the set, so its mark is the quietest possible: the bare
+// subscript byte count, ₙ. The arrows are reserved for OP_PUSHDATA1/2/4,
+// whose length rides in a separate prefix -- arrow weight matching prefix
+// width: ↧ₙ (1-byte), ⇊ₙ (2-byte), ⤋ₙ (4-byte). The pushed data itself
+// follows the mark, as prose or an inline quote. (The coinbase preamble's
+// βₙ and ⊕n marks fold their push opcode in -- the mark alone determines
+// the exact bytes.)
+const PUSH_GLYPHS = { 0: '', 1: '↧', 2: '⇊', 4: '⤋' };
 function pushToken(form, byteLen) {
   const title = form
     ? `OP_PUSHDATA${form} — push ${byteLen} bytes, the length in a ${form}-byte prefix`
     : `OP_PUSHBYTES_${byteLen} — push the next ${byteLen} bytes`;
-  return `<span class="op op-push" title="${title}">${PUSH_GLYPHS[form] || '↧'}${toSubscript(byteLen)}</span>`;
+  return `<span class="op op-push" title="${title}">${PUSH_GLYPHS[form] || ''}${toSubscript(byteLen)}</span>`;
 }
 
 // ─── DER signature compaction ──────────────────────────────────────────

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -18,6 +18,14 @@
 
 import { encodeSeedPhrase } from './glossia-msg.js';
 import { findAsciiStrings, tokenizeScript, bitsToTargetHex, bitsToDifficulty } from './btc-tx.js';
+import { volumeBookChapter } from './btc-citation.js';
+
+const ROMAN = [[1000, 'M'], [900, 'CM'], [500, 'D'], [400, 'CD'], [100, 'C'], [90, 'XC'], [50, 'L'], [40, 'XL'], [10, 'X'], [9, 'IX'], [5, 'V'], [4, 'IV'], [1, 'I']];
+function toRoman(n) {
+  let out = '';
+  for (const [v, s] of ROMAN) while (n >= v) { out += s; n -= v; }
+  return out || '0';
+}
 
 // The timelock fields get symbols rather than digit strings, on a small grammar
 // that separates the whole transaction's status (nLockTime) from each input's
@@ -31,10 +39,15 @@ import { findAsciiStrings, tokenizeScript, bitsToTargetHex, bitsToDifficulty } f
 // downstream, not encoded here.
 const LOCKTIME_THRESHOLD = 500000000;   // nLockTime below this is a block height, at/above a unix timestamp
 
-// nLockTime -> { mark, title }: □ (none), ■n (absolute block), ⊥n (absolute time).
+// nLockTime -> { mark, title }: □ (none), ■ + citation (absolute block --
+// the block is a chapter of the book, so it's cited as volume book chapter
+// rather than a bare height), ⊥n (absolute time).
 function locktimeInfo(locktime) {
   if (locktime === 0) return { mark: '□', title: 'no locktime — final with respect to time' };
-  if (locktime < LOCKTIME_THRESHOLD) return { mark: `■${locktime}`, title: `locktime: not before block ${locktime}` };
+  if (locktime < LOCKTIME_THRESHOLD) {
+    const { volume, book, chapter } = volumeBookChapter(locktime);
+    return { mark: `■ ${toRoman(volume)} ${book} ${chapter}`, title: `locktime: not before block ${locktime} — volume ${volume}, book ${book}, chapter ${chapter}` };
+  }
   const date = new Date(locktime * 1000).toISOString().slice(0, 16).replace('T', ' ');
   return { mark: `⊥${locktime}`, title: `locktime: not before ${date} UTC (unix ${locktime})` };
 }
@@ -49,9 +62,11 @@ function locktimeInfo(locktime) {
 function sequenceInfo(seq) {
   if ((seq & 0x80000000) === 0) {
     const n = seq & 0x0000ffff;
+    // A relative block delay counts chapters, so it reads in Roman numerals
+    // (■CXLIV = 144 blocks); a time delay is physical time and stays decimal.
     return (seq & 0x00400000)
       ? { rbf: true, mark: `⊥${n}`, kind: 'time', title: `replaceable; relative locktime ${n} × 512 s after the input's confirmation` }
-      : { rbf: true, mark: `■${n}`, kind: 'block', title: `replaceable; relative locktime ${n} block${n === 1 ? '' : 's'} after the input's confirmation` };
+      : { rbf: true, mark: `■${toRoman(n)}`, kind: 'block', title: `replaceable; relative locktime ${n} block${n === 1 ? '' : 's'} after the input's confirmation` };
   }
   if (seq === 0xffffffff) return { rbf: false, mark: '●', kind: 'final', title: 'final — disables the transaction locktime for this input' };
   if (seq === 0xfffffffe) return { rbf: false, mark: '○', kind: 'locktime', title: 'not replaceable, but respects the transaction locktime' };

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -58,16 +58,30 @@ function sequenceInfo(seq) {
   return { rbf: true, mark: '', kind: 'rbf', title: 'replaceable — signals opt-in RBF' };
 }
 
-// nBits (a block header's compact difficulty target) -> { mark, title }: the
-// raw compact form leads, as it appears on the wire and in Bitcoin Core's own
-// display of it; the title expands it to the full 256-bit target and the
-// difficulty relative to the genesis block, so hovering explains what the
-// four bytes actually require of a valid block hash.
+const SUBSCRIPT_DIGITS = '₀₁₂₃₄₅₆₇₈₉';
+const toSubscript = (n) => String(n).split('').map((d) => SUBSCRIPT_DIGITS[+d]).join('');
+
+// nBits (a compact difficulty target) -> { sym, num, title }. The target is
+// rendered as the thing it is -- the ceiling a mined hash must dip under --
+// via its leading zero run: β's subscript counts the zero hex digits beyond
+// the eight the genesis target opens with, so β₀ is difficulty 1 and the
+// subscript climbs as difficulty rises. `num` carries the target's remaining
+// significant digits; empty for the baseline mantissa ffff, so every
+// difficulty-1 block reads as a bare β₀. Exact both ways: zeros + digits
+// rebuild the full 256-bit target, which re-packs to the compact form. A
+// target looser than the genesis baseline (never on mainnet) falls back to
+// the raw compact hex. The title keeps the raw nBits, the full target and
+// the difficulty ratio for hover.
 function bitsInfo(bits) {
   const targetHex = bitsToTargetHex(bits);
   const difficulty = bitsToDifficulty(bits);
   const diffStr = difficulty.toLocaleString(undefined, { maximumFractionDigits: difficulty < 1000 ? 2 : 0 });
-  return { mark: bits.toString(16).padStart(8, '0'), title: `a valid block hash must read below ${targetHex} — difficulty ${diffStr} (relative to the genesis block)` };
+  const compact = bits.toString(16).padStart(8, '0');
+  const title = `nBits ${compact} — a valid block hash must read below ${targetHex} — difficulty ${diffStr} (relative to the genesis block)`;
+  const zeros = targetHex.length - targetHex.replace(/^0+/, '').length;
+  if (zeros < 8) return { sym: compact, num: '', title };
+  const digits = targetHex.slice(zeros).replace(/0+$/, '') || '0';
+  return { sym: `β${toSubscript(zeros - 8)}`, num: digits === 'ffff' ? '' : digits, title };
 }
 
 // A block header's nTime -> { mark, title }: the mark is the human date --
@@ -95,7 +109,7 @@ export function composeBlockHeaderFields(header) {
   return {
     version: String(header.version),
     timestamp: time.mark, timestampTitle: time.title,
-    bits: bits.mark, bitsTitle: bits.title,
+    bits: bits.sym + bits.num, bitsTitle: bits.title,
     nonce: String(header.nonce),
   };
 }
@@ -232,8 +246,8 @@ function derToCompact(hex) {
 // restating the block's compact difficulty target (the header's nBits,
 // byte for byte), then a small-integer push -- the extranonce, the counter
 // a miner rolled once the header's 32-bit nonce was exhausted. Both are
-// numbers, not entropy, so they render as decoded marks (◎target, ⊕n)
-// rather than payload words -- which also lets embedded text (the genesis
+// numbers, not entropy, so they render as decoded marks (βₙ, ⊕n) rather
+// than payload words -- which also lets embedded text (the genesis
 // headline) stand as the coinbase's first words instead of trailing runs
 // of bytes-as-prose.
 
@@ -263,14 +277,15 @@ function extranonceFromPush(push) {
   return BigInt('0x' + reverseHexStr(push)).toString();
 }
 
-// A decoded mark: glyph + value, both carrying the same explanatory title.
-const markToken = (glyph, text, title) => `<span class="op" title="${title}">${glyph}</span><span class="op-num" title="${title}">${text}</span>`;
+// A decoded mark: glyph + value (when there is one to show), both carrying
+// the same explanatory title.
+const markToken = (glyph, text, title) => `<span class="op" title="${title}">${glyph}</span>${text ? `<span class="op-num" title="${title}">${text}</span>` : ''}`;
 
 // data push to Glossia prose. Options: `eligible` (an OP_RETURN payload, or a
 // coinbase) turns on inline ASCII quoting for legible pushes; `nested` reveals a
 // script pushed as data -- a P2SH redeemScript, always the final push -- by
 // rendering it as opcodes in turn; `preamble` (a coinbase) decodes the early
-// mining preamble's leading pushes into ◎/⊕ marks. Opcode glyphs, OP_* names
+// mining preamble's leading pushes into β/⊕ marks. Opcode glyphs, OP_* names
 // and the preamble marks are the only HTML added here; pushed data is Glossia
 // prose (safe) and quoted ASCII is escaped, so the result is safe to render
 // via innerHTML like before.
@@ -295,7 +310,7 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
         const bits = compactBitsFromPush(t.push);
         if (bits !== null) {
           const info = bitsInfo(bits);
-          parts.push(markToken('◎', info.mark, `the difficulty target this block was mined against — ${info.title}`));
+          parts.push(markToken(info.sym, info.num, `the difficulty target this block was mined against — ${info.title}`));
           pre = 'extranonce';
           return;
         }

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -63,20 +63,16 @@ const toSubscript = (n) => String(n).split('').map((d) => SUBSCRIPT_DIGITS[+d]).
 const SUPERSCRIPT_DIGITS = '⁰¹²³⁴⁵⁶⁷⁸⁹';
 const toSuperscript = (n) => String(n).split('').map((d) => SUPERSCRIPT_DIGITS[+d]).join('');
 
-// nBits (a compact difficulty target) -> { sym, num, title }. The target is
+// nBits (a compact difficulty target) -> { sym, title }. The target is
 // rendered as the thing it is -- the ceiling a mined hash must dip under --
 // and β's subscript is that demand in its physical unit: the number of
 // leading zero BITS a valid hash must open with. Genesis (difficulty 1) is
 // β₃₂, and the subscript climbs as difficulty rises -- each +1 is a
-// doubling of the work. `num` carries the target's remaining significant
-// hex digits, set off with a middot (β₄₅·4864c) so they can't read as part
-// of the decimal subscript; empty for the baseline mantissa ffff, so every
-// difficulty-1 block reads as a bare β₃₂. Exact both ways: the digits fix
-// the zero bits inside their own first digit, so n + digits rebuild the
-// full 256-bit target, which re-packs to the compact form. A target looser
-// than the genesis baseline (never on mainnet) falls back to the raw
-// compact hex. The title keeps the raw nBits, the full target and the
-// difficulty ratio for hover.
+// doubling of the work. The mantissa is deliberately not shown: βₙ is a
+// summary mark, and the exact compact nBits, the full 256-bit target and
+// the difficulty ratio all ride in the hover title. A target looser than
+// the genesis baseline (never on mainnet) falls back to the raw compact
+// hex.
 function bitsInfo(bits) {
   const targetHex = bitsToTargetHex(bits);
   const difficulty = bitsToDifficulty(bits);
@@ -84,12 +80,11 @@ function bitsInfo(bits) {
   const compact = bits.toString(16).padStart(8, '0');
   const zeros = targetHex.length - targetHex.replace(/^0+/, '').length;
   const baseTitle = (extra) => `nBits ${compact} — a valid block hash must read below ${targetHex}${extra} — difficulty ${diffStr} (relative to the genesis block)`;
-  if (zeros < 8) return { sym: compact, num: '', title: baseTitle('') };
-  const digits = targetHex.slice(zeros).replace(/0+$/, '') || '0';
+  if (zeros < 8) return { sym: compact, title: baseTitle('') };
   // Zero bits inside the first significant hex digit: 1 -> 3, 2-3 -> 2, 4-7 -> 1, 8-f -> 0.
-  const first = parseInt(digits[0], 16);
+  const first = parseInt(targetHex[zeros], 16);
   const lz = zeros * 4 + (first >= 8 ? 0 : first >= 4 ? 1 : first >= 2 ? 2 : 3);
-  return { sym: `β${toSubscript(lz)}`, num: digits === 'ffff' ? '' : '·' + digits, title: baseTitle(` (${lz} leading zero bits)`) };
+  return { sym: `β${toSubscript(lz)}`, title: baseTitle(` (${lz} leading zero bits)`) };
 }
 
 // A block header's nTime -> { mark, title }: the mark is the human date --
@@ -117,7 +112,7 @@ export function composeBlockHeaderFields(header) {
   return {
     version: String(header.version),
     timestamp: time.mark, timestampTitle: time.title,
-    bits: bits.sym + bits.num, bitsTitle: bits.title,
+    bits: bits.sym, bitsTitle: bits.title,
     nonce: String(header.nonce),
   };
 }
@@ -369,7 +364,7 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
         const bits = compactBitsFromPush(t.push);
         if (bits !== null) {
           const info = bitsInfo(bits);
-          parts.push(markToken(info.sym, info.num, `the difficulty target this block was mined against — ${info.title}`));
+          parts.push(markToken(info.sym, '', `the difficulty target this block was mined against — ${info.title}`));
           pre = 'extranonce';
           return;
         }

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -60,6 +60,8 @@ function sequenceInfo(seq) {
 
 const SUBSCRIPT_DIGITS = '₀₁₂₃₄₅₆₇₈₉';
 const toSubscript = (n) => String(n).split('').map((d) => SUBSCRIPT_DIGITS[+d]).join('');
+const SUPERSCRIPT_DIGITS = '⁰¹²³⁴⁵⁶⁷⁸⁹';
+const toSuperscript = (n) => String(n).split('').map((d) => SUPERSCRIPT_DIGITS[+d]).join('');
 
 // nBits (a compact difficulty target) -> { sym, num, title }. The target is
 // rendered as the thing it is -- the ceiling a mined hash must dip under --
@@ -67,7 +69,9 @@ const toSubscript = (n) => String(n).split('').map((d) => SUBSCRIPT_DIGITS[+d]).
 // the eight the genesis target opens with, so β₀ is difficulty 1 and the
 // subscript climbs as difficulty rises. `num` carries the target's remaining
 // significant digits; empty for the baseline mantissa ffff, so every
-// difficulty-1 block reads as a bare β₀. Exact both ways: zeros + digits
+// difficulty-1 block reads as a bare β₀ -- and when digits are shown they
+// are set off with a middot (β₃·4864c) so the hex mantissa can't read as
+// part of the decimal subscript. Exact both ways: zeros + digits
 // rebuild the full 256-bit target, which re-packs to the compact form. A
 // target looser than the genesis baseline (never on mainnet) falls back to
 // the raw compact hex. The title keeps the raw nBits, the full target and
@@ -81,7 +85,7 @@ function bitsInfo(bits) {
   const zeros = targetHex.length - targetHex.replace(/^0+/, '').length;
   if (zeros < 8) return { sym: compact, num: '', title };
   const digits = targetHex.slice(zeros).replace(/0+$/, '') || '0';
-  return { sym: `β${toSubscript(zeros - 8)}`, num: digits === 'ffff' ? '' : digits, title };
+  return { sym: `β${toSubscript(zeros - 8)}`, num: digits === 'ffff' ? '' : '·' + digits, title };
 }
 
 // A block header's nTime -> { mark, title }: the mark is the human date --
@@ -223,9 +227,10 @@ function opToken(code) {
 
 // A push opcode's mark. A direct push (OP_PUSHBYTES_n) is the quietest
 // instruction in the set, so its mark is the quietest possible: the bare
-// subscript byte count, ₙ. The arrows are reserved for OP_PUSHDATA1/2/4,
-// whose length rides in a separate prefix -- arrow weight matching prefix
-// width: ↧ₙ (1-byte), ⇊ₙ (2-byte), ⤋ₙ (4-byte). The pushed data itself
+// superscript byte count, ⁿ. (Superscripts count bytes; subscripts index an
+// opcode family's variants -- ⧉₂, °₄, β₀.) The arrows are reserved for
+// OP_PUSHDATA1/2/4, whose length rides in a separate prefix -- arrow weight
+// matching prefix width: ↧ⁿ (1-byte), ⇊ⁿ (2-byte), ⤋ⁿ (4-byte). The pushed data itself
 // follows the mark, as prose or an inline quote. (The coinbase preamble's
 // βₙ and ηn marks fold their push opcode in -- the mark alone determines
 // the exact bytes.)
@@ -234,7 +239,7 @@ function pushToken(form, byteLen) {
   const title = form
     ? `OP_PUSHDATA${form} — push ${byteLen} bytes, the length in a ${form}-byte prefix`
     : `OP_PUSHBYTES_${byteLen} — push the next ${byteLen} bytes`;
-  return `<span class="op op-push" title="${title}">${PUSH_GLYPHS[form] || ''}${toSubscript(byteLen)}</span>`;
+  return `<span class="op op-push" title="${title}">${PUSH_GLYPHS[form] || ''}${toSuperscript(byteLen)}</span>`;
 }
 
 // ─── DER signature compaction ──────────────────────────────────────────

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -17,7 +17,7 @@
 // margin layout.
 
 import { encodeSeedPhrase } from './glossia-msg.js';
-import { findAsciiStrings, tokenizeScript } from './btc-tx.js';
+import { findAsciiStrings, tokenizeScript, bitsToTargetHex, bitsToDifficulty } from './btc-tx.js';
 
 // The timelock fields get symbols rather than digit strings, on a small grammar
 // that separates the whole transaction's status (nLockTime) from each input's
@@ -56,6 +56,48 @@ function sequenceInfo(seq) {
   if (seq === 0xffffffff) return { rbf: false, mark: '●', kind: 'final', title: 'final — disables the transaction locktime for this input' };
   if (seq === 0xfffffffe) return { rbf: false, mark: '○', kind: 'locktime', title: 'not replaceable, but respects the transaction locktime' };
   return { rbf: true, mark: '', kind: 'rbf', title: 'replaceable — signals opt-in RBF' };
+}
+
+// nBits (a block header's compact difficulty target) -> { mark, title }: the
+// raw compact form leads, as it appears on the wire and in Bitcoin Core's own
+// display of it; the title expands it to the full 256-bit target and the
+// difficulty relative to the genesis block, so hovering explains what the
+// four bytes actually require of a valid block hash.
+function bitsInfo(bits) {
+  const targetHex = bitsToTargetHex(bits);
+  const difficulty = bitsToDifficulty(bits);
+  const diffStr = difficulty.toLocaleString(undefined, { maximumFractionDigits: difficulty < 1000 ? 2 : 0 });
+  return { mark: bits.toString(16).padStart(8, '0'), title: `a valid block hash must read below ${targetHex} — difficulty ${diffStr} (relative to the genesis block)` };
+}
+
+// A block header's nTime -> { mark, title }: the mark is the human date --
+// the interpreted, legible form -- since unlike nonce there's nothing more
+// "raw" a reader would want at a glance; the title carries the literal unix
+// value for verification against the wire bytes.
+function timestampInfo(timestamp) {
+  const date = new Date(timestamp * 1000).toISOString().slice(0, 16).replace('T', ' ');
+  return { mark: `${date} UTC`, title: `unix ${timestamp}` };
+}
+
+// A parsed block header (btc-tx.js's parseBlockHeader) -> its rendered
+// fields. version, timestamp, bits and nonce are small structural numbers --
+// never entropy -- so they're rendered literally/decoded rather than
+// Glossia-encoded, mirroring how composeTransactionFields treats a
+// transaction's version and locktime. The nonce in particular gets no
+// further decoding: it's already exactly what it looks like, the number a
+// miner incremented in the search for a hash below the bits target. The
+// previous-block hash and merkle root are genuinely opaque 32-byte hashes --
+// callers Glossia-encode those themselves (as bitcoin-book.html already does
+// for the block/txid hashes), not here.
+export function composeBlockHeaderFields(header) {
+  const time = timestampInfo(header.timestamp);
+  const bits = bitsInfo(header.bits);
+  return {
+    version: String(header.version),
+    timestamp: time.mark, timestampTitle: time.title,
+    bits: bits.mark, bitsTitle: bits.title,
+    nonce: String(header.nonce),
+  };
 }
 
 // A decimal integer string with a middle-dot every three digits (an output

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -39,9 +39,23 @@ function toRoman(n) {
 // downstream, not encoded here.
 const LOCKTIME_THRESHOLD = 500000000;   // nLockTime below this is a block height, at/above a unix timestamp
 
+// A relative time delay (n × 512 s) -> an exact physical duration: 512 s
+// decomposes cleanly into d h m s (144 units = 73 728 s = 20h28m48s), so
+// the physical form loses nothing against the wire value.
+function durationFrom512s(n) {
+  let s = n * 512;
+  const parts = [];
+  const d = Math.floor(s / 86400); if (d) parts.push(d + 'd'); s %= 86400;
+  const h = Math.floor(s / 3600); if (h) parts.push(h + 'h'); s %= 3600;
+  const m = Math.floor(s / 60); if (m) parts.push(m + 'm'); s %= 60;
+  if (s || !parts.length) parts.push(s + 's');
+  return parts.join('');
+}
+
 // nLockTime -> { mark, title }: □ (none), ■ + citation (absolute block --
 // the block is a chapter of the book, so it's cited as volume book chapter
-// rather than a bare height), ⊥n (absolute time).
+// rather than a bare height), ⊥ + UTC date (absolute time -- rendered
+// physically, the raw unix value in the hover).
 function locktimeInfo(locktime) {
   if (locktime === 0) return { mark: '□', title: 'no locktime — final with respect to time' };
   if (locktime < LOCKTIME_THRESHOLD) {
@@ -49,7 +63,7 @@ function locktimeInfo(locktime) {
     return { mark: `■ ${toRoman(volume)} ${book} ${chapter}`, title: `locktime: not before block ${locktime} — volume ${volume}, book ${book}, chapter ${chapter}` };
   }
   const date = new Date(locktime * 1000).toISOString().slice(0, 16).replace('T', ' ');
-  return { mark: `⊥${locktime}`, title: `locktime: not before ${date} UTC (unix ${locktime})` };
+  return { mark: `⊥${date}`, title: `locktime: not before ${date} UTC (unix ${locktime})` };
 }
 
 // nSequence -> { rbf, mark, kind, title }. BIP68 relative locktime is enabled
@@ -63,9 +77,10 @@ function sequenceInfo(seq) {
   if ((seq & 0x80000000) === 0) {
     const n = seq & 0x0000ffff;
     // A relative block delay counts chapters, so it reads in Roman numerals
-    // (■CXLIV = 144 blocks); a time delay is physical time and stays decimal.
+    // (■CXLIV = 144 blocks); a time delay is physical time, so it reads as
+    // an exact duration (⊥20h28m48s), the wire units kept in the hover.
     return (seq & 0x00400000)
-      ? { rbf: true, mark: `⊥${n}`, kind: 'time', title: `replaceable; relative locktime ${n} × 512 s after the input's confirmation` }
+      ? { rbf: true, mark: `⊥${durationFrom512s(n)}`, kind: 'time', title: `replaceable; relative locktime ${durationFrom512s(n)} (${n} × 512 s) after the input's confirmation` }
       : { rbf: true, mark: `■${toRoman(n)}`, kind: 'block', title: `replaceable; relative locktime ${n} block${n === 1 ? '' : 's'} after the input's confirmation` };
   }
   if (seq === 0xffffffff) return { rbf: false, mark: '●', kind: 'final', title: 'final — disables the transaction locktime for this input' };

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -336,6 +336,32 @@ function extranonceFromPush(push) {
 // the same explanatory title.
 const markToken = (glyph, text, title) => `<span class="op" title="${title}">${glyph}</span>${text ? `<span class="op-num" title="${title}">${text}</span>` : ''}`;
 
+// ─── data type marks ───────────────────────────────────────────────────
+//
+// A pushed datum whose kind is recognizable carries its type mark from the
+// Notation key -- 𝒫 public key, 𝒮 signature, ℋ hash, ℛ redeem script,
+// 𝒲 witness script, 𝒯 tapscript -- set just before its prose, so a script
+// reads as its pattern (⁶⁵𝒫 ∇) without consulting the key. Classification
+// is display-only annotation: it never changes what gets encoded.
+const dataMark = (sym, title) => `<span class="dt" title="${title}">${sym}</span>`;
+
+// Classify a script push -> a type mark, or '' when its kind isn't evident.
+// `compact` is derToCompact's verdict (a canonical DER signature). A 20-byte
+// push in script context is a HASH160; a 32-byte one is a hash -- except
+// directly after ① (a witness-v1 program: Taproot's tweaked output key), or
+// directly before a signature check (an x-only key inside a tapscript).
+// Non-canonical DER (0x30-led, signature-sized) still marks 𝒮.
+const SIG_CHECK_OPS = new Set([0xac, 0xad, 0xba]);
+function scriptDataMark(push, compact, prevOp, nextOp) {
+  const n = push.length / 2;
+  if (compact || (push.slice(0, 2) === '30' && n >= 68 && n <= 73)) return dataMark('𝒮', 'signature');
+  if (isPubkey(push)) return dataMark('𝒫', 'public key');
+  if (n === 32 && prevOp === 0x51) return dataMark('𝒫', 'public key — Taproot tweaked output key');
+  if (n === 32 && SIG_CHECK_OPS.has(nextOp)) return dataMark('𝒫', 'public key — x-only');
+  if (n === 20 || n === 32) return dataMark('ℋ', 'hash');
+  return '';
+}
+
 // data push to Glossia prose. Options: `eligible` (an OP_RETURN payload, or a
 // coinbase) turns on inline ASCII quoting for legible pushes; `nested` reveals a
 // script pushed as data -- a P2SH redeemScript, always the final push -- by
@@ -354,9 +380,11 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
   // the extranonce must directly follow it; anything else ends the hunt and
   // the push falls through to the ordinary treatment.
   let pre = preamble ? 'target' : 'done';
+  let prevOp = null;   // the opcode preceding a push -- context for its type mark
   toks.forEach((t, i) => {
     if (t.op !== undefined) {
       pre = 'done';
+      prevOp = t.op;
       parts.push(opToken(t.op));
     } else if (t.push !== undefined) {
       if (pre === 'target') {
@@ -379,14 +407,16 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
       const mark = pushToken(t.pushForm || 0, t.push.length / 2);
       if (!t.push) { parts.push(mark); return; }              // a zero-length extended push -- the mark alone
       if (i === redeemIdx && looksLikeScript(t.push)) {
-        parts.push(mark, renderScript(t.push, collect));      // reveal the redeemScript
+        // reveal the redeemScript, typed ℛ
+        parts.push(mark + dataMark('ℛ', 'redeem script — revealed as opcodes'), renderScript(t.push, collect));
         return;
       }
       if (eligible) {
         const found = findAsciiStrings(t.push);
         if (found.length) { parts.push(mark, found.map((s) => `“${escapeHtml(s)}”`).join(' ')); return; }
       }
-      parts.push(mark, collect(derToCompact(t.push) || t.push));   // a DER signature is stripped to r‖s‖sighash
+      const compact = derToCompact(t.push);                   // a DER signature is stripped to r‖s‖sighash
+      parts.push(mark + scriptDataMark(t.push, compact, prevOp, toks[i + 1]?.op), collect(compact || t.push));
     } else {
       pre = 'done';
       parts.push(collect(t.trunc));                           // malformed tail -- carry it as prose
@@ -458,16 +488,25 @@ function witnessScriptIndex(items) {
 
 // An input's witness stack (hex items) -> its footnote display. `encode` turns
 // a data item's hex into Glossia prose; the one script item, if present,
-// becomes opcode notation. Items are separated so each reads as its own stack
-// element.
+// becomes opcode notation, typed 𝒲 (a P2WSH witnessScript) or 𝒯 (a Taproot
+// tapscript, identified by the control block above it). Data items carry
+// their own type marks -- 𝒮 a signature, 𝒫 a key -- and items are separated
+// so each reads as its own stack element.
 export function renderWitness(items, encode) {
   if (!items || !items.length) return '∅';
   const scriptIdx = witnessScriptIndex(items);
+  const isTapscript = scriptIdx >= 0 && scriptIdx + 1 < items.length && isControlBlock(items[scriptIdx + 1]);
   return items
     .map((hex, i) => {
       if (!hex) return '<span class="wit-empty">∅</span>';    // an empty stack item
-      if (i === scriptIdx) return renderScript(hex, encode);
-      return encode(derToCompact(hex) || hex);                // a DER signature is stripped to r‖s‖sighash
+      if (i === scriptIdx) {
+        return (isTapscript ? dataMark('𝒯', 'tapscript — a Taproot leaf, revealed as opcodes') : dataMark('𝒲', 'witness script — revealed as opcodes'))
+          + ' ' + renderScript(hex, encode);
+      }
+      const compact = derToCompact(hex);                      // a DER signature is stripped to r‖s‖sighash
+      const dm = (compact || isSignature(hex)) ? dataMark('𝒮', 'signature')
+        : isPubkey(hex) ? dataMark('𝒫', 'public key') : '';
+      return (dm ? dm + ' ' : '') + encode(compact || hex);
     })
     .join('<span class="wit-sep"> · </span>');
 }

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -138,34 +138,63 @@ function escapeHtml(s) {
 // legible ASCII) -- exactly what carried the whole script before opcodes had
 // their own marks.
 
-// Opcode byte -> Glossia glyph, for the opcodes we've defined so far.
+// Opcode byte -> Glossia glyph. Every defined opcode has one; families share
+// a base glyph, with the house subscript convention distinguishing variants
+// (⧉₂ = 2DUP, °₄ = NOP4, ∇₊ = CHECKSIGADD). Disabled opcodes keep their
+// natural symbol like any other -- a script is notation whether or not the
+// network would still execute it.
 const OPCODE_SYMBOLS = {
-  0x00: '⓪',                                                  // OP_0
-  0x4f: '⊖',                                                  // OP_1NEGATE
-  0x51: '①', 0x52: '②', 0x53: '③', 0x54: '④', 0x55: '⑤',      // OP_1 …
+  // constants
+  0x00: '⓪', 0x4f: '⊖',
+  0x51: '①', 0x52: '②', 0x53: '③', 0x54: '④', 0x55: '⑤',
   0x56: '⑥', 0x57: '⑦', 0x58: '⑧', 0x59: '⑨', 0x5a: '⑩',
-  0x5b: '⑪', 0x5c: '⑫', 0x5d: '⑬', 0x5e: '⑭', 0x5f: '⑮', 0x60: '⑯',   // … OP_16
-  0x63: '⟨', 0x67: '│', 0x68: '⟩',                            // OP_IF / OP_ELSE / OP_ENDIF
-  0x69: '✓',                                                  // OP_VERIFY
-  0x6a: '¶',                                                  // OP_RETURN
-  0x75: '⌄', 0x76: '⧉',                                       // OP_DROP / OP_DUP
-  0x87: '=', 0x88: '≡',                                       // OP_EQUAL / OP_EQUALVERIFY
-  0xa6: 'ρ', 0xa7: 'σ', 0xa8: 'Σ', 0xa9: '⌖', 0xaa: '⌘',      // RIPEMD160 / SHA1 / SHA256 / HASH160 / HASH256
-  0xac: '∇', 0xad: '▼', 0xae: '◇', 0xaf: '◆',                 // CHECKSIG(VERIFY) / CHECKMULTISIG(VERIFY)
-  0xb1: 'τ', 0xb2: 'Δ',                                       // CLTV (absolute) / CSV (relative)
+  0x5b: '⑪', 0x5c: '⑫', 0x5d: '⑬', 0x5e: '⑭', 0x5f: '⑮', 0x60: '⑯',
+  // flow control
+  0x61: '°', 0x63: '⟨', 0x64: '¬⟨', 0x67: '│', 0x68: '⟩', 0x69: '✓', 0x6a: '¶',
+  // stack choreography (arrows), the alt-stack shelf pair, and depth/size
+  0x6b: '⇥', 0x6c: '⇤',
+  0x6d: '⌄₂', 0x6e: '⧉₂', 0x6f: '⧉₃', 0x70: '⇗₂', 0x71: '↻₂', 0x72: '⇄₂',
+  0x73: '⧉?', 0x74: '↕', 0x75: '⌄', 0x76: '⧉', 0x77: '⌦', 0x78: '⇗',
+  0x79: '⇡', 0x7a: '⥀', 0x7b: '↻', 0x7c: '⇄', 0x7d: '⇘',
+  // splice
+  0x7e: '⧺', 0x7f: '⊂', 0x80: '↤', 0x81: '↦', 0x82: 'ℓ',
+  // bitwise, and byte equality
+  0x83: '∼', 0x84: '∩', 0x85: '∪', 0x86: '⊻', 0x87: '=', 0x88: '≡',
+  // arithmetic and comparison
+  0x8b: '+₁', 0x8c: '−₁', 0x8d: '×₂', 0x8e: '÷₂', 0x8f: '∓', 0x90: '|·|',
+  0x91: '¬', 0x92: '≠₀',
+  0x93: '+', 0x94: '−', 0x95: '×', 0x96: '÷', 0x97: '%', 0x98: '«', 0x99: '»',
+  0x9a: '∧', 0x9b: '∨', 0x9c: '≐', 0x9d: '≑', 0x9e: '≠',
+  0x9f: '<', 0xa0: '>', 0xa1: '≤', 0xa2: '≥', 0xa3: '⊓', 0xa4: '⊔', 0xa5: '∈',
+  // crypto
+  0xa6: 'ρ', 0xa7: 'σ', 0xa8: 'Σ', 0xa9: '⌖', 0xaa: '⌘', 0xab: '‖',
+  0xac: '∇', 0xad: '▼', 0xae: '◇', 0xaf: '◆', 0xba: '∇₊',
+  // timelocks
+  0xb1: 'τ', 0xb2: 'Δ',
+  // no-ops
+  0xb0: '°₁', 0xb3: '°₄', 0xb4: '°₅', 0xb5: '°₆', 0xb6: '°₇',
+  0xb7: '°₈', 0xb8: '°₉', 0xb9: '°₁₀',
+  // reserved / invalid
+  0x50: '⊘', 0x62: '⊘ᵛ', 0x65: '⊘⟨', 0x66: '⊘¬⟨', 0x89: '⊘₁', 0x8a: '⊘₂',
+  0xff: '☒',
 };
 
-// Opcode byte -> Bitcoin Core name, the fallback for opcodes without a glyph.
-// Data-push opcodes (0x01-0x4b, OP_PUSHDATA1/2/4) never reach this table --
-// tokenizeScript surfaces them as their pushed data, not as an opcode.
+// Opcode byte -> Bitcoin Core name: the hover title carried on every glyph,
+// and the display fallback for undefined bytes (shown as OP_UNKNOWN).
 const OPCODE_NAMES = {
-  0x50: 'OP_RESERVED',
-  0x61: 'OP_NOP', 0x62: 'OP_VER', 0x64: 'OP_NOTIF', 0x65: 'OP_VERIF', 0x66: 'OP_VERNOTIF',
+  0x00: 'OP_0', 0x4f: 'OP_1NEGATE', 0x50: 'OP_RESERVED',
+  0x51: 'OP_1', 0x52: 'OP_2', 0x53: 'OP_3', 0x54: 'OP_4', 0x55: 'OP_5',
+  0x56: 'OP_6', 0x57: 'OP_7', 0x58: 'OP_8', 0x59: 'OP_9', 0x5a: 'OP_10',
+  0x5b: 'OP_11', 0x5c: 'OP_12', 0x5d: 'OP_13', 0x5e: 'OP_14', 0x5f: 'OP_15', 0x60: 'OP_16',
+  0x61: 'OP_NOP', 0x62: 'OP_VER', 0x63: 'OP_IF', 0x64: 'OP_NOTIF', 0x65: 'OP_VERIF', 0x66: 'OP_VERNOTIF',
+  0x67: 'OP_ELSE', 0x68: 'OP_ENDIF', 0x69: 'OP_VERIFY', 0x6a: 'OP_RETURN',
   0x6b: 'OP_TOALTSTACK', 0x6c: 'OP_FROMALTSTACK', 0x6d: 'OP_2DROP', 0x6e: 'OP_2DUP', 0x6f: 'OP_3DUP',
   0x70: 'OP_2OVER', 0x71: 'OP_2ROT', 0x72: 'OP_2SWAP', 0x73: 'OP_IFDUP', 0x74: 'OP_DEPTH',
+  0x75: 'OP_DROP', 0x76: 'OP_DUP',
   0x77: 'OP_NIP', 0x78: 'OP_OVER', 0x79: 'OP_PICK', 0x7a: 'OP_ROLL', 0x7b: 'OP_ROT', 0x7c: 'OP_SWAP', 0x7d: 'OP_TUCK',
   0x7e: 'OP_CAT', 0x7f: 'OP_SUBSTR', 0x80: 'OP_LEFT', 0x81: 'OP_RIGHT', 0x82: 'OP_SIZE',
   0x83: 'OP_INVERT', 0x84: 'OP_AND', 0x85: 'OP_OR', 0x86: 'OP_XOR',
+  0x87: 'OP_EQUAL', 0x88: 'OP_EQUALVERIFY',
   0x89: 'OP_RESERVED1', 0x8a: 'OP_RESERVED2',
   0x8b: 'OP_1ADD', 0x8c: 'OP_1SUB', 0x8d: 'OP_2MUL', 0x8e: 'OP_2DIV', 0x8f: 'OP_NEGATE',
   0x90: 'OP_ABS', 0x91: 'OP_NOT', 0x92: 'OP_0NOTEQUAL',
@@ -173,17 +202,36 @@ const OPCODE_NAMES = {
   0x9a: 'OP_BOOLAND', 0x9b: 'OP_BOOLOR', 0x9c: 'OP_NUMEQUAL', 0x9d: 'OP_NUMEQUALVERIFY', 0x9e: 'OP_NUMNOTEQUAL',
   0x9f: 'OP_LESSTHAN', 0xa0: 'OP_GREATERTHAN', 0xa1: 'OP_LESSTHANOREQUAL', 0xa2: 'OP_GREATERTHANOREQUAL',
   0xa3: 'OP_MIN', 0xa4: 'OP_MAX', 0xa5: 'OP_WITHIN',
+  0xa6: 'OP_RIPEMD160', 0xa7: 'OP_SHA1', 0xa8: 'OP_SHA256', 0xa9: 'OP_HASH160', 0xaa: 'OP_HASH256',
   0xab: 'OP_CODESEPARATOR',
-  0xb0: 'OP_NOP1', 0xb3: 'OP_NOP4', 0xb4: 'OP_NOP5', 0xb5: 'OP_NOP6', 0xb6: 'OP_NOP7',
+  0xac: 'OP_CHECKSIG', 0xad: 'OP_CHECKSIGVERIFY', 0xae: 'OP_CHECKMULTISIG', 0xaf: 'OP_CHECKMULTISIGVERIFY',
+  0xb0: 'OP_NOP1', 0xb1: 'OP_CHECKLOCKTIMEVERIFY', 0xb2: 'OP_CHECKSEQUENCEVERIFY',
+  0xb3: 'OP_NOP4', 0xb4: 'OP_NOP5', 0xb5: 'OP_NOP6', 0xb6: 'OP_NOP7',
   0xb7: 'OP_NOP8', 0xb8: 'OP_NOP9', 0xb9: 'OP_NOP10', 0xba: 'OP_CHECKSIGADD',
   0xff: 'OP_INVALIDOPCODE',
 };
 
-// One opcode -> its HTML: a defined glyph (accent-styled), else the OP_* name.
+// One opcode -> its HTML: the glyph (accent-styled, canonical OP_* name as
+// its hover title), or the bare OP_* name for a byte with no glyph. The
+// glyph is escaped -- a few marks (< > ≤-family) are HTML-significant.
 function opToken(code) {
   const sym = OPCODE_SYMBOLS[code];
-  if (sym) return `<span class="op">${sym}</span>`;
-  return `<span class="op-name">${OPCODE_NAMES[code] || 'OP_UNKNOWN'}</span>`;
+  const name = OPCODE_NAMES[code] || 'OP_UNKNOWN';
+  if (sym) return `<span class="op" title="${name}">${escapeHtml(sym)}</span>`;
+  return `<span class="op-name">${name}</span>`;
+}
+
+// A push opcode's mark: ↧ₙ for a direct push (OP_PUSHBYTES_n), ↡ₙ / ⇊ₙ / ⤋ₙ
+// for OP_PUSHDATA1/2/4, whose length rides in a 1/2/4-byte prefix. The
+// subscript is the byte count; the pushed data itself follows the mark, as
+// prose or an inline quote. (The coinbase preamble's βₙ and ⊕n marks fold
+// their push opcode in -- the mark alone determines the exact bytes.)
+const PUSH_GLYPHS = { 0: '↧', 1: '↡', 2: '⇊', 4: '⤋' };
+function pushToken(form, byteLen) {
+  const title = form
+    ? `OP_PUSHDATA${form} — push ${byteLen} bytes, the length in a ${form}-byte prefix`
+    : `OP_PUSHBYTES_${byteLen} — push the next ${byteLen} bytes`;
+  return `<span class="op op-push" title="${title}">${PUSH_GLYPHS[form] || '↧'}${toSubscript(byteLen)}</span>`;
 }
 
 // ─── DER signature compaction ──────────────────────────────────────────
@@ -304,7 +352,6 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
       pre = 'done';
       parts.push(opToken(t.op));
     } else if (t.push !== undefined) {
-      if (!t.push) return;                                    // empty push -- nothing to show
       if (pre === 'target') {
         pre = 'done';
         const bits = compactBitsFromPush(t.push);
@@ -322,15 +369,17 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
           return;
         }
       }
+      const mark = pushToken(t.pushForm || 0, t.push.length / 2);
+      if (!t.push) { parts.push(mark); return; }              // a zero-length extended push -- the mark alone
       if (i === redeemIdx && looksLikeScript(t.push)) {
-        parts.push(renderScript(t.push, collect));            // reveal the redeemScript
+        parts.push(mark, renderScript(t.push, collect));      // reveal the redeemScript
         return;
       }
       if (eligible) {
         const found = findAsciiStrings(t.push);
-        if (found.length) { parts.push(found.map((s) => `“${escapeHtml(s)}”`).join(' ')); return; }
+        if (found.length) { parts.push(mark, found.map((s) => `“${escapeHtml(s)}”`).join(' ')); return; }
       }
-      parts.push(collect(derToCompact(t.push) || t.push));    // a DER signature is stripped to r‖s‖sighash
+      parts.push(mark, collect(derToCompact(t.push) || t.push));   // a DER signature is stripped to r‖s‖sighash
     } else {
       pre = 'done';
       parts.push(collect(t.trunc));                           // malformed tail -- carry it as prose

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -361,13 +361,17 @@ export function findAsciiStrings(hex, minRun = ASCII_MIN_RUN) {
 //
 // A scriptSig / scriptPubKey (hex) -> an ordered list of tokens, so a caller
 // can render it as opcode notation. Each token is one of:
-//   { op }         a non-push opcode (its byte)
-//   { push }       a data push (the pushed bytes, hex) -- covers direct pushes
-//                  (0x01-0x4b) and OP_PUSHDATA1/2/4 alike; the push opcode
-//                  itself is implicit, surfaced as its data
-//   { trunc }      a malformed tail (a push claiming more bytes than remain),
-//                  carried verbatim so a caller never crashes on odd bytes
-// Byte-exact and lossless: concatenating the tokens back reproduces the script.
+//   { op }            a non-push opcode (its byte)
+//   { push, pushForm } a data push (the pushed bytes, hex). pushForm records
+//                     which push opcode carried it -- 0 for a direct push
+//                     (OP_PUSHBYTES_1..75), or 1/2/4 for OP_PUSHDATA1/2/4 --
+//                     so a caller can render the push opcode itself, not just
+//                     its data
+//   { trunc }         a malformed tail (a push claiming more bytes than remain),
+//                     carried verbatim so a caller never crashes on odd bytes
+// Byte-exact and lossless: the tokens carry everything needed to reproduce
+// the script (a direct push's length prefix is its data's length; a PUSHDATA's
+// form is in pushForm).
 export function tokenizeScript(hex) {
   const bytes = hexToBytes(hex);
   const toks = [];
@@ -378,7 +382,7 @@ export function tokenizeScript(hex) {
     if (op >= 0x01 && op <= 0x4b) {                    // direct push of `op` bytes
       const start = i + 1, end = start + op;
       if (end > bytes.length) { tail(i); break; }
-      toks.push({ push: bytesToHex(bytes.subarray(start, end)) });
+      toks.push({ push: bytesToHex(bytes.subarray(start, end)), pushForm: 0 });
       i = end;
     } else if (op === 0x4c || op === 0x4d || op === 0x4e) {   // OP_PUSHDATA1/2/4
       const nlen = op === 0x4c ? 1 : op === 0x4d ? 2 : 4;
@@ -387,7 +391,7 @@ export function tokenizeScript(hex) {
       for (let k = 0; k < nlen; k++) len += bytes[i + 1 + k] * 2 ** (8 * k);
       const start = i + 1 + nlen, end = start + len;
       if (end > bytes.length) { tail(i); break; }
-      toks.push({ push: bytesToHex(bytes.subarray(start, end)) });
+      toks.push({ push: bytesToHex(bytes.subarray(start, end)), pushForm: nlen });
       i = end;
     } else {                                           // a non-push opcode
       toks.push({ op });

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -126,6 +126,66 @@ export async function computeTxid(baseHex) {
   return bytesToHex(reverseBytes(await hash256(hexToBytes(baseHex))));
 }
 
+// ─── block header parsing ───────────────────────────────────────────────
+//
+// The 80-byte block header -- version, previous block hash, merkle root,
+// timestamp, bits (compact difficulty target), nonce. It never appears
+// inside a transaction; a transaction only references its confirming block
+// indirectly (a merkle proof), so this is a separate wire format, fetched
+// and parsed on its own.
+
+// Raw block header hex -> structured fields. Throws unless it's exactly 80
+// bytes -- a header has no variable-length parts to account for a short or
+// padded read. prevBlockHash/merkleRoot come back in display (byte-reversed)
+// order, same convention as parseTransaction's txid.
+export function parseBlockHeader(hex) {
+  const bytes = hexToBytes(hex);
+  if (bytes.length !== 80) throw new Error(`block header must be 80 bytes, got ${bytes.length}`);
+  const r = new Reader(bytes);
+  const version = r.u32le();
+  const prevBlockHash = bytesToHex(reverseBytes(r.bytesN(32)));
+  const merkleRoot = bytesToHex(reverseBytes(r.bytesN(32)));
+  const timestamp = r.u32le();
+  const bits = r.u32le();
+  const nonce = r.u32le();
+  return { version, prevBlockHash, merkleRoot, timestamp, bits, nonce };
+}
+
+// The header bytes hashed with double-SHA256 and byte-reversed -- a block's
+// hash, computed with no explorer API involved (mirrors computeTxid).
+export async function computeBlockHash(headerHex) {
+  return bytesToHex(reverseBytes(await hash256(hexToBytes(headerHex))));
+}
+
+// ─── compact difficulty target (nBits) ──────────────────────────────────
+//
+// nBits packs a 256-bit target into 4 bytes: the top byte is a byte-length
+// exponent, the low 3 bytes a mantissa -- arith_uint256::SetCompact in
+// Bitcoin Core. Unpacked two ways: the full 32-byte target (so its leading
+// zero bytes -- literally the proof-of-work requirement -- are visible in
+// full, unlike a mined hash's they're never dropped here) and a difficulty
+// ratio against the genesis block's target.
+
+// nBits -> the 256-bit target, as 64 hex chars (32 bytes, display order).
+export function bitsToTargetHex(bits) {
+  const exponent = bits >>> 24;
+  const mantissa = BigInt(bits & 0x007fffff);   // top bit of the 3-byte mantissa is a sign flag, masked off
+  const target = exponent <= 3 ? mantissa >> BigInt(8 * (3 - exponent)) : mantissa << BigInt(8 * (exponent - 3));
+  return target.toString(16).padStart(64, '0');
+}
+
+// nBits -> difficulty relative to the genesis block's target (defined as
+// difficulty 1). Mirrors Bitcoin Core's GetDifficulty: shift by whole bytes
+// in floating point rather than dividing the raw 256-bit targets, which
+// would overflow a double.
+export function bitsToDifficulty(bits) {
+  let shift = bits >>> 24;
+  let diff = 0x0000ffff / (bits & 0x00ffffff);
+  while (shift < 29) { diff *= 256; shift++; }
+  while (shift > 29) { diff /= 256; shift--; }
+  return diff;
+}
+
 // ─── address derivation from scriptPubKey (no external library) ──────────
 
 const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';


### PR DESCRIPTION
Each chapter now opens with its block header, independently parsed from
the raw 80-byte header and re-hashed to confirm it matches the
requested block rather than trusting the API's own decoded fields.

The previous-block hash and merkle root are genuinely opaque 32-byte
hashes, so they're Glossia-encoded like the existing chapter/verse
hashes (genesis's null previous-block shows as ∅). Version, timestamp,
the nonce and the compact difficulty target (nBits) are small
structural numbers, not entropy, so they're decoded and shown
literally: nBits is unpacked into the full 256-bit target and a
difficulty ratio (shown on hover), and the nonce -- previously entirely
absent, since it lives in the header rather than any transaction -- is
now the literal number a miner searched over.