### PR TITLE
Tidy Bitcoin book table of contents and declutter notation key

### DIFF
--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -308,9 +308,12 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    operational opcodes -- it frames the data that follows rather than acting
    on the stack, so it shouldn't compete with the prose it introduces. */
 .op-push { color: var(--meta); }
-/* A data type mark (𝓅 𝓈 𝒽 𝓇 𝓌 𝓉): names what the prose after it carries.
+/* A data type mark (p s h r w t): names what the prose after it carries.
    Dim like the push count it rides with -- annotation, not instruction. */
-.dt { color: var(--dim); font-style: normal; }
+/* Data marks (p s h r w t) in live prose: bold, since a confirmed
+   transaction's data is on chain. In the pattern table the same letters go
+   plain where a spend introduces them at validation (see .seq.exec .ph). */
+.dt { color: var(--dim); font-style: normal; font-weight: 700; }
 /* A witness footnote is a stack of items; a thin middot separates each, and an
    empty stack item shows as ∅. */
 .wit-sep, .wit-empty { color: var(--meta); font-style: normal; }
@@ -376,6 +379,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .glyph-row .g i { font-style: normal; opacity: .5; font-size: .82em; }
 .glyph-row .m { font: 400 13px/1.45 'Public Sans', sans-serif; color: var(--dim); }
 .glyph-row .m b { color: var(--ink-soft); font-weight: 500; }
+.notation-note { margin: 12px 0 0; font-size: 12px; line-height: 1.5; color: var(--meta); }
 /* Common script patterns: one row per payment type, read as a state
    transition -- the unspent output at rest (UTXO), the script a node runs then
    discards (validator), and the same output once spent (STXO). Wide, so it
@@ -465,49 +469,49 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <div class="pattern-table">
           <span class="phead"></span><span class="phead">UTXO</span><span class="phead">Validator</span><span class="phead">STXO</span>
           <span class="pname">P2PK</span>
-            <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">𝓅</span> <span class="op">∇</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph chain">𝓅</span> <span class="op">∇</span></span>
-            <span class="seq"><span class="ph">𝓈</span></span>
+            <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">p</span> <span class="op">∇</span></span>
+            <span class="seq exec"><span class="ph">s</span> <span class="ph chain">p</span> <span class="op">∇</span></span>
+            <span class="seq"><span class="ph">s</span></span>
           <span class="pname">P2PKH</span>
-            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
-            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
+            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">h</span> <span class="op">≡</span> <span class="op">∇</span></span>
+            <span class="seq exec"><span class="ph">s</span> <span class="ph">p</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">≡</span> <span class="op">∇</span></span>
+            <span class="seq"><span class="ph">s</span> <span class="ph">p</span></span>
           <span class="pname">Multisig</span>
-            <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
-            <span class="seq exec"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">◇</span></span>
-            <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span></span>
+            <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">p</span> <span class="op op-push">³³</span><span class="ph">p</span> <span class="op op-push">³³</span><span class="ph">p</span> <span class="op">③</span> <span class="op">◇</span></span>
+            <span class="seq exec"><span class="op">⓪</span> <span class="ph">s</span> <span class="ph">s</span> <span class="op">◇</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">s</span> <span class="ph">s</span></span>
           <span class="pname">P2SH</span>
-            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
-            <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(𝓇)</span></span>
-            <span class="seq"><span class="op">(𝓇)</span></span>
+            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">h</span> <span class="op">=</span></span>
+            <span class="seq exec"><span class="ph">r</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(r)</span></span>
+            <span class="seq"><span class="op">(r)</span></span>
           <span class="pname">P2SH · 2-of-3</span>
-            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
-            <span class="seq exec"><span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(</span><span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span><span class="op">)</span></span>
-            <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
+            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">h</span> <span class="op">=</span></span>
+            <span class="seq exec"><span class="op">②</span> <span class="ph">p</span> <span class="ph">p</span> <span class="ph">p</span> <span class="op">③</span> <span class="op">◇</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(</span><span class="op">②</span> <span class="ph">p</span> <span class="ph">p</span> <span class="ph">p</span> <span class="op">③</span> <span class="op">◇</span><span class="op">)</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">s</span> <span class="ph">s</span> <span class="op">②</span> <span class="ph">p</span> <span class="ph">p</span> <span class="ph">p</span> <span class="op">③</span> <span class="op">◇</span></span>
           <span class="pname">P2WPKH</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
-            <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">h</span></span>
+            <span class="seq exec"><span class="ph">s</span> <span class="ph">p</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">≡</span> <span class="op">∇</span></span>
+            <span class="seq">∅ · <span class="ph">s</span> <span class="ph">p</span></span>
           <span class="pname">P2WSH</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(𝓌)</span></span>
-            <span class="seq">∅ · <span class="op">(𝓌)</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">h</span></span>
+            <span class="seq exec"><span class="ph">w</span> <span class="op">Σ</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(w)</span></span>
+            <span class="seq">∅ · <span class="op">(w)</span></span>
           <span class="pname">Lightning HTLC</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(</span><span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span><span class="op">)</span></span>
-            <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝒽</span> <span class="ph">𝓌</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">h</span></span>
+            <span class="seq exec"><span class="ph">w</span> <span class="op">Σ</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(</span><span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span><span class="op">)</span></span>
+            <span class="seq">∅ · <span class="ph">s</span> <span class="ph">h</span> <span class="ph">w</span></span>
           <span class="pname">P2TR key</span>
-            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="op">∇</span></span>
-            <span class="seq">∅ · <span class="ph">𝓈</span></span>
+            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">p</span></span>
+            <span class="seq exec"><span class="ph">s</span> <span class="op">∇</span></span>
+            <span class="seq">∅ · <span class="ph">s</span></span>
           <span class="pname">P2TR script</span>
-            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="op">(𝓉)</span></span>
-            <span class="seq">∅ · <span class="op">(𝓉)</span></span>
+            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">p</span></span>
+            <span class="seq exec"><span class="ph">s</span> <span class="ph">t</span> <span class="op">(t)</span></span>
+            <span class="seq">∅ · <span class="op">(t)</span></span>
           <span class="pname">Data</span>
             <span class="seq none">—</span>
             <span class="seq none">—</span>
-            <span class="seq"><span class="op">¶</span> <span class="op op-push">ⁿ</span><span class="ph">…</span></span>
+            <span class="seq"><span class="op">¶</span> <span class="op op-push">ⁿ</span></span>
         </div>
         </div>
       </div>
@@ -629,7 +633,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">⟨ │ ⟩</span><span class="m">if … else … end</span></div>
           <div class="glyph-row"><span class="g">¬⟨</span><span class="m"><b>if not</b></span></div>
-          <div class="glyph-row"><span class="g">( )</span><span class="m"><b>run</b> the revealed script (𝓇 𝓌 𝓉)</span></div>
+          <div class="glyph-row"><span class="g">( )</span><span class="m"><b>run</b> the revealed script (r w t)</span></div>
           <div class="glyph-row"><span class="g">✓</span><span class="m">assert true</span></div>
           <div class="glyph-row"><span class="g">¶</span><span class="m"><b>data output</b> — provably unspendable</span></div>
           <div class="glyph-row"><span class="g">° °<i>n</i></span><span class="m"><b>no-op</b> · numbered no-ops</span></div>
@@ -643,13 +647,14 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <div class="notation-group">
         <h4>Data</h4>
         <div class="glyph-grid">
-          <div class="glyph-row"><span class="g">𝓅</span><span class="m"><b>public key</b></span></div>
-          <div class="glyph-row"><span class="g">𝓈</span><span class="m"><b>signature</b></span></div>
-          <div class="glyph-row"><span class="g">𝒽</span><span class="m"><b>hash</b></span></div>
-          <div class="glyph-row"><span class="g">𝓇</span><span class="m"><b>redeem script</b> (inside P2SH)</span></div>
-          <div class="glyph-row"><span class="g">𝓌</span><span class="m"><b>witness script</b> (inside P2WSH)</span></div>
-          <div class="glyph-row"><span class="g">𝓉</span><span class="m"><b>tapscript</b> (a Taproot leaf)</span></div>
+          <div class="glyph-row"><span class="g"><b>p</b></span><span class="m"><b>public key</b></span></div>
+          <div class="glyph-row"><span class="g"><b>s</b></span><span class="m"><b>signature</b></span></div>
+          <div class="glyph-row"><span class="g"><b>h</b></span><span class="m"><b>hash</b></span></div>
+          <div class="glyph-row"><span class="g"><b>r</b></span><span class="m"><b>redeem script</b> (inside P2SH)</span></div>
+          <div class="glyph-row"><span class="g"><b>w</b></span><span class="m"><b>witness script</b> (inside P2WSH)</span></div>
+          <div class="glyph-row"><span class="g"><b>t</b></span><span class="m"><b>tapscript</b> (a Taproot leaf)</span></div>
         </div>
+        <p class="notation-note"><b>Bold</b> where the datum is on chain — a lock, or what a spend writes; <b>plain</b> where a spend introduces it at validation.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -386,8 +386,14 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .pattern-table .phead { color: var(--accent); }
 .pattern-table .seq { font: 400 16px/1.5 'Newsreader', system-ui, 'Segoe UI Symbol', serif; color: var(--ink-soft); white-space: nowrap; }
 .pattern-table .none { color: var(--meta); }
-.pattern-table .to { color: var(--meta); font-size: .8em; padding: 0 .15em; }
-.ph { color: var(--dim); font-style: italic; }
+/* Gold marks anything read from or written to the chain -- the lock, the
+   authorization, and the data (keys, sigs, hashes, scripts) that flows through
+   a spend. White marks the ephemeral execution: the operations a node applies
+   in the middle column and the ⇒ ✓ it reduces to, none of which is ever stored.
+   So chain data stays gold even while it threads through the white run. */
+.pattern-table .ph { color: var(--accent); font-style: normal; }
+.pattern-table .seq.exec .op { color: var(--ink); }
+.pattern-table .to { color: var(--ink); font-size: .8em; padding: 0 .15em; }
 .notation-note { margin: 11px 0 0; font-size: 12px; line-height: 1.5; color: var(--meta); }
 @media (max-width: 480px) { .glyph-grid { grid-template-columns: 1fr; } }
 </style>
@@ -458,39 +464,39 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <span class="phead"></span><span class="phead">Initial state</span><span class="phead">Node executes</span><span class="phead">Written</span>
           <span class="pname">P2PK</span>
             <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">𝓅</span> <span class="op">∇</span></span>
-            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq"><span class="ph">𝓈</span></span>
           <span class="pname">P2PKH</span>
             <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
-            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
           <span class="pname">Multisig</span>
             <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
-            <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span></span>
           <span class="pname">P2SH</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
-            <span class="seq"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓇</span></span>
           <span class="pname">P2WPKH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span></span>
-            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
           <span class="pname">P2WSH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · ∅ <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓌</span></span>
           <span class="pname">Lightning HTLC</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝒽</span> <span class="ph">𝓌</span></span>
           <span class="pname">P2TR key</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
-            <span class="seq"><span class="ph">𝓈</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span></span>
           <span class="pname">P2TR script</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
-            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="ph">…</span></span>
           <span class="pname">Data</span>
             <span class="seq none">—</span>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -313,7 +313,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 /* Data marks (p s h r w t) in live prose: bold, since a confirmed
    transaction's data is on chain. In the pattern table the same letters go
    plain where a spend introduces them at validation (see .seq.exec .ph). */
-.dt { color: var(--dim); font-style: normal; font-weight: 700; }
+.dt { color: var(--accent); font-style: normal; font-weight: 700; }
 /* A witness footnote is a stack of items; a thin middot separates each, and an
    empty stack item shows as ∅. */
 .wit-sep, .wit-empty { color: var(--meta); font-style: normal; }
@@ -379,6 +379,8 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .glyph-row .g i { font-style: normal; opacity: .5; font-size: .82em; }
 .glyph-row .m { font: 400 13px/1.45 'Public Sans', sans-serif; color: var(--dim); }
 .glyph-row .m b { color: var(--ink-soft); font-weight: 500; }
+/* Data-type letters (p s h r w t) glow gold in the key, as they do on chain. */
+.glyph-row .g b { color: var(--accent); }
 .notation-note { margin: 12px 0 0; font-size: 12px; line-height: 1.5; color: var(--meta); }
 /* Common script patterns: one row per payment type, read as a state
    transition -- the unspent output at rest (UTXO), the script a node runs then

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -389,16 +389,14 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 /* Gold and bold mark what the chain keeps: the lock (initial state), the
    authorization once written, and any datum read from a confirmed output -- a
    committed hash. White, regular weight marks the ephemeral: the operations a
-   node runs and the ⇒ ✓ it reduces to, plus the transaction's own data, which
-   stays unverified until a block puts it on chain (where it turns gold). Bold
-   carries the split into a black-and-white print. */
+   node runs, plus the transaction's own data, which stays unverified until a
+   block puts it on chain (where it turns gold). Bold carries the split into a
+   black-and-white print. */
 .pattern-table .op { font-weight: 700; }
 .pattern-table .op-push { font-weight: 400; }
 .pattern-table .ph { color: var(--accent); font-style: normal; font-weight: 700; }
 .pattern-table .seq.exec .op, .pattern-table .seq.exec .ph { color: var(--ink); font-weight: 400; }
 .pattern-table .seq.exec .ph.chain { color: var(--accent); font-weight: 700; }
-.pattern-table .to { color: var(--ink); font-weight: 400; font-size: .8em; padding: 0 .15em; }
-.notation-note { margin: 11px 0 0; font-size: 12px; line-height: 1.5; color: var(--meta); }
 @media (max-width: 480px) { .glyph-grid { grid-template-columns: 1fr; } }
 </style>
 </head>
@@ -468,39 +466,39 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <span class="phead"></span><span class="phead">Initial state</span><span class="phead">Node executes</span><span class="phead">Written</span>
           <span class="pname">P2PK</span>
             <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">𝓅</span> <span class="op">∇</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph chain">𝓅</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph chain">𝓅</span> <span class="op">∇</span></span>
             <span class="seq"><span class="ph">𝓈</span></span>
           <span class="pname">P2PKH</span>
             <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
             <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
           <span class="pname">Multisig</span>
             <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
-            <span class="seq exec"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">◇</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span></span>
           <span class="pname">P2SH</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
-            <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">◇</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓇</span></span>
           <span class="pname">P2WPKH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
           <span class="pname">P2WSH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">◇</span></span>
             <span class="seq">∅ · ∅ <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓌</span></span>
           <span class="pname">Lightning HTLC</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝒽</span> <span class="ph">𝓌</span></span>
           <span class="pname">P2TR key</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="op">∇</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span></span>
           <span class="pname">P2TR script</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓉</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="ph">…</span></span>
           <span class="pname">Data</span>
             <span class="seq none">—</span>
@@ -508,7 +506,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq"><span class="op">¶</span> <span class="op op-push">ⁿ</span><span class="ph">…</span></span>
         </div>
         </div>
-        <p class="notation-note">Each row is a spend read as a state transition: <b>initial state</b> is the lock at rest in the UTXO set; <b>node executes</b> is the script a validator runs over the offered data, then discards (⇒ ✓); <b>written</b> is what the spend leaves on chain — its authorization, in the scriptSig or (∅ then) the witness. <b>Gold, bold</b> is what the chain keeps — the lock, a committed 𝒽 read from it, and the authorization once written; <b>white</b> is the ephemeral run and the transaction's own data (𝓈 𝓅 𝓇 𝓌 𝓉), which stays unverified until a block puts it on chain, where it turns gold. (The weight carries the split into a colorless print.) A hash check reads its committed 𝒽 from the lock and its <i>preimage</i> from the input — a pubkey 𝓅, or a whole revealed script 𝓇 / 𝓌 (which may carry its own inner hash, as an HTLC's does). Executing is where the segwit forms come clear: P2WPKH runs the very same ⧉ ⌖ 𝒽 ≡ ∇ as P2PKH.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -476,7 +476,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
             <span class="seq exec"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">◇</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span></span>
-          <span class="pname">P2SH</span>
+          <span class="pname">P2SH · 2-of-3</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
             <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">◇</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓇</span></span>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -476,10 +476,14 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
             <span class="seq exec"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">◇</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span></span>
+          <span class="pname">P2SH</span>
+            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
+            <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(𝓇)</span></span>
+            <span class="seq"><span class="ph">…</span> <span class="ph">𝓇</span></span>
           <span class="pname">P2SH · 2-of-3</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
-            <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">◇</span></span>
-            <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓇</span></span>
+            <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(</span><span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span><span class="op">)</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
           <span class="pname">P2WPKH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span></span>
             <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
@@ -625,6 +629,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">⟨ │ ⟩</span><span class="m">if … else … end</span></div>
           <div class="glyph-row"><span class="g">¬⟨</span><span class="m"><b>if not</b></span></div>
+          <div class="glyph-row"><span class="g">( )</span><span class="m"><b>run</b> the revealed script (𝓇 𝓌 𝓉)</span></div>
           <div class="glyph-row"><span class="g">✓</span><span class="m">assert true</span></div>
           <div class="glyph-row"><span class="g">¶</span><span class="m"><b>data output</b> — provably unspendable</span></div>
           <div class="glyph-row"><span class="g">° °<i>n</i></span><span class="m"><b>no-op</b> · numbered no-ops</span></div>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -377,20 +377,20 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .glyph-row .m { font: 400 13px/1.45 'Public Sans', sans-serif; color: var(--dim); }
 .glyph-row .m b { color: var(--ink-soft); font-weight: 500; }
 /* Common script patterns: one row per payment type, read as a state
-   transition -- the lock at rest (initial state), the script a node runs then
-   discards (executed), and what the spend leaves on chain (written). Wide, so
-   it scrolls in its own container on narrow screens. */
+   transition -- the unspent output at rest (UTXO), the script a node runs then
+   discards (validator), and the same output once spent (STXO). Wide, so it
+   scrolls in its own container on narrow screens. */
 .pattern-scroll { overflow-x: auto; }
 .pattern-table { display: grid; grid-template-columns: repeat(4, max-content); gap: 9px 22px; align-items: baseline; }
 .pattern-table .phead, .pattern-table .pname { font: 600 10px/1.5 'IBM Plex Mono',monospace; letter-spacing: .06em; text-transform: uppercase; color: var(--meta); white-space: nowrap; }
 .pattern-table .phead { color: var(--accent); }
 .pattern-table .seq { font: 400 16px/1.5 'Newsreader', system-ui, 'Segoe UI Symbol', serif; color: var(--ink-soft); white-space: nowrap; }
 .pattern-table .none { color: var(--meta); }
-/* Gold and bold mark what the chain keeps: the lock (initial state), the
-   authorization once written, and any datum read from a confirmed output -- a
-   committed hash. White, regular weight marks the ephemeral: the operations a
-   node runs, plus the transaction's own data, which stays unverified until a
-   block puts it on chain (where it turns gold). Bold carries the split into a
+/* Gold and bold mark what the chain keeps: the UTXO's lock, the STXO's
+   authorization, and any datum read from a confirmed output -- a committed
+   hash. White, regular weight marks the ephemeral validator: the operations it
+   runs, plus the transaction's own data, which stays unverified until a block
+   puts it on chain (where it turns gold). Bold carries the split into a
    black-and-white print. */
 .pattern-table .op { font-weight: 700; }
 .pattern-table .op-push { font-weight: 400; }
@@ -463,7 +463,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Common script patterns</h4>
         <div class="pattern-scroll">
         <div class="pattern-table">
-          <span class="phead"></span><span class="phead">Initial state</span><span class="phead">Node executes</span><span class="phead">Written</span>
+          <span class="phead"></span><span class="phead">UTXO</span><span class="phead">Validator</span><span class="phead">STXO</span>
           <span class="pname">P2PK</span>
             <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">𝓅</span> <span class="op">∇</span></span>
             <span class="seq exec"><span class="ph">𝓈</span> <span class="ph chain">𝓅</span> <span class="op">∇</span></span>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -361,7 +361,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .notation summary::before { content: '+ '; color: var(--accent); }
 .notation[open] summary::before { content: '– '; }
 .notation-body { margin-top: 14px; }
-.notation-lede { margin: 0 0 22px; font-size: 12.5px; line-height: 1.5; color: var(--meta); }
 .notation-group { margin: 0 0 22px; }
 .notation-group > h4 {
   margin: 0 0 11px; font: 600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.18em;
@@ -377,7 +376,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .glyph-row .g i { font-style: normal; opacity: .5; font-size: .82em; }
 .glyph-row .m { font: 400 13px/1.45 'Public Sans', sans-serif; color: var(--dim); }
 .glyph-row .m b { color: var(--ink-soft); font-weight: 500; }
-.notation-note { margin: 9px 0 0; font-size: 12px; font-style: italic; color: var(--meta); }
 /* Common script patterns: one row per payment type, its marks split across
    where they live on the wire -- input (scriptSig), output (scriptPubKey),
    witness. Wide, so it scrolls in its own container on narrow screens. */
@@ -450,11 +448,8 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <details class="notation">
     <summary>Notation</summary>
     <div class="notation-body">
-      <p class="notation-lede">A key to the sigla used in the manuscript: the glyphs that notate a Bitcoin <b>script's opcodes</b>, and the <b>marks</b> drawn in each transaction's margins. Every defined opcode has a glyph, push instructions included; pushed data — keys, hashes, signatures — is rendered as prose after its push mark. Hovering any glyph names its opcode.</p>
-
       <div class="notation-group">
         <h4>Common script patterns</h4>
-        <p class="notation-note">A payment's kind is legible in its marks — one row per type, split across where its pieces live on the wire. The output column is the lock; the input and witness columns are the spend that opens it.</p>
         <div class="pattern-scroll">
         <div class="pattern-table">
           <span class="phead"></span><span class="phead">Input</span><span class="phead">Output</span><span class="phead">Witness</span>
@@ -500,7 +495,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq none">—</span>
         </div>
         </div>
-        <p class="notation-note">Read the proof's migration down the table: legacy types carry it in the input, segwit types leave the input empty (∅) and move it to the witness. The push superscripts are the patterns' fingerprints — P2WPKH and P2WSH share the witness-v0 mark <span class="op" style="font-style:normal">⓪</span> and differ only in the hashed length, ²⁰ a HASH160 of a key, ³² a SHA-256 of a script. A script hidden behind a hash — 𝓇, 𝓌, 𝓉 — is revealed in the same notation when spent: an m-of-n <span class="op" style="font-style:normal">◇</span>, or an HTLC <span class="op" style="font-style:normal">⟨ Σ</span> <span class="ph">𝒽</span> <span class="op" style="font-style:normal">≡</span> <span class="ph">𝓅</span> <span class="op" style="font-style:normal">│</span> <span class="ph">n</span> <span class="op" style="font-style:normal">τ ⌄</span> <span class="ph">𝓅</span> <span class="op" style="font-style:normal">⟩ ∇</span>. That hash-timelock is what a <b>Lightning</b> channel writes on-chain when it force-closes: the channel's funding output is a P2WSH 2-of-2 <span class="op" style="font-style:normal">◇</span>, and each in-flight payment is the Lightning HTLC row above — a P2WSH whose witnessScript <span class="ph">𝓌</span> is that hash-timelock, spent either by revealing the preimage <span class="ph">𝒽</span> or by waiting out the timelock <span class="op" style="font-style:normal">τ</span>. In witness cells, · separates stack items and ∅ is an empty item (the multisig dummy) — a witness is a stack, not a script, so ⓪ the opcode never appears there; in the P2SH spend's input, which IS script, the dummy is the real ⓪ byte. The Data output is provably unspendable, so it has no spend at all.</p>
       </div>
 
       <div class="notation-group">
@@ -509,7 +503,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">²⁰</span><span class="m"><b>push</b> — the bare superscript is the byte count (²⁰ pushes twenty)</span></div>
           <div class="glyph-row"><span class="g">↧<i>n</i> ⇊<i>n</i> ⤋<i>n</i></span><span class="m">extended push — length in a 1 / 2 / 4-byte prefix</span></div>
         </div>
-        <p class="notation-note">The pushed bytes follow the mark, as prose or an inline quote; arrow weight matches prefix width. The coinbase preamble's β<i>n</i> and η<i>n</i> fold their push in — the mark alone determines the exact bytes.</p>
       </div>
 
       <div class="notation-group">
@@ -521,7 +514,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">◆</span><span class="m">check m-of-n, <b>else fail</b></span></div>
           <div class="glyph-row"><span class="g">∇₊</span><span class="m">check a signature, <b>tallying</b> (tapscript multisig)</span></div>
         </div>
-        <p class="notation-note">A triangle is one signer, a diamond is many; a filled shape must hold or the script fails.</p>
       </div>
 
       <div class="notation-group">
@@ -533,7 +525,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">σ</span><span class="m">SHA-1</span></div>
           <div class="glyph-row"><span class="g">ρ</span><span class="m">RIPEMD-160</span></div>
         </div>
-        <p class="notation-note">Lower-case Greek is a 160-bit digest, upper-case a 256-bit one. ⌖ points to where value is sent; ⌘ marks what names a transaction.</p>
       </div>
 
       <div class="notation-group">
@@ -542,7 +533,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">τ</span><span class="m"><b>absolute</b> — not before a fixed time or block</span></div>
           <div class="glyph-row"><span class="g">Δ</span><span class="m"><b>relative</b> — a delay after this coin confirmed</span></div>
         </div>
-        <p class="notation-note">τ is a fixed point in time; Δ is an interval measured from the moment the coin was received.</p>
       </div>
 
       <div class="notation-group">
@@ -560,7 +550,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b> — a valid hash opens with n zero bits</span></div>
           <div class="glyph-row"><span class="g">η<i>n</i></span><span class="m"><b>extranonce</b> — search space beyond the header's η</span></div>
         </div>
-        <p class="notation-note">β's subscript is the target's demand in leading zero bits — β₃₂ at genesis (difficulty 1), climbing as difficulty rises; each +1 doubles the work. The exact target rides in β's hover. The chain's earliest coinbases open with this preamble — the miner's restatement of the header's target, then the counter it rolled once the header's 32-bit nonce ran out — decoded to marks so any embedded words (the genesis headline) lead the text.</p>
       </div>
 
       <div class="notation-group">
@@ -571,7 +560,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b>, as in the preamble</span></div>
           <div class="glyph-row"><span class="g">η<i>n</i></span><span class="m">the <b>nonce</b> the miner landed on</span></div>
         </div>
-        <p class="notation-note">The chapter head runs the header's fields in wire order: version, the previous chapter's hash as prose (∅ for genesis), the merkle root as prose, the timestamp, β, η. The header's η and the coinbase preamble's extranonce together are the miner's full search space.</p>
       </div>
 
       <div class="notation-group">
@@ -590,7 +578,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">↕</span><span class="m"><b>depth</b> of the stack</span></div>
           <div class="glyph-row"><span class="g">⇥ ⇤</span><span class="m"><b>shelve / retrieve</b> via the alt stack</span></div>
         </div>
-        <p class="notation-note">A subscript doubles or triples the choreography: ⧉₂ ⧉₃ duplicate pairs and triples, ⌄₂ drops a pair, ⇄₂ ↻₂ ⇗₂ work on pairs.</p>
       </div>
 
       <div class="notation-group">
@@ -609,7 +596,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">« »</span><span class="m">shift left · right</span></div>
           <div class="glyph-row"><span class="g">= ≡</span><span class="m">bytes equal? · equal, <b>else fail</b></span></div>
         </div>
-        <p class="notation-note">= compares raw bytes; ≐ compares as numbers. The doubled form is the else-fail variant, as everywhere in this notation.</p>
       </div>
 
       <div class="notation-group">
@@ -621,7 +607,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">∼ ∩ ∪ ⊻</span><span class="m">bitwise invert · and · or · xor</span></div>
           <div class="glyph-row"><span class="g">ℓ</span><span class="m"><b>length</b> of the top item</span></div>
         </div>
-        <p class="notation-note">The splice and bitwise family (and × ÷ % « » above) has been disabled since 2010 — but a script is notation whether or not the network would still run it.</p>
       </div>
 
       <div class="notation-group">
@@ -649,7 +634,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">𝓌</span><span class="m"><b>witness script</b> (inside P2WSH)</span></div>
           <div class="glyph-row"><span class="g">𝓉</span><span class="m"><b>tapscript</b> (a Taproot leaf)</span></div>
         </div>
-        <p class="notation-note">Type marks naming what a push carries. On the page they sit between the push count and the prose (⁶⁵𝓅 …), wherever the kind is recognizable from the bytes and their context; a push that could be anything stays unmarked.</p>
       </div>
 
       <div class="notation-group">
@@ -673,7 +657,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">∅</span><span class="m"><b>empty</b> — a coinbase's absent prevout, a segwit input's zero-byte script, an empty witness item</span></div>
           <div class="glyph-row"><span class="g">§<i>n</i></span><span class="m">verse — the transaction's position</span></div>
         </div>
-        <p class="notation-note">■ marks block-height and Τ marks time, in both places; a square reads as the whole transaction, a circle as one input. An absolute height is a place in the book, so it is cited; a relative block delay is a count of chapters, so it is a Roman numeral. Time renders physically: an absolute lock as its UTC date, a relative one as a duration.</p>
       </div>
     </div>
   </details>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -462,7 +462,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq"><span class="ph">𝓈</span></span>
           <span class="pname">P2PKH</span>
             <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
-            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
           <span class="pname">Multisig</span>
             <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
@@ -470,19 +470,19 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span></span>
           <span class="pname">P2SH</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
-            <span class="seq"><span class="ph">𝓇</span> <span class="op">⌖</span><span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓇</span></span>
           <span class="pname">P2WPKH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span></span>
-            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
           <span class="pname">P2WSH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq"><span class="ph">𝓌</span> <span class="op">Σ</span><span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · ∅ <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓌</span></span>
           <span class="pname">Lightning HTLC</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq"><span class="ph">𝓌</span> <span class="op">Σ</span><span class="op">=</span> <span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝒽</span> <span class="ph">𝓌</span></span>
           <span class="pname">P2TR key</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
@@ -498,7 +498,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq"><span class="op">¶</span> <span class="op op-push">ⁿ</span><span class="ph">…</span></span>
         </div>
         </div>
-        <p class="notation-note">Each row is a spend read as a state transition: <b>initial state</b> is the lock at rest in the UTXO set; <b>node executes</b> is the script a validator runs over the offered data, then discards (⇒ ✓); <b>written</b> is what the spend leaves on chain — its authorization, in the scriptSig or (∅ then) the witness. A node keeps state and authorizations, never the execution; the new outputs a spend also writes are each a fresh lock — a later row's initial state. Executing is where the segwit forms come clear: P2WPKH runs the very same ⧉ ⌖ ≡ ∇ as P2PKH, and a hash-locked script (𝓇 𝓌 𝓉) is revealed and run only when spent.</p>
+        <p class="notation-note">Each row is a spend read as a state transition: <b>initial state</b> is the lock at rest in the UTXO set; <b>node executes</b> is the script a validator runs over the offered data, then discards (⇒ ✓); <b>written</b> is what the spend leaves on chain — its authorization, in the scriptSig or (∅ then) the witness. A node keeps state and authorizations, never the execution; the new outputs a spend also writes are each a fresh lock — a later row's initial state. A hash check reads its committed 𝒽 from the lock and its <i>preimage</i> from the input — a pubkey 𝓅, or a whole revealed script 𝓇 / 𝓌 (which may carry its own inner hash, as an HTLC's does). Executing is where the segwit forms come clear: P2WPKH runs the very same ⧉ ⌖ 𝒽 ≡ ∇ as P2PKH.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -226,13 +226,13 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .hash-menu-title .hash-title-row .ghost { background: transparent; color: var(--dim); border: 1px solid var(--input-bd); }
 .hash-menu-title .hash-title-row .ghost:hover { background: transparent; color: var(--ink); border-color: var(--accent); }
 
-/* Per-verse navigation: Previous / Next flanking the verse title -- the
-   transaction's position within its block, rendered as "Verse N". */
-.verse-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin: 22px 0 0; }
-.verse-title { flex:1; text-align:center; margin:0; font:600 13px/1 'IBM Plex Mono',monospace; letter-spacing:.28em; text-transform:uppercase; color:var(--accent); }
-/* The transaction's own txid, rendered as Glossia prose beneath the verse title
+/* Per-section navigation: Previous / Next flanking the section title -- the
+   transaction's position within its block, rendered as "Section N". */
+.section-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin: 22px 0 0; }
+.section-title { flex:1; text-align:center; margin:0; font:600 13px/1 'IBM Plex Mono',monospace; letter-spacing:.28em; text-transform:uppercase; color:var(--accent); }
+/* The transaction's own txid, rendered as Glossia prose beneath the section title
    (as the block hash is beneath the chapter title). */
-.verse-hash { margin: 13px auto 0; max-width: 46ch; font: italic 400 14px/1.55 'Newsreader',serif; color: var(--meta); }
+.section-hash { margin: 13px auto 0; max-width: 46ch; font: italic 400 14px/1.55 'Newsreader',serif; color: var(--meta); }
 
 .chapter-body { font-family: 'Newsreader', serif; font-size: 19px; line-height: 1.75; color: var(--ink-soft); font-variant-numeric: oldstyle-nums; }
 
@@ -245,7 +245,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    laid out in horizontal bands, each part aligned with the body it annotates:
      .tx-inputs   a subgrid (row 1, left + body): every input is a [citation |
                   scriptSig] pair, so an input's provenance sits on its own line.
-                  The citation is the referenced output's volume·book·chapter·verse
+                  The citation is the referenced output's volume·book·chapter·section
                   plus its output index (a coinbase shows ∅).
      .tx-outputs  a subgrid (row 2, body + right): every output is a [scriptPubKey
                   | amount] pair, so an amount sits on the line of its output.
@@ -263,11 +263,11 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .tx-in-cite.resolving { color: var(--meta); }
 .tx-in-cite.cite-unresolved { color: var(--meta); font-style: italic; }
 .tx-in-cite.tx-version { color: var(--meta); letter-spacing: .03em; }
-.cite-verse-link { color: inherit; text-decoration: none; }
-.cite-verse-link:hover { color: var(--accent); text-decoration: underline; }
+.cite-section-link { color: inherit; text-decoration: none; }
+.cite-section-link:hover { color: var(--accent); text-decoration: underline; }
 /* The amount of the output this input spends, under its reference. */
 .cite-amount { margin-top: .1em; font: italic 400 12px/1.3 'Newsreader',serif; color: var(--meta); }
-/* An output's forward citation -- the verse that later spent it -- under its
+/* An output's forward citation -- the section that later spent it -- under its
    amount in the right margin, mirroring the left margin's provenance cites.
    Empty for an unspent output. */
 .fwd-cite { margin-top: .1em; font: 500 11.5px/1.3 'IBM Plex Mono',monospace; color: var(--dim); }
@@ -430,12 +430,12 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <h1 class="chapter-title" id="ch-title"></h1>
       <div class="chapter-hash" id="ch-hash-short"></div>
       <div class="chapter-frontispiece" id="ch-frontispiece"></div>
-      <nav class="verse-nav">
+      <nav class="section-nav">
         <button type="button" id="page-prev">← Previous</button>
-        <h2 class="verse-title" id="verse-title"></h2>
+        <h2 class="section-title" id="section-title"></h2>
         <button type="button" id="page-next">Next →</button>
       </nav>
-      <div class="verse-hash" id="verse-hash"></div>
+      <div class="section-hash" id="section-hash"></div>
     </header>
 
     <div class="chapter-body" id="ch-paragraphs"></div>
@@ -655,7 +655,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">■ <i>v b c</i></span><span class="m">not before the cited chapter (volume book chapter)</span></div>
           <div class="glyph-row"><span class="g">Τ<i>t</i></span><span class="m">not before a UTC date</span></div>
           <div class="glyph-row"><span class="g">∅</span><span class="m"><b>empty</b> — a coinbase's absent prevout, a segwit input's zero-byte script, an empty witness item</span></div>
-          <div class="glyph-row"><span class="g">§<i>n</i></span><span class="m">verse — the transaction's position</span></div>
+          <div class="glyph-row"><span class="g">§<i>n</i></span><span class="m">section — the transaction's position</span></div>
         </div>
       </div>
     </div>
@@ -663,9 +663,9 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 
   <details class="about">
     <summary>About</summary>
-    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above. The margins carry the citation graph: each input cites the verse it spends from (that output's amount in parentheses beneath), and each spent output carries a forward citation — the verse that later consumed it — beneath its amount. An unspent output has none.</p>
+    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above. The margins carry the citation graph: each input cites the section it spends from (that output's amount in parentheses beneath), and each spent output carries a forward citation — the section that later consumed it — beneath its amount. An unspent output has none.</p>
     <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and witness items' length prefixes — is dropped, since it is reconstructable from structure; a script's push opcodes render as superscript byte counts (with ↧/⇊/⤋ arrows when the length rides in a 1/2/4-byte prefix). And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
-    <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and verse hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to β and η marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
+    <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and section hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to β and η marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
     <p class="hint muted">Every Glossia-encoded hash — a block hash, a transaction id, the previous-block hash and merkle root above — hovers (or, on touch, taps) into a small selectable panel carrying the exact hex it encodes. Clicking it opens a menu: copy that hex, or bookmark it under a title of your choosing. A bookmarked hash flies a small bookmark ribbon at its top-right corner; bookmarks (block hashes, previous-block hashes and transaction ids — anything you can navigate back to) are kept in this browser, each with its title, and join your <b>Bookmarks</b> in the lookup card, which opens with a curated set of notable transactions. The full <a href="./bitcoin-contents.html">table of contents</a> lists them on their own page.</p>
     <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet), falling back to the compatible <a href="https://mempool.space/docs/api/rest" target="_blank" rel="noopener">mempool.space API</a> when Blockstream rate-limits. Pick the data source — or add your own Esplora/Electrs endpoint — from the <b>Data source</b> menu above; custom endpoints are remembered in this browser.</p>
   </details>
@@ -874,7 +874,7 @@ const lazyEncode = (() => {
     // A push's prose, deferred: hex rides in a data attribute (hex is [0-9a-f],
     // safe unquoted) and the ⋯ gives the span a layout box so the observer fires.
     placeholder: (hex) => hex ? `<span class="glossia-lazy" data-hex="${hex}">⋯</span>` : '',
-    // Drop pending chunks from a previous verse (their nodes are already detached).
+    // Drop pending chunks from a previous section (their nodes are already detached).
     reset: () => { if (io) io.disconnect(); },
     // Start watching every placeholder under `root`; encode all now if the
     // browser has no IntersectionObserver.
@@ -915,7 +915,7 @@ let currentFootnotes = [];
 let footnotesLoaded = false;
 
 // Each input's prevout is shown as a citation to the output it spends -- the
-// referenced transaction's volume·book·chapter·verse. Resolving one needs a
+// referenced transaction's volume·book·chapter·section. Resolving one needs a
 // lookup (its block height + position in that block), so results are memoized
 // by txid and `renderGen` lets a citation that resolves after the reader has
 // paged away drop its stale DOM update.
@@ -923,7 +923,7 @@ const citationCache = new Map();   // txid -> Promise<{ height, pos, outputs }>
 let renderGen = 0;
 
 // txid -> { height, pos, outputs } for the referenced transaction: the merkle
-// proof gives its confirming height and index within that block (the verse),
+// proof gives its confirming height and index within that block (the section),
 // while /tx gives its outputs (so a spent output's amount can be shown under
 // the reference). Fetched together, memoized by txid.
 function resolveCitation(txid) {
@@ -958,13 +958,13 @@ function fromRoman(s) {
 }
 
 // Parse a scripture-style reference into { height, index }. Volume comes first
-// (Roman); book, chapter and verse are optional and each default to the first:
-//   "III"        -> era 3, book 1, chapter 1, verse 1
+// (Roman); book, chapter and section are optional and each default to the first:
+//   "III"        -> era 3, book 1, chapter 1, section 1
 //   "III 2"      -> era 3, book 2, first block   (the requested behaviour)
 //   "III 2 5"    -> chapter 5
-//   "III 2 5 §3" / "III 2 5 3" -> verse 3
+//   "III 2 5 §3" / "III 2 5 3" -> section 3
 // A trailing ".output" (as citations print, e.g. "III 2 5 §3.1") is accepted
-// and ignored -- it picks an output within the verse, not another verse.
+// and ignored -- it picks an output within the section, not another section.
 // Returns null when the string isn't a reference at all.
 function parseReference(input) {
   const s = input.trim().replace(/\s+/g, ' ');
@@ -974,9 +974,9 @@ function parseReference(input) {
   if (!Number.isFinite(volume) || volume < 1) return null;
   const book = m[2] ? parseInt(m[2], 10) : 1;
   const chapter = m[3] ? parseInt(m[3], 10) : 1;
-  const verse = m[4] ? parseInt(m[4], 10) : 1;
-  if (book < 1 || chapter < 1 || verse < 1) return null;
-  return { height: heightOf(volume, book, chapter), index: verse - 1 };
+  const section = m[4] ? parseInt(m[4], 10) : 1;
+  if (book < 1 || chapter < 1 || section < 1) return null;
+  return { height: heightOf(volume, book, chapter), index: section - 1 };
 }
 
 // txid -> the spending status of every output at once (Esplora /outspends):
@@ -993,7 +993,7 @@ function loadOutspends(txid) {
   return outspendsCache.get(txid);
 }
 
-// Fill each output's forward-citation cell with the verse that spent it --
+// Fill each output's forward-citation cell with the section that spent it --
 // the mirror of the input margin's provenance cites: the left margin says
 // where value came from, the right margin says where it went next. One
 // outspends call covers every output; each confirmed spender then resolves
@@ -1011,11 +1011,11 @@ async function resolveForwardCitations(txid, cells, gen) {
         if (gen !== renderGen) return;
         const { volume, book, chapter } = volumeBookChapter(height);
         const link = document.createElement('a');
-        link.className = 'cite-verse-link';
+        link.className = 'cite-section-link';
         link.href = `?block=${height}&index=${pos}`;
         link.textContent = `${toRoman(volume)} ${book} ${chapter} §${pos + 1}`;
         link.title = `spent by input ${sp.vin + 1} of ${sp.txid}`;
-        link.addEventListener('click', (e) => { e.preventDefault(); goToVerse(height, pos, `in-${sp.vin}`); });
+        link.addEventListener('click', (e) => { e.preventDefault(); goToSection(height, pos, `in-${sp.vin}`); });
         cell.append(link);
       } catch { /* unresolvable spender -- leave the cell empty */ }
     }));
@@ -1023,27 +1023,28 @@ async function resolveForwardCitations(txid, cells, gen) {
 }
 
 // Populate a citation cell with the scripture-style reference "volume(Roman)
-// book chapter §verse.output-index" (e.g. "XII 37 184 §17.2"), the whole of
-// which links to that verse.
+// book chapter §section.verse" -- the section is the transaction, the verse its
+// output index (e.g. "XII 37 184 §17.2"), the whole of which links to that
+// section.
 function renderCitation(citeBody, height, pos, vout) {
   const { volume, book, chapter } = volumeBookChapter(height);
   const link = document.createElement('a');
-  link.className = 'cite-verse-link';
+  link.className = 'cite-section-link';
   link.href = `?block=${height}&index=${pos}`;
   link.textContent = `${toRoman(volume)} ${book} ${chapter} §${pos + 1}.${vout}`;
   link.title = `go to §${pos + 1}.${vout}`;
-  link.addEventListener('click', (e) => { e.preventDefault(); goToVerse(height, pos, `out-${vout}`); });
+  link.addEventListener('click', (e) => { e.preventDefault(); goToSection(height, pos, `out-${vout}`); });
   citeBody.textContent = '';
   citeBody.append(link);
 }
 
-// Navigate to a referenced verse (the transaction at `index` in the block at
+// Navigate to a referenced section (the transaction at `index` in the block at
 // `height`) in place, then bring `scrollId` to the top of the page. The two
 // directions mirror each other: following an input's provenance scrolls to the
 // output it spends (out-N), and following an output's forward citation scrolls
 // to the input that spends it (in-N). The lookup field is refreshed by
 // renderChapter, so it isn't set here.
-async function goToVerse(height, index, scrollId) {
+async function goToSection(height, index, scrollId) {
   await openLookup(String(height), index);
   if (scrollId) {
     const el = $(scrollId);
@@ -1052,7 +1053,7 @@ async function goToVerse(height, index, scrollId) {
 }
 
 // Fill each pending citation cell once its reference resolves; skip if the
-// reader has since paged to another verse (gen no longer current).
+// reader has since paged to another section (gen no longer current).
 async function resolveCitations(pending, gen) {
   await Promise.all(pending.map(async ({ citeBody, cite, amtEl, txid, vout }) => {
     try {
@@ -1080,7 +1081,7 @@ async function resolveCitations(pending, gen) {
 
 // A block's ordered txid list, memoized by block hash. It's the heaviest part
 // of a block's metadata -- every transaction hash -- so it's fetched on its own
-// and only when needed: opening one transaction by id doesn't need it (its verse
+// and only when needed: opening one transaction by id doesn't need it (its section
 // comes from the merkle proof), only stepping through the block does.
 const txidsCache = new Map();
 function fetchTxids(hash) {
@@ -1100,8 +1101,8 @@ async function ensureTxids(st) {
 }
 
 // `withTxids: false` leaves the (heavy) txid list unfetched -- used when opening
-// a single transaction, whose verse index comes from its merkle proof instead.
-// The block's transaction count still comes from its info (tx_count), so verse
+// a single transaction, whose section index comes from its merkle proof instead.
+// The block's transaction count still comes from its info (tx_count), so section
 // bounds and Next work without the list.
 async function loadBlockMeta(hash, { withTxids = true } = {}) {
   const [[blockRes, headerRes], txids] = await Promise.all([
@@ -1126,7 +1127,7 @@ async function loadBlockByHeight(height) {
 }
 
 // A txid -> the block that confirmed it, plus the transaction's index within
-// that block (its verse). The verse comes from the merkle proof's position, so
+// that block (its section). The section comes from the merkle proof's position, so
 // opening one transaction never downloads the whole block's txid list -- that's
 // deferred (ensureTxids) until the reader steps Prev/Next. This is what makes
 // navigation by reference fast regardless of how large the block is.
@@ -1137,7 +1138,7 @@ async function loadBlockByTxid(txid) {
   ]);
   if (!txRes.ok) throw new Error(txRes.status === 404 ? `No transaction ${txid.slice(0, 8)}…` : `Esplora returned ${txRes.status}.`);
   const tx = await txRes.json();
-  if (!tx.status || !tx.status.confirmed) throw new Error('That transaction is unconfirmed — it has no verse yet.');
+  if (!tx.status || !tx.status.confirmed) throw new Error('That transaction is unconfirmed — it has no section yet.');
   const hash = tx.status.block_hash;
   if (mpRes.ok) {
     const meta = await loadBlockMeta(hash, { withTxids: false });
@@ -1203,7 +1204,7 @@ function attachHashCopy(el, hex, label) {
 // The block header itself, in wire order, as a small mono line under the
 // chapter hash: version, previous-block hash, merkle root, timestamp,
 // difficulty target, nonce. The two hashes are Glossia-encoded here (like
-// the chapter/verse hash above); the rest come pre-decoded from
+// the chapter/section hash above); the rest come pre-decoded from
 // composeBlockHeaderFields. Genesis has no previous block, shown as ∅.
 function renderFrontispiece(header) {
   const el = $('ch-frontispiece');
@@ -1239,7 +1240,7 @@ function renderChapter(para) {
 
   // Keep the lookup field showing where we are, in the same reference form the
   // citations use, so it round-trips: any navigation refreshes it, and pressing
-  // Read chapter on it returns to this very verse.
+  // Read chapter on it returns to this very section.
   $('block-input').value = `${toRoman(volume)} ${book} ${chapter} §${state.index + 1}`;
 
   // The big title (and hash subtitle) introduce the chapter as a whole, so
@@ -1255,7 +1256,7 @@ function renderChapter(para) {
   const isGenesis = volume === 1 && book === 1 && chapter === 1;
   const eventTitle = NOTABLE.find((e) => e.id === String(state.height))?.title;
   $('ch-title').textContent = isGenesis ? 'Genesis' : (eventTitle || `Chapter ${chapter.toLocaleString()}`);
-  // Running head (every verse past the first): the event name for a notable
+  // Running head (every section past the first): the event name for a notable
   // block, otherwise the bare chapter numeral -- a locator, not a quantity.
   $('ch-chapter-inline').textContent = onFirstTx ? '' : ` · ${eventTitle || `Chapter ${chapter}`}`;
   $('ch-title').classList.toggle('hidden', !onFirstTx);
@@ -1266,12 +1267,12 @@ function renderChapter(para) {
   $('ch-frontispiece').classList.toggle('hidden', !onFirstTx);
   if (onFirstTx) renderFrontispiece(state.header);
 
-  // This verse's own txid, encoded as prose beneath the verse title. Reversed
+  // This section's own txid, encoded as prose beneath the section title. Reversed
   // to internal byte order first (like the block hash) so it carries the txid's
   // actual bytes; every byte kept, since a txid has no droppable leading zeros.
   const { prose: txidProse } = encodeSeedPhrase(reverseHex(para.txid), 'english', BEST_OF);
-  $('verse-hash').textContent = txidProse;
-  attachHashCopy($('verse-hash'), para.txid, 'transaction id');
+  $('section-hash').textContent = txidProse;
+  attachHashCopy($('section-hash'), para.txid, 'transaction id');
 
   const body = $('ch-paragraphs');
   body.innerHTML = '';
@@ -1281,17 +1282,17 @@ function renderChapter(para) {
 
   // The transaction's position within its block titles the section ("§ 3").
   const titleAttr = `txid ${para.txid}${para.verified ? '' : ' — could not be independently verified'}`;
-  const verseTitle = $('verse-title');
-  verseTitle.textContent = `§ ${para.num}`;
-  verseTitle.title = titleAttr;
+  const sectionTitle = $('section-title');
+  sectionTitle.textContent = `§ ${para.num}`;
+  sectionTitle.title = titleAttr;
 
   // The transaction is laid out in horizontal bands (see .tx-flow CSS). The
   // inputs are a [citation | scriptSig] subgrid: each input's provenance -- the
-  // volume·book·chapter·verse of the output it spends, plus that output's index
+  // volume·book·chapter·section of the output it spends, plus that output's index
   // -- sits in the left margin, level with its scriptSig. The outputs are a
   // [scriptPubKey | amount] subgrid; the locktime closes on the right.
   const gen = ++renderGen;
-  lazyEncode.reset();   // drop chunks still pending from the previous verse (body + footnotes)
+  lazyEncode.reset();   // drop chunks still pending from the previous section (body + footnotes)
   const flow = document.createElement('div');
   flow.className = 'tx-flow';
   const inputsEl = document.createElement('div');
@@ -1433,7 +1434,7 @@ function renderChapter(para) {
     const valueCell = document.createElement('div');
     valueCell.className = 'tx-note tx-out-value';
     valueCell.textContent = out.value;
-    // Forward citation placeholder: filled with the verse that later spent
+    // Forward citation placeholder: filled with the section that later spent
     // this output, once the outspends resolve. An unspent output keeps it
     // empty -- still-live value has no forward reference.
     const fwd = document.createElement('div');
@@ -1467,7 +1468,7 @@ function renderChapter(para) {
 
 // Encode every witness-bearing input's witness into a numbered footnote and
 // reveal the footnotes section. Done once per transaction, and skipped if the
-// reader has paged to another verse before the (heavy) encoding finishes.
+// reader has paged to another section before the (heavy) encoding finishes.
 async function renderFootnotes(gen) {
   if (footnotesLoaded || !currentFootnotes.length) return;
   if (!ready) await init().catch(() => {});
@@ -1513,7 +1514,7 @@ const clampIndex = (i, meta) => Math.min(Math.max(0, i || 0), meta.txCount - 1);
 // Load whatever the reader gave us: a block height, a block hash, or a
 // transaction id. A 64-hex value is either a block hash or a txid -- they're
 // indistinguishable by shape -- so it's tried as a block first and, failing
-// that, as a txid, which jumps straight to that transaction's verse.
+// that, as a txid, which jumps straight to that transaction's section.
 async function openLookup(input, index = 0) {
   input = (input || '').trim();
   $('chapter').classList.add('hidden');
@@ -1692,7 +1693,7 @@ function selectEndpoint(url, { reload = true } = {}) {
   try { localStorage.setItem(SELECTED_KEY, url); } catch {}
   renderEndpoints();
   setEndpointMsg(`Data source: ${hostOf(url)}`);
-  // Reload the current chapter/verse from state (not the input box, which Next/
+  // Reload the current chapter/section from state (not the input box, which Next/
   // Prev navigation doesn't update) so the new source takes effect at once.
   if (reload && state) openLookup(String(state.height), state.index);
 }
@@ -1970,7 +1971,7 @@ window.addEventListener('scroll', closeHashMenu, true);
 renderContents();
 
 // Entry points, in priority order: ?txid= jumps straight to a transaction's
-// verse; ?block= (with optional ?index=) opens a block; otherwise the input's
+// section; ?block= (with optional ?index=) opens a block; otherwise the input's
 // default value.
 const params = new URLSearchParams(location.search);
 const txidParam = params.get('txid');

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -482,7 +482,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq"><span class="ph">…</span> <span class="ph">𝓇</span></span>
           <span class="pname">P2SH · 2-of-3</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
-            <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(</span><span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span><span class="op">)</span></span>
+            <span class="seq exec"><span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(</span><span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span><span class="op">)</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
           <span class="pname">P2WPKH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span></span>
@@ -490,11 +490,11 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
           <span class="pname">P2WSH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">◇</span></span>
+            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(𝓌)</span></span>
             <span class="seq">∅ · ∅ <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓌</span></span>
           <span class="pname">Lightning HTLC</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span></span>
+            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(</span><span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span><span class="op">)</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝒽</span> <span class="ph">𝓌</span></span>
           <span class="pname">P2TR key</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
@@ -502,7 +502,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq">∅ · <span class="ph">𝓈</span></span>
           <span class="pname">P2TR script</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓉</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="op">(𝓉)</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="ph">…</span></span>
           <span class="pname">Data</span>
             <span class="seq none">—</span>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -679,7 +679,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">●</span><span class="m"><b>final</b></span></div>
           <div class="glyph-row"><span class="g">○</span><span class="m">respects the locktime</span></div>
           <div class="glyph-row"><span class="g">†</span><span class="m"><b>replaceable</b> (opt-in RBF)</span></div>
-          <div class="glyph-row"><span class="g">■<i>N</i></span><span class="m">relative: N blocks after confirmation (Roman — a count of chapters)</span></div>
+          <div class="glyph-row"><span class="g">■<i>N</i></span><span class="m">relative: N blocks after confirmation (a count of chapters)</span></div>
           <div class="glyph-row"><span class="g">Τ<i>Δt</i></span><span class="m">relative: a duration after confirmation (d h m s)</span></div>
           <div class="glyph-row"><span class="g">(<i>n</i>)</span><span class="m">the <b>amount spent</b> by this input — value flowing in; an output's amount stands bare</span></div>
         </div>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -382,10 +382,13 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .notation-note { margin: 12px 0 0; font-size: 12px; line-height: 1.5; color: var(--meta); }
 /* Common script patterns: one row per payment type, read as a state
    transition -- the unspent output at rest (UTXO), the script a node runs then
-   discards (validator), and the same output once spent (STXO). Wide, so it
-   scrolls in its own container on narrow screens. */
+   discards (validator), and the spend that consumes it, split across where it
+   lives on the wire: the input's scriptSig (STXO) and its witness (Witness).
+   Legacy types write the STXO and leave the witness empty; segwit types empty
+   the scriptSig (∅) and write the witness. Wide, so it scrolls in its own
+   container on narrow screens. */
 .pattern-scroll { overflow-x: auto; }
-.pattern-table { display: grid; grid-template-columns: repeat(4, max-content); gap: 9px 22px; align-items: baseline; }
+.pattern-table { display: grid; grid-template-columns: repeat(5, max-content); gap: 9px 22px; align-items: baseline; }
 .pattern-table .phead, .pattern-table .pname { font: 600 10px/1.5 'IBM Plex Mono',monospace; letter-spacing: .06em; text-transform: uppercase; color: var(--meta); white-space: nowrap; }
 .pattern-table .phead { color: var(--accent); }
 .pattern-table .seq { font: 400 16px/1.5 'Newsreader', system-ui, 'Segoe UI Symbol', serif; color: var(--ink-soft); white-space: nowrap; }
@@ -467,51 +470,62 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Common script patterns</h4>
         <div class="pattern-scroll">
         <div class="pattern-table">
-          <span class="phead"></span><span class="phead">UTXO</span><span class="phead">Validator</span><span class="phead">STXO</span>
+          <span class="phead"></span><span class="phead">UTXO</span><span class="phead">Validator</span><span class="phead">STXO</span><span class="phead">Witness</span>
           <span class="pname">P2PK</span>
             <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">p</span> <span class="op">∇</span></span>
             <span class="seq exec"><span class="ph">s</span> <span class="ph chain">p</span> <span class="op">∇</span></span>
             <span class="seq"><span class="ph">s</span></span>
+            <span class="seq none">—</span>
           <span class="pname">P2PKH</span>
             <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">h</span> <span class="op">≡</span> <span class="op">∇</span></span>
             <span class="seq exec"><span class="ph">s</span> <span class="ph">p</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">≡</span> <span class="op">∇</span></span>
             <span class="seq"><span class="ph">s</span> <span class="ph">p</span></span>
+            <span class="seq none">—</span>
           <span class="pname">Multisig</span>
             <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">p</span> <span class="op op-push">³³</span><span class="ph">p</span> <span class="op op-push">³³</span><span class="ph">p</span> <span class="op">③</span> <span class="op">◇</span></span>
             <span class="seq exec"><span class="op">⓪</span> <span class="ph">s</span> <span class="ph">s</span> <span class="op">◇</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">s</span> <span class="ph">s</span></span>
+            <span class="seq none">—</span>
           <span class="pname">P2SH</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">h</span> <span class="op">=</span></span>
             <span class="seq exec"><span class="ph">r</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(r)</span></span>
             <span class="seq"><span class="op">(r)</span></span>
+            <span class="seq none">—</span>
           <span class="pname">P2SH · 2-of-3</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">h</span> <span class="op">=</span></span>
             <span class="seq exec"><span class="op">②</span> <span class="ph">p</span> <span class="ph">p</span> <span class="ph">p</span> <span class="op">③</span> <span class="op">◇</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(</span><span class="op">②</span> <span class="ph">p</span> <span class="ph">p</span> <span class="ph">p</span> <span class="op">③</span> <span class="op">◇</span><span class="op">)</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">s</span> <span class="ph">s</span> <span class="op">②</span> <span class="ph">p</span> <span class="ph">p</span> <span class="ph">p</span> <span class="op">③</span> <span class="op">◇</span></span>
+            <span class="seq none">—</span>
           <span class="pname">P2WPKH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">h</span></span>
             <span class="seq exec"><span class="ph">s</span> <span class="ph">p</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">≡</span> <span class="op">∇</span></span>
-            <span class="seq">∅ · <span class="ph">s</span> <span class="ph">p</span></span>
+            <span class="seq none">∅</span>
+            <span class="seq"><span class="ph">s</span> <span class="ph">p</span></span>
           <span class="pname">P2WSH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">h</span></span>
             <span class="seq exec"><span class="ph">w</span> <span class="op">Σ</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(w)</span></span>
-            <span class="seq">∅ · <span class="op">(w)</span></span>
+            <span class="seq none">∅</span>
+            <span class="seq"><span class="op">(w)</span></span>
           <span class="pname">Lightning HTLC</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">h</span></span>
             <span class="seq exec"><span class="ph">w</span> <span class="op">Σ</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(</span><span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span><span class="op">)</span></span>
-            <span class="seq">∅ · <span class="ph">s</span> <span class="ph">h</span> <span class="ph">w</span></span>
+            <span class="seq none">∅</span>
+            <span class="seq"><span class="ph">s</span> <span class="ph">h</span> <span class="ph">w</span></span>
           <span class="pname">P2TR key</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">p</span></span>
             <span class="seq exec"><span class="ph">s</span> <span class="op">∇</span></span>
-            <span class="seq">∅ · <span class="ph">s</span></span>
+            <span class="seq none">∅</span>
+            <span class="seq"><span class="ph">s</span></span>
           <span class="pname">P2TR script</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">p</span></span>
             <span class="seq exec"><span class="ph">s</span> <span class="ph">t</span> <span class="op">(t)</span></span>
-            <span class="seq">∅ · <span class="op">(t)</span></span>
+            <span class="seq none">∅</span>
+            <span class="seq"><span class="op">(t)</span></span>
           <span class="pname">Data</span>
-            <span class="seq none">—</span>
-            <span class="seq none">—</span>
             <span class="seq"><span class="op">¶</span> <span class="op op-push">ⁿ</span></span>
+            <span class="seq none">—</span>
+            <span class="seq none">—</span>
+            <span class="seq none">—</span>
         </div>
         </div>
       </div>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -376,16 +376,19 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .glyph-row .g i { font-style: normal; opacity: .5; font-size: .82em; }
 .glyph-row .m { font: 400 13px/1.45 'Public Sans', sans-serif; color: var(--dim); }
 .glyph-row .m b { color: var(--ink-soft); font-weight: 500; }
-/* Common script patterns: one row per payment type, its marks split across
-   where they live on the wire -- input (scriptSig), output (scriptPubKey),
-   witness. Wide, so it scrolls in its own container on narrow screens. */
+/* Common script patterns: one row per payment type, read as a state
+   transition -- the lock at rest (initial state), the script a node runs then
+   discards (executed), and what the spend leaves on chain (written). Wide, so
+   it scrolls in its own container on narrow screens. */
 .pattern-scroll { overflow-x: auto; }
 .pattern-table { display: grid; grid-template-columns: repeat(4, max-content); gap: 9px 22px; align-items: baseline; }
 .pattern-table .phead, .pattern-table .pname { font: 600 10px/1.5 'IBM Plex Mono',monospace; letter-spacing: .06em; text-transform: uppercase; color: var(--meta); white-space: nowrap; }
 .pattern-table .phead { color: var(--accent); }
 .pattern-table .seq { font: 400 16px/1.5 'Newsreader', system-ui, 'Segoe UI Symbol', serif; color: var(--ink-soft); white-space: nowrap; }
 .pattern-table .none { color: var(--meta); }
+.pattern-table .to { color: var(--meta); font-size: .8em; padding: 0 .15em; }
 .ph { color: var(--dim); font-style: italic; }
+.notation-note { margin: 11px 0 0; font-size: 12px; line-height: 1.5; color: var(--meta); }
 @media (max-width: 480px) { .glyph-grid { grid-template-columns: 1fr; } }
 </style>
 </head>
@@ -452,49 +455,50 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Common script patterns</h4>
         <div class="pattern-scroll">
         <div class="pattern-table">
-          <span class="phead"></span><span class="phead">Input</span><span class="phead">Output</span><span class="phead">Witness</span>
+          <span class="phead"></span><span class="phead">Initial state</span><span class="phead">Node executes</span><span class="phead">Written</span>
           <span class="pname">P2PK</span>
-            <span class="seq"><span class="op op-push">⁷¹</span><span class="ph">𝓈</span></span>
             <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">𝓅</span> <span class="op">∇</span></span>
-            <span class="seq none">—</span>
-          <span class="pname">P2PKH</span>
-            <span class="seq"><span class="op op-push">⁷¹</span><span class="ph">𝓈</span> <span class="op op-push">³³</span><span class="ph">𝓅</span></span>
-            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
-            <span class="seq none">—</span>
-          <span class="pname">Multisig</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">⁷¹</span><span class="ph">𝓈</span> <span class="op op-push">⁷¹</span><span class="ph">𝓈</span></span>
-            <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
-            <span class="seq none">—</span>
-          <span class="pname">P2SH</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">⁷¹</span><span class="ph">𝓈</span> <span class="op op-push">⁷¹</span><span class="ph">𝓈</span> <span class="op op-push">ⁿ</span><span class="ph">𝓇</span></span>
-            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
-            <span class="seq none">—</span>
-          <span class="pname">P2WPKH</span>
-            <span class="seq none">∅</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span></span>
-            <span class="seq"><span class="ph">𝓈</span> · <span class="ph">𝓅</span></span>
-          <span class="pname">P2WSH</span>
-            <span class="seq none">∅</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq">∅ · <span class="ph">𝓈</span> · <span class="ph">𝓈</span> · <span class="ph">𝓌</span></span>
-          <span class="pname">Lightning HTLC</span>
-            <span class="seq none">∅</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq"><span class="ph">𝓈</span> · <span class="ph">𝒽</span> · <span class="ph">𝓌</span></span>
-          <span class="pname">P2TR key</span>
-            <span class="seq none">∅</span>
-            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
+            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq"><span class="ph">𝓈</span></span>
-          <span class="pname">P2TR script</span>
-            <span class="seq none">∅</span>
+          <span class="pname">P2PKH</span>
+            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
+            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
+          <span class="pname">Multisig</span>
+            <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span></span>
+          <span class="pname">P2SH</span>
+            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
+            <span class="seq"><span class="ph">𝓇</span> <span class="op">⌖</span><span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓇</span></span>
+          <span class="pname">P2WPKH</span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span></span>
+            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
+          <span class="pname">P2WSH</span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
+            <span class="seq"><span class="ph">𝓌</span> <span class="op">Σ</span><span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq">∅ · ∅ <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓌</span></span>
+          <span class="pname">Lightning HTLC</span>
+            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
+            <span class="seq"><span class="ph">𝓌</span> <span class="op">Σ</span><span class="op">=</span> <span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝒽</span> <span class="ph">𝓌</span></span>
+          <span class="pname">P2TR key</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
-            <span class="seq"><span class="ph">𝓈</span> · <span class="ph">𝓉</span> · <span class="ph">…</span></span>
+            <span class="seq"><span class="ph">𝓈</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq">∅ · <span class="ph">𝓈</span></span>
+          <span class="pname">P2TR script</span>
+            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
+            <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="ph">…</span></span>
           <span class="pname">Data</span>
             <span class="seq none">—</span>
-            <span class="seq"><span class="op">¶</span> <span class="op op-push">ⁿ</span><span class="ph">…</span></span>
             <span class="seq none">—</span>
+            <span class="seq"><span class="op">¶</span> <span class="op op-push">ⁿ</span><span class="ph">…</span></span>
         </div>
         </div>
+        <p class="notation-note">Each row is a spend read as a state transition: <b>initial state</b> is the lock at rest in the UTXO set; <b>node executes</b> is the script a validator runs over the offered data, then discards (⇒ ✓); <b>written</b> is what the spend leaves on chain — its authorization, in the scriptSig or (∅ then) the witness. A node keeps state and authorizations, never the execution; the new outputs a spend also writes are each a fresh lock — a later row's initial state. Executing is where the segwit forms come clear: P2WPKH runs the very same ⧉ ⌖ ≡ ∇ as P2PKH, and a hash-locked script (𝓇 𝓌 𝓉) is revealed and run only when spent.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -479,7 +479,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <span class="pname">P2SH</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
             <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(𝓇)</span></span>
-            <span class="seq"><span class="ph">…</span> <span class="ph">𝓇</span></span>
+            <span class="seq"><span class="op">(𝓇)</span></span>
           <span class="pname">P2SH · 2-of-3</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
             <span class="seq exec"><span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(</span><span class="op">②</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span><span class="op">)</span></span>
@@ -491,7 +491,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <span class="pname">P2WSH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
             <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(𝓌)</span></span>
-            <span class="seq">∅ · ∅ <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓌</span></span>
+            <span class="seq">∅ · <span class="op">(𝓌)</span></span>
           <span class="pname">Lightning HTLC</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
             <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">(</span><span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span><span class="op">)</span></span>
@@ -503,7 +503,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <span class="pname">P2TR script</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
             <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="op">(𝓉)</span></span>
-            <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓉</span> <span class="ph">…</span></span>
+            <span class="seq">∅ · <span class="op">(𝓉)</span></span>
           <span class="pname">Data</span>
             <span class="seq none">—</span>
             <span class="seq none">—</span>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -386,14 +386,18 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .pattern-table .phead { color: var(--accent); }
 .pattern-table .seq { font: 400 16px/1.5 'Newsreader', system-ui, 'Segoe UI Symbol', serif; color: var(--ink-soft); white-space: nowrap; }
 .pattern-table .none { color: var(--meta); }
-/* Gold marks anything read from or written to the chain -- the lock, the
-   authorization, and the data (keys, sigs, hashes, scripts) that flows through
-   a spend. White marks the ephemeral execution: the operations a node applies
-   in the middle column and the ⇒ ✓ it reduces to, none of which is ever stored.
-   So chain data stays gold even while it threads through the white run. */
-.pattern-table .ph { color: var(--accent); font-style: normal; }
-.pattern-table .seq.exec .op { color: var(--ink); }
-.pattern-table .to { color: var(--ink); font-size: .8em; padding: 0 .15em; }
+/* Gold and bold mark what the chain keeps: the lock (initial state), the
+   authorization once written, and any datum read from a confirmed output -- a
+   committed hash. White, regular weight marks the ephemeral: the operations a
+   node runs and the ⇒ ✓ it reduces to, plus the transaction's own data, which
+   stays unverified until a block puts it on chain (where it turns gold). Bold
+   carries the split into a black-and-white print. */
+.pattern-table .op { font-weight: 700; }
+.pattern-table .op-push { font-weight: 400; }
+.pattern-table .ph { color: var(--accent); font-style: normal; font-weight: 700; }
+.pattern-table .seq.exec .op, .pattern-table .seq.exec .ph { color: var(--ink); font-weight: 400; }
+.pattern-table .seq.exec .ph.chain { color: var(--accent); font-weight: 700; }
+.pattern-table .to { color: var(--ink); font-weight: 400; font-size: .8em; padding: 0 .15em; }
 .notation-note { margin: 11px 0 0; font-size: 12px; line-height: 1.5; color: var(--meta); }
 @media (max-width: 480px) { .glyph-grid { grid-template-columns: 1fr; } }
 </style>
@@ -464,11 +468,11 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <span class="phead"></span><span class="phead">Initial state</span><span class="phead">Node executes</span><span class="phead">Written</span>
           <span class="pname">P2PK</span>
             <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">𝓅</span> <span class="op">∇</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph chain">𝓅</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq"><span class="ph">𝓈</span></span>
           <span class="pname">P2PKH</span>
             <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq"><span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
           <span class="pname">Multisig</span>
             <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op op-push">³³</span><span class="ph">𝓅</span> <span class="op">③</span> <span class="op">◇</span></span>
@@ -476,19 +480,19 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span></span>
           <span class="pname">P2SH</span>
             <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span> <span class="op">=</span></span>
-            <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓇</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓇</span></span>
           <span class="pname">P2WPKH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓈</span> <span class="ph">𝓅</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">𝒽</span> <span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝓅</span></span>
           <span class="pname">P2WSH</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">◇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · ∅ <span class="ph">𝓈</span> <span class="ph">𝓈</span> <span class="ph">𝓌</span></span>
           <span class="pname">Lightning HTLC</span>
             <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">𝒽</span></span>
-            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph">𝒽</span> <span class="op">=</span> <span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
+            <span class="seq exec"><span class="ph">𝓌</span> <span class="op">Σ</span> <span class="ph chain">𝒽</span> <span class="op">=</span> <span class="op">Σ</span><span class="op">≡</span> <span class="op">∇</span> <span class="to">⇒</span> <span class="op">✓</span></span>
             <span class="seq">∅ · <span class="ph">𝓈</span> <span class="ph">𝒽</span> <span class="ph">𝓌</span></span>
           <span class="pname">P2TR key</span>
             <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">𝓅</span></span>
@@ -504,7 +508,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
             <span class="seq"><span class="op">¶</span> <span class="op op-push">ⁿ</span><span class="ph">…</span></span>
         </div>
         </div>
-        <p class="notation-note">Each row is a spend read as a state transition: <b>initial state</b> is the lock at rest in the UTXO set; <b>node executes</b> is the script a validator runs over the offered data, then discards (⇒ ✓); <b>written</b> is what the spend leaves on chain — its authorization, in the scriptSig or (∅ then) the witness. A node keeps state and authorizations, never the execution; the new outputs a spend also writes are each a fresh lock — a later row's initial state. A hash check reads its committed 𝒽 from the lock and its <i>preimage</i> from the input — a pubkey 𝓅, or a whole revealed script 𝓇 / 𝓌 (which may carry its own inner hash, as an HTLC's does). Executing is where the segwit forms come clear: P2WPKH runs the very same ⧉ ⌖ 𝒽 ≡ ∇ as P2PKH.</p>
+        <p class="notation-note">Each row is a spend read as a state transition: <b>initial state</b> is the lock at rest in the UTXO set; <b>node executes</b> is the script a validator runs over the offered data, then discards (⇒ ✓); <b>written</b> is what the spend leaves on chain — its authorization, in the scriptSig or (∅ then) the witness. <b>Gold, bold</b> is what the chain keeps — the lock, a committed 𝒽 read from it, and the authorization once written; <b>white</b> is the ephemeral run and the transaction's own data (𝓈 𝓅 𝓇 𝓌 𝓉), which stays unverified until a block puts it on chain, where it turns gold. (The weight carries the split into a colorless print.) A hash check reads its committed 𝒽 from the lock and its <i>preimage</i> from the input — a pubkey 𝓅, or a whole revealed script 𝓇 / 𝓌 (which may carry its own inner hash, as an HTLC's does). Executing is where the segwit forms come clear: P2WPKH runs the very same ⧉ ⌖ 𝒽 ≡ ∇ as P2PKH.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-contents.html
+++ b/web/bitcoin-contents.html
@@ -41,6 +41,7 @@ a:hover { text-decoration: underline; }
 .toc-entry.under-book { padding-left:32px; }
 .toc-title { flex:1; min-width:0; font:500 17px/1.35 'Newsreader',serif; color:var(--ink-soft); }
 .toc-ref { flex:none; min-width:84px; text-align:right; font:600 13px/1.4 'IBM Plex Mono',monospace; letter-spacing:.06em; color:var(--accent); white-space:nowrap; font-variant-numeric:tabular-nums; }
+.toc-ref.none { color:var(--meta); font-weight:400; }
 .toc-entry:hover .toc-title { color:var(--ink); }
 .toc-entry:hover .toc-ref, .toc-entry:focus-visible .toc-ref { text-decoration:underline; color:var(--accent-2); }
 .toc-entry:focus-visible { outline:none; }
@@ -106,13 +107,16 @@ function tailRef({ book, chapter, verse }, underBook) {
 }
 
 // One contents row: the title on the left, its remaining reference on the right;
-// the whole row is a link that navigates into the book.
+// the whole row is a link that navigates into the book. An entry whose citation
+// never resolved carries a dash in place of a reference.
 function entryEl(entry, underBook) {
   const row = document.createElement('a');
   row.className = 'toc-entry' + (underBook ? ' under-book' : '');
   row.href = entryHref(entry.id);
   const t = document.createElement('span'); t.className = 'toc-title'; t.textContent = entry.title;
-  const r = document.createElement('span'); r.className = 'toc-ref'; r.textContent = tailRef(entry.place, underBook);
+  const r = document.createElement('span'); r.className = 'toc-ref';
+  if (entry.place) r.textContent = tailRef(entry.place, underBook);
+  else { r.textContent = '—'; r.classList.add('none'); }
   row.append(t, r);
   return row;
 }
@@ -124,8 +128,9 @@ function head(cls, label) { const d = document.createElement('div'); d.className
 // Entries arrive in reading order (ascending height), so anything sharing a
 // volume or book is already contiguous.
 const toc = document.getElementById('toc');
-function render(entries) {
+function render() {
   toc.replaceChildren();
+  const entries = placed();
   for (let i = 0; i < entries.length;) {
     const vol = entries[i].place.volume;
     let jv = i + 1; while (jv < entries.length && entries[jv].place.volume === vol) jv++;
@@ -143,6 +148,13 @@ function render(entries) {
     }
     i = jv;
   }
+  // Entries whose citation could not be resolved fall to the end under a dash,
+  // still linked so the book can resolve and open them on the next attempt.
+  const stranded = unresolved();
+  if (stranded.length) {
+    toc.append(head('toc-vol', 'Unresolved'));
+    for (const e of stranded) toc.append(entryEl(e, false));
+  }
   const bookmarks = readBookmarks();
   if (bookmarks.length) {
     toc.append(head('toc-vol', 'Your bookmarks'));
@@ -159,15 +171,16 @@ function render(entries) {
 
 // Block placements are offline, so render them at once; transaction citations
 // stream in as each resolves, slotting into their volume and book in order. An
-// entry that never resolves simply stays out of the contents (its raw id is
-// never written).
+// entry whose lookup fails (placement null) drops to an "Unresolved" tail
+// rather than printing its raw id.
 const placements = new Map();
 const placed = () => NOTABLE.filter((e) => placements.get(e.id)).map((e) => ({ ...e, place: placements.get(e.id) }));
+const unresolved = () => NOTABLE.filter((e) => placements.has(e.id) && !placements.get(e.id));
 for (const e of NOTABLE) if (isBlockId(e.id)) placements.set(e.id, placeOf(Number(e.id), null));
-render(placed());
+render();
 await Promise.all(NOTABLE.filter((e) => !placements.has(e.id)).map(async (e) => {
   placements.set(e.id, await resolvePlacement(e.id));
-  render(placed());
+  render();
 }));
 </script>
 </body>

--- a/web/bitcoin-contents.html
+++ b/web/bitcoin-contents.html
@@ -78,10 +78,10 @@ const GENESIS_COINBASE = '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b
 // Every entry is cited by its reference, never its raw id. A block's placement
 // is known offline from its height; a transaction's is resolved the same way the
 // reader resolves a citation -- a /tx/<txid>/merkle-proof gives the confirming
-// block height and the transaction's index (its §verse). Tried across the same
+// block height and the transaction's index (its §section). Tried across the same
 // public mirrors the book uses.
 const ESPLORA_MIRRORS = ['https://blockstream.info/api', 'https://mempool.space/api'];
-const placeOf = (height, pos) => { const p = volumeBookChapter(height); return { ...p, verse: pos == null ? null : pos + 1 }; };
+const placeOf = (height, pos) => { const p = volumeBookChapter(height); return { ...p, section: pos == null ? null : pos + 1 }; };
 async function resolvePlacement(id) {
   if (isBlockId(id)) return placeOf(Number(id), null);
   if (id === GENESIS_COINBASE) return placeOf(0, 0);
@@ -97,12 +97,12 @@ async function resolvePlacement(id) {
 }
 
 // The tail of an entry's citation -- the part its heading hasn't already named.
-// Under a Book heading only the chapter (and a transaction's §verse) remains;
+// Under a Book heading only the chapter (and a transaction's §section) remains;
 // directly under a Volume, the book leads it. Spaced like the book's own
 // citations (e.g. "29 596", "1 §1").
-function tailRef({ book, chapter, verse }, underBook) {
+function tailRef({ book, chapter, section }, underBook) {
   let s = (underBook ? [chapter] : [book, chapter]).join(' ');
-  if (verse != null) s += ` §${verse}`;
+  if (section != null) s += ` §${section}`;
   return s;
 }
 

--- a/web/bitcoin-contents.html
+++ b/web/bitcoin-contents.html
@@ -25,17 +25,25 @@ a:hover { text-decoration: underline; }
 .page-head { text-align:center; padding-bottom:30px; margin-bottom:36px; border-bottom:1px solid var(--rule); }
 .page-eyebrow { font:600 11px/1 'IBM Plex Mono',monospace; letter-spacing:.3em; text-transform:uppercase; color:var(--accent); }
 
-.toc-group { font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.14em; text-transform:uppercase; color:var(--meta); margin:34px 0 6px; }
+/* The contents nest by the book's own citation scheme: a Volume part header,
+   then a Book sub-header whenever consecutive entries share one, so each row
+   need only cite the portion of its reference that its heading hasn't already
+   named -- a chapter under its book, or a book·chapter under its volume. */
+.toc-vol { margin:36px 0 4px; padding-top:15px; border-top:1px solid var(--rule);
+  font:600 11px/1 'IBM Plex Mono',monospace; letter-spacing:.22em; text-transform:uppercase; color:var(--accent); }
+.toc-vol:first-child { margin-top:8px; padding-top:0; border-top:none; }
+.toc-book { margin:15px 0 1px; padding-left:16px;
+  font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.16em; text-transform:uppercase; color:var(--meta); }
 
-/* A contents row: title (and date) on the left, a clickable reference on the
-   right that navigates into the book -- the manuscript's own citation form,
-   not a button. */
-.toc-entry { display:flex; align-items:baseline; gap:16px; padding:11px 2px; border-bottom:1px solid var(--hair); }
-.toc-title { flex:1; min-width:0; font:500 17px/1.4 'Newsreader',serif; color:var(--ink-soft); }
-.toc-date { flex:none; width:92px; text-align:right; font:400 12px/1.4 'IBM Plex Mono',monospace; color:var(--meta); letter-spacing:.02em; font-variant-numeric:tabular-nums; }
-.toc-ref { flex:none; min-width:104px; text-align:right; font:600 13px/1.4 'IBM Plex Mono',monospace; letter-spacing:.08em; color:var(--accent); white-space:nowrap; text-decoration:none; font-variant-numeric:tabular-nums; }
-.toc-ref:hover, .toc-ref:focus-visible, .toc-entry:hover .toc-ref { text-decoration:underline; color:var(--accent-2); outline:none; }
-.toc-ref.resolving { color:var(--meta); }
+/* A contents row: title on the left, its remaining reference on the right; the
+   whole row navigates into the book, the manuscript's own citation form. */
+.toc-entry { display:flex; align-items:baseline; gap:16px; padding:9px 2px 9px 16px; border-bottom:1px solid var(--hair); text-decoration:none; }
+.toc-entry.under-book { padding-left:32px; }
+.toc-title { flex:1; min-width:0; font:500 17px/1.35 'Newsreader',serif; color:var(--ink-soft); }
+.toc-ref { flex:none; min-width:84px; text-align:right; font:600 13px/1.4 'IBM Plex Mono',monospace; letter-spacing:.06em; color:var(--accent); white-space:nowrap; font-variant-numeric:tabular-nums; }
+.toc-entry:hover .toc-title { color:var(--ink); }
+.toc-entry:hover .toc-ref, .toc-entry:focus-visible .toc-ref { text-decoration:underline; color:var(--accent-2); }
+.toc-entry:focus-visible { outline:none; }
 </style>
 <body>
 <div class="wrap">
@@ -52,7 +60,8 @@ a:hover { text-decoration: underline; }
 </div>
 
 <script type="module">
-import { NOTABLE, isBlockId, blockRef, refFromProof, entryHref } from './btc-contents.js';
+import { NOTABLE, isBlockId, entryHref } from './btc-contents.js';
+import { volumeBookChapter, toRoman } from './btc-citation.js';
 
 const BOOKMARKS_KEY = 'glossia-btc-bookmarks';
 const readBookmarks = () => {
@@ -61,63 +70,105 @@ const readBookmarks = () => {
 };
 const shortHex = (hex) => `${hex.slice(0, 10)}…${hex.slice(-6)}`;
 
-// A transaction's reference is resolved the same way the reader resolves a
-// citation: its /tx/<txid>/merkle-proof gives the confirming block height and
-// the transaction's index within it. Tried across the same public mirrors the
-// book uses; memoized so a repeat render is free.
+// The genesis coinbase places offline -- block 0, first transaction -- so the
+// book opens at I 1 1 §1 without waiting on the network.
+const GENESIS_COINBASE = '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b';
+
+// Every entry is cited by its reference, never its raw id. A block's placement
+// is known offline from its height; a transaction's is resolved the same way the
+// reader resolves a citation -- a /tx/<txid>/merkle-proof gives the confirming
+// block height and the transaction's index (its §verse). Tried across the same
+// public mirrors the book uses.
 const ESPLORA_MIRRORS = ['https://blockstream.info/api', 'https://mempool.space/api'];
-const refCache = new Map();
-function resolveTxRef(txid) {
-  if (!refCache.has(txid)) {
-    refCache.set(txid, (async () => {
-      for (const base of ESPLORA_MIRRORS) {
-        try {
-          const res = await fetch(`${base}/tx/${txid}/merkle-proof`);
-          if (!res.ok) continue;
-          const mp = await res.json();
-          return refFromProof(mp.block_height, mp.pos);
-        } catch { /* try the next mirror */ }
-      }
-      return null;
-    })().catch(() => null));
+const placeOf = (height, pos) => { const p = volumeBookChapter(height); return { ...p, verse: pos == null ? null : pos + 1 }; };
+async function resolvePlacement(id) {
+  if (isBlockId(id)) return placeOf(Number(id), null);
+  if (id === GENESIS_COINBASE) return placeOf(0, 0);
+  for (const base of ESPLORA_MIRRORS) {
+    try {
+      const res = await fetch(`${base}/tx/${id}/merkle-proof`);
+      if (!res.ok) continue;
+      const mp = await res.json();
+      return placeOf(mp.block_height, mp.pos);
+    } catch { /* try the next mirror */ }
   }
-  return refCache.get(txid);
+  return null;
 }
 
-// One contents row: the title (and date) on the left, and a clickable reference
-// on the right that navigates into the book -- the manuscript's own citation
-// form, rather than a button spanning the whole row. A transaction's reference
-// streams in once resolved; until then (or if it can't be) its short hash links.
-function entryEl({ title, date, id }) {
-  const row = document.createElement('div');
-  row.className = 'toc-entry';
-  const t = document.createElement('span'); t.className = 'toc-title'; t.textContent = title;
-  row.append(t);
-  const d = document.createElement('span'); d.className = 'toc-date'; d.textContent = date || ''; row.append(d);
-  const link = document.createElement('a');
-  link.className = 'toc-ref';
-  link.href = entryHref(id);
-  if (isBlockId(id)) {
-    link.textContent = blockRef(id);
-  } else {
-    link.textContent = shortHex(id);
-    link.classList.add('resolving');
-    resolveTxRef(id).then((ref) => { if (ref) { link.textContent = ref; } link.classList.remove('resolving'); });
-  }
-  row.append(link);
+// The tail of an entry's citation -- the part its heading hasn't already named.
+// Under a Book heading only the chapter (and a transaction's §verse) remains;
+// directly under a Volume, the book leads it. Spaced like the book's own
+// citations (e.g. "29 596", "1 §1").
+function tailRef({ book, chapter, verse }, underBook) {
+  let s = (underBook ? [chapter] : [book, chapter]).join(' ');
+  if (verse != null) s += ` §${verse}`;
+  return s;
+}
+
+// One contents row: the title on the left, its remaining reference on the right;
+// the whole row is a link that navigates into the book.
+function entryEl(entry, underBook) {
+  const row = document.createElement('a');
+  row.className = 'toc-entry' + (underBook ? ' under-book' : '');
+  row.href = entryHref(entry.id);
+  const t = document.createElement('span'); t.className = 'toc-title'; t.textContent = entry.title;
+  const r = document.createElement('span'); r.className = 'toc-ref'; r.textContent = tailRef(entry.place, underBook);
+  row.append(t, r);
   return row;
 }
+function head(cls, label) { const d = document.createElement('div'); d.className = cls; d.textContent = label; return d; }
 
-function group(label) { const d = document.createElement('div'); d.className = 'toc-group'; d.textContent = label; return d; }
-
+// Render the placed entries as a nested contents: a Volume part header, then a
+// Book sub-header wherever two or more consecutive entries share one, so each
+// row need only cite the portion of its reference its headings haven't named.
+// Entries arrive in reading order (ascending height), so anything sharing a
+// volume or book is already contiguous.
 const toc = document.getElementById('toc');
-for (const e of NOTABLE) toc.append(entryEl({ title: e.title, date: e.date, id: e.id }));
-
-const bookmarks = readBookmarks();
-if (bookmarks.length) {
-  toc.append(group('Your bookmarks'));
-  for (const b of bookmarks) toc.append(entryEl({ title: b.title || b.prose || shortHex(b.hex), id: b.hex }));
+function render(entries) {
+  toc.replaceChildren();
+  for (let i = 0; i < entries.length;) {
+    const vol = entries[i].place.volume;
+    let jv = i + 1; while (jv < entries.length && entries[jv].place.volume === vol) jv++;
+    toc.append(head('toc-vol', `Volume ${toRoman(vol)}`));
+    for (let k = i; k < jv;) {
+      const bk = entries[k].place.book;
+      let jb = k + 1; while (jb < jv && entries[jb].place.book === bk) jb++;
+      if (jb - k >= 2) {
+        toc.append(head('toc-book', `Book ${bk}`));
+        for (let m = k; m < jb; m++) toc.append(entryEl(entries[m], true));
+      } else {
+        toc.append(entryEl(entries[k], false));
+      }
+      k = jb;
+    }
+    i = jv;
+  }
+  const bookmarks = readBookmarks();
+  if (bookmarks.length) {
+    toc.append(head('toc-vol', 'Your bookmarks'));
+    for (const b of bookmarks) {
+      const row = document.createElement('a');
+      row.className = 'toc-entry';
+      row.href = entryHref(b.hex);
+      const t = document.createElement('span'); t.className = 'toc-title'; t.textContent = b.title || b.prose || shortHex(b.hex);
+      row.append(t);
+      toc.append(row);
+    }
+  }
 }
+
+// Block placements are offline, so render them at once; transaction citations
+// stream in as each resolves, slotting into their volume and book in order. An
+// entry that never resolves simply stays out of the contents (its raw id is
+// never written).
+const placements = new Map();
+const placed = () => NOTABLE.filter((e) => placements.get(e.id)).map((e) => ({ ...e, place: placements.get(e.id) }));
+for (const e of NOTABLE) if (isBlockId(e.id)) placements.set(e.id, placeOf(Number(e.id), null));
+render(placed());
+await Promise.all(NOTABLE.filter((e) => !placements.has(e.id)).map(async (e) => {
+  placements.set(e.id, await resolvePlacement(e.id));
+  render(placed());
+}));
 </script>
 </body>
 </html>

--- a/web/bitcoin-contents.html
+++ b/web/bitcoin-contents.html
@@ -30,10 +30,10 @@ a:hover { text-decoration: underline; }
 /* A contents row: title (and date) on the left, a clickable reference on the
    right that navigates into the book -- the manuscript's own citation form,
    not a button. */
-.toc-entry { display:flex; align-items:baseline; gap:12px; padding:11px 2px; border-bottom:1px solid var(--hair); }
+.toc-entry { display:flex; align-items:baseline; gap:16px; padding:11px 2px; border-bottom:1px solid var(--hair); }
 .toc-title { flex:1; min-width:0; font:500 17px/1.4 'Newsreader',serif; color:var(--ink-soft); }
-.toc-date { flex:none; font:400 12px/1.4 'IBM Plex Mono',monospace; color:var(--meta); letter-spacing:.02em; }
-.toc-ref { flex:none; font:600 13px/1.4 'IBM Plex Mono',monospace; letter-spacing:.08em; color:var(--accent); white-space:nowrap; text-decoration:none; }
+.toc-date { flex:none; width:92px; text-align:right; font:400 12px/1.4 'IBM Plex Mono',monospace; color:var(--meta); letter-spacing:.02em; font-variant-numeric:tabular-nums; }
+.toc-ref { flex:none; min-width:104px; text-align:right; font:600 13px/1.4 'IBM Plex Mono',monospace; letter-spacing:.08em; color:var(--accent); white-space:nowrap; text-decoration:none; font-variant-numeric:tabular-nums; }
 .toc-ref:hover, .toc-ref:focus-visible, .toc-entry:hover .toc-ref { text-decoration:underline; color:var(--accent-2); outline:none; }
 .toc-ref.resolving { color:var(--meta); }
 </style>
@@ -93,7 +93,7 @@ function entryEl({ title, date, id }) {
   row.className = 'toc-entry';
   const t = document.createElement('span'); t.className = 'toc-title'; t.textContent = title;
   row.append(t);
-  if (date) { const d = document.createElement('span'); d.className = 'toc-date'; d.textContent = date; row.append(d); }
+  const d = document.createElement('span'); d.className = 'toc-date'; d.textContent = date || ''; row.append(d);
   const link = document.createElement('a');
   link.className = 'toc-ref';
   link.href = entryHref(id);

--- a/web/btc-citation.js
+++ b/web/btc-citation.js
@@ -48,7 +48,7 @@ export function toRoman(n) {
 }
 
 // The scripture-style reference for a block height: Roman volume, then book and
-// chapter (e.g. "III 2 5"). A transaction adds a §verse to this.
+// chapter (e.g. "III 2 5"). A transaction adds a §section to this.
 export function reference(height) {
   const { volume, book, chapter } = volumeBookChapter(height);
   return `${toRoman(volume)} ${book} ${chapter}`;

--- a/web/btc-contents.js
+++ b/web/btc-contents.js
@@ -19,6 +19,7 @@ export const NOTABLE = [
   { title: 'Bitcoin Pizza Day', id: '57043' },
   { title: '100K block milestone', id: '100000' },
   { title: 'Luke Dashjr’s Bible verses', id: '139690' },
+  { title: 'First P2SH spend', id: 'e5779b9e78f9650debc2893fd9636d827b26b4ddfa6a8172fe8708c924f5c39d' },
   { title: 'First halving', id: '210000' },
   { title: 'First coinbase OP_RETURN', id: '246816' },
   { title: 'Second halving', id: '420000' },
@@ -35,8 +36,8 @@ export const NOTABLE = [
 ];
 
 // More transaction-level entries still to confirm against the chain before
-// adding: payment-type firsts (P2PKH, P2SH, P2WPKH/P2WSH, P2TR key/script,
-// OP_RETURN spend) and a Lightning force-close revealing an HTLC.
+// adding: payment-type firsts (P2PKH, P2WPKH/P2WSH, P2TR key/script, OP_RETURN
+// spend) and a Lightning force-close revealing an HTLC.
 
 export const isBlockId = (id) => /^[0-9]+$/.test(id);
 

--- a/web/btc-contents.js
+++ b/web/btc-contents.js
@@ -3,34 +3,35 @@
 // the lookup card) and bitcoin-contents.html (the table-of-contents page).
 //
 // Each `id` is handed straight to the book's lookup: a bare number is a block
-// height, a 64-hex value a transaction id. A block's reference is known offline
-// (volume·book·chapter from its height); a transaction's is resolved the same
-// way the reader resolves a citation -- a /tx/<txid>/merkle-proof lookup gives
-// its block height and index, yielding volume·book·chapter·§verse. Ordered
-// chronologically (reading order).
+// height, a 64-hex value a transaction id. Every entry is cited by its
+// reference, never its raw id: a block's is known offline (volume·book·chapter
+// from its height); a transaction's is resolved the same way the reader resolves
+// a citation -- a /tx/<txid>/merkle-proof lookup gives its block height and
+// index, yielding volume·book·chapter·§verse. Ordered chronologically (reading
+// order).
 
 import { reference } from './btc-citation.js';
 
 export const NOTABLE = [
-  { title: 'The Times 03/Jan/2009 Chancellor on brink of second bailout for banks', id: '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b', date: 'Jan 3, 2009' },
-  { title: 'Block 1 mined', id: '1', date: 'Jan 9, 2009' },
-  { title: 'First peer-to-peer transaction', id: '170', date: 'Jan 12, 2009' },
-  { title: 'Bitcoin Pizza Day', id: '57043', date: 'May 22, 2010' },
-  { title: '100K block milestone', id: '100000', date: 'Dec 29, 2010' },
-  { title: 'Luke Dashjr’s Bible verses', id: '139690', date: 'Aug 5, 2011' },
-  { title: 'First halving', id: '210000', date: 'Nov 28, 2012' },
-  { title: 'First coinbase OP_RETURN', id: '246816', date: 'Jul 16, 2013' },
-  { title: 'Second halving', id: '420000', date: 'Jul 9, 2016' },
-  { title: 'Bitcoin Cash fork', id: '478558', date: 'Aug 1, 2017' },
-  { title: 'SegWit activation', id: '481824', date: 'Aug 24, 2017' },
-  { title: '500K block milestone', id: '500000', date: 'Dec 18, 2017' },
-  { title: 'Third halving', id: '630000', date: 'May 11, 2020' },
-  { title: 'Block 666,666', id: '666666', date: 'Jan 18, 2021' },
-  { title: 'Romans 12:21 message', id: '057954bb28527ff9c7701c6fd2b7f770163718ded09745da56cc95e7606afe99', date: 'Jan 2021' },
-  { title: 'Taproot activation', id: '709632', date: 'Nov 14, 2021' },
-  { title: 'First Ordinals inscription', id: '6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799', date: 'Dec 14, 2022' },
-  { title: 'Largest block (at the time)', id: '774628', date: 'Feb 1, 2023' },
-  { title: 'Fourth halving', id: '840000', date: 'Apr 20, 2024' },
+  { title: 'The Times 03/Jan/2009 Chancellor on brink of second bailout for banks', id: '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b' },
+  { title: 'Block 1 mined', id: '1' },
+  { title: 'First peer-to-peer transaction', id: '170' },
+  { title: 'Bitcoin Pizza Day', id: '57043' },
+  { title: '100K block milestone', id: '100000' },
+  { title: 'Luke Dashjr’s Bible verses', id: '139690' },
+  { title: 'First halving', id: '210000' },
+  { title: 'First coinbase OP_RETURN', id: '246816' },
+  { title: 'Second halving', id: '420000' },
+  { title: 'Bitcoin Cash fork', id: '478558' },
+  { title: 'SegWit activation', id: '481824' },
+  { title: '500K block milestone', id: '500000' },
+  { title: 'Third halving', id: '630000' },
+  { title: 'Block 666,666', id: '666666' },
+  { title: 'Romans 12:21 message', id: '057954bb28527ff9c7701c6fd2b7f770163718ded09745da56cc95e7606afe99' },
+  { title: 'Taproot activation', id: '709632' },
+  { title: 'First Ordinals inscription', id: '6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799' },
+  { title: 'Largest block (at the time)', id: '774628' },
+  { title: 'Fourth halving', id: '840000' },
 ];
 
 // More transaction-level entries still to confirm against the chain before

--- a/web/btc-contents.js
+++ b/web/btc-contents.js
@@ -7,7 +7,7 @@
 // reference, never its raw id: a block's is known offline (volume·book·chapter
 // from its height); a transaction's is resolved the same way the reader resolves
 // a citation -- a /tx/<txid>/merkle-proof lookup gives its block height and
-// index, yielding volume·book·chapter·§verse. Ordered chronologically (reading
+// index, yielding volume·book·chapter·§section. Ordered chronologically (reading
 // order).
 
 import { reference } from './btc-citation.js';
@@ -47,7 +47,7 @@ export function blockRef(id) {
 }
 
 // Format a resolved citation -- a block height and the transaction's index
-// within it -- as a full volume·book·chapter·§verse reference.
+// within it -- as a full volume·book·chapter·§section reference.
 export function refFromProof(height, pos) {
   return reference(height) + (pos != null ? ` §${pos + 1}` : '');
 }

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -369,9 +369,9 @@ const markToken = (glyph, text, title) => `<span class="op" title="${title}">${g
 // ─── data type marks ───────────────────────────────────────────────────
 //
 // A pushed datum whose kind is recognizable carries its type mark from the
-// Notation key -- 𝓅 public key, 𝓈 signature, 𝒽 hash, 𝓇 redeem script,
-// 𝓌 witness script, 𝓉 tapscript -- set just before its prose, so a script
-// reads as its pattern (⁶⁵𝓅 ∇) without consulting the key. Classification
+// Notation key -- p public key, s signature, h hash, r redeem script,
+// w witness script, t tapscript -- set just before its prose, so a script
+// reads as its pattern (⁶⁵p ∇) without consulting the key. Classification
 // is display-only annotation: it never changes what gets encoded.
 const dataMark = (sym, title) => `<span class="dt" title="${title}">${sym}</span>`;
 
@@ -380,15 +380,15 @@ const dataMark = (sym, title) => `<span class="dt" title="${title}">${sym}</span
 // push in script context is a HASH160; a 32-byte one is a hash -- except
 // directly after ① (a witness-v1 program: Taproot's tweaked output key), or
 // directly before a signature check (an x-only key inside a tapscript).
-// Non-canonical DER (0x30-led, signature-sized) still marks 𝓈.
+// Non-canonical DER (0x30-led, signature-sized) still marks s.
 const SIG_CHECK_OPS = new Set([0xac, 0xad, 0xba]);
 function scriptDataMark(push, compact, prevOp, nextOp) {
   const n = push.length / 2;
-  if (compact || (push.slice(0, 2) === '30' && n >= 68 && n <= 73)) return dataMark('𝓈', 'signature');
-  if (isPubkey(push)) return dataMark('𝓅', 'public key');
-  if (n === 32 && prevOp === 0x51) return dataMark('𝓅', 'public key — Taproot tweaked output key');
-  if (n === 32 && SIG_CHECK_OPS.has(nextOp)) return dataMark('𝓅', 'public key — x-only');
-  if (n === 20 || n === 32) return dataMark('𝒽', 'hash');
+  if (compact || (push.slice(0, 2) === '30' && n >= 68 && n <= 73)) return dataMark('s', 'signature');
+  if (isPubkey(push)) return dataMark('p', 'public key');
+  if (n === 32 && prevOp === 0x51) return dataMark('p', 'public key — Taproot tweaked output key');
+  if (n === 32 && SIG_CHECK_OPS.has(nextOp)) return dataMark('p', 'public key — x-only');
+  if (n === 20 || n === 32) return dataMark('h', 'hash');
   return '';
 }
 
@@ -454,8 +454,8 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
       const mark = pushToken(t.pushForm || 0, t.push.length / 2);
       if (!t.push) { parts.push(mark); return; }              // a zero-length extended push -- the mark alone
       if (i === redeemIdx && looksLikeScript(t.push)) {
-        // reveal the redeemScript, typed 𝓇
-        parts.push(mark + dataMark('𝓇', 'redeem script — revealed as opcodes'), renderScript(t.push, collect));
+        // reveal the redeemScript, typed r
+        parts.push(mark + dataMark('r', 'redeem script — revealed as opcodes'), renderScript(t.push, collect));
         return;
       }
       if (eligible) {
@@ -539,9 +539,9 @@ function witnessScriptIndex(items) {
 
 // An input's witness stack (hex items) -> its footnote display. `encode` turns
 // a data item's hex into Glossia prose; the one script item, if present,
-// becomes opcode notation, typed 𝓌 (a P2WSH witnessScript) or 𝓉 (a Taproot
+// becomes opcode notation, typed w (a P2WSH witnessScript) or t (a Taproot
 // tapscript, identified by the control block above it). Data items carry
-// their own type marks -- 𝓈 a signature, 𝓅 a key -- and items are separated
+// their own type marks -- s a signature, p a key -- and items are separated
 // so each reads as its own stack element.
 export function renderWitness(items, encode) {
   if (!items || !items.length) return '∅';
@@ -551,12 +551,12 @@ export function renderWitness(items, encode) {
     .map((hex, i) => {
       if (!hex) return '<span class="wit-empty">∅</span>';    // an empty stack item
       if (i === scriptIdx) {
-        return (isTapscript ? dataMark('𝓉', 'tapscript — a Taproot leaf, revealed as opcodes') : dataMark('𝓌', 'witness script — revealed as opcodes'))
+        return (isTapscript ? dataMark('t', 'tapscript — a Taproot leaf, revealed as opcodes') : dataMark('w', 'witness script — revealed as opcodes'))
           + ' ' + renderScript(hex, encode);
       }
       const compact = derToCompact(hex);                      // a DER signature is stripped to r‖s‖sighash
-      const dm = (compact || isSignature(hex)) ? dataMark('𝓈', 'signature')
-        : isPubkey(hex) ? dataMark('𝓅', 'public key') : '';
+      const dm = (compact || isSignature(hex)) ? dataMark('s', 'signature')
+        : isPubkey(hex) ? dataMark('p', 'public key') : '';
       return (dm ? dm + ' ' : '') + encode(compact || hex);
     })
     .join('<span class="wit-sep"> · </span>');

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -393,11 +393,12 @@ function scriptDataMark(push, compact, prevOp, nextOp) {
 }
 
 // A data push whose bytes are ALL printable ASCII (e.g. an Ordinals inscription's
-// content type or a text body) -> its decoded string, else null. Requiring the
-// WHOLE push to be printable -- not merely a run within it -- keeps keys, hashes
-// and signatures (dense binary) from ever being mistaken for text, so this is
-// safe to apply to any script, not just an OP_RETURN payload.
-const ASCII_PUSH_MIN = 5;
+// "ord" tag, its content type or a text body) -> its decoded string, else null.
+// Requiring the WHOLE push to be printable -- not merely a run within it -- keeps
+// keys, hashes and signatures (dense binary, and all ≥ 20 bytes) from ever being
+// mistaken for text, so this is safe to apply to any script, not just an OP_RETURN
+// payload. The floor is 3 so a short protocol tag like Ordinals' "ord" is caught.
+const ASCII_PUSH_MIN = 3;
 function asciiPush(hex) {
   if (!hex || hex.length / 2 < ASCII_PUSH_MIN) return null;
   let out = '';

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -76,12 +76,13 @@ function locktimeInfo(locktime) {
 function sequenceInfo(seq) {
   if ((seq & 0x80000000) === 0) {
     const n = seq & 0x0000ffff;
-    // A relative block delay counts chapters, so it reads in Roman numerals
-    // (■CXLIV = 144 blocks); a time delay is physical time, so it reads as
-    // an exact duration (Τ20h28m48s), the wire units kept in the hover.
+    // A relative block delay counts chapters, so it reads as a decimal count
+    // (■144 = 144 blocks) -- chapters are numbered in decimal, only volumes in
+    // Roman; a time delay is physical time, so it reads as an exact duration
+    // (Τ20h28m48s), the wire units kept in the hover.
     return (seq & 0x00400000)
       ? { rbf: true, mark: `Τ${durationFrom512s(n)}`, kind: 'time', title: `replaceable; relative locktime ${durationFrom512s(n)} (${n} × 512 s) after the input's confirmation` }
-      : { rbf: true, mark: `■${toRoman(n)}`, kind: 'block', title: `replaceable; relative locktime ${n} block${n === 1 ? '' : 's'} after the input's confirmation` };
+      : { rbf: true, mark: `■${n}`, kind: 'block', title: `replaceable; relative locktime ${n} block${n === 1 ? '' : 's'} after the input's confirmation` };
   }
   if (seq === 0xffffffff) return { rbf: false, mark: '●', kind: 'final', title: 'final — disables the transaction locktime for this input' };
   if (seq === 0xfffffffe) return { rbf: false, mark: '○', kind: 'locktime', title: 'not replaceable, but respects the transaction locktime' };

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -423,6 +423,26 @@ function numberPush(hex) {
   return BigInt('0x' + reverseHexStr(hex)).toString();
 }
 
+// The little-endian value a short push encodes (1-5 bytes, per CScriptNum), for
+// reading a CLTV/CSV threshold; null if it isn't a plausible script number. The
+// operands are positive, so unsigned LE reads them exactly (a sign byte is 0x00).
+function scriptNumValue(hex) {
+  const n = hex.length / 2;
+  if (n < 1 || n > 5) return null;
+  return Number(BigInt('0x' + reverseHexStr(hex)));
+}
+
+// A CSV (OP_CHECKSEQUENCEVERIFY) operand -> its relative-timelock mark in the
+// same ■(block, a count of chapters) / Τ(time, a duration) grammar an input's
+// nSequence uses; null when the disable bit is set (not a relative timelock).
+function csvMark(value) {
+  if (value & 0x80000000) return null;
+  const n = value & 0xffff;
+  return (value & 0x00400000)
+    ? { mark: `Τ${durationFrom512s(n)}`, title: `relative locktime — at least ${durationFrom512s(n)} (${n} × 512 s) after this coin was confirmed` }
+    : { mark: `■${n}`, title: `relative locktime — at least ${n} block${n === 1 ? '' : 's'} after this coin was confirmed` };
+}
+
 // data push to Glossia prose. Options: `eligible` (an OP_RETURN payload, or a
 // coinbase) turns on inline ASCII quoting for legible pushes; `nested` reveals a
 // script pushed as data -- a P2SH redeemScript, always the final push -- by
@@ -471,6 +491,16 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
         // reveal the redeemScript, typed r
         parts.push(mark + dataMark('r', 'redeem script — revealed as opcodes'), renderScript(t.push, collect));
         return;
+      }
+      // A push directly before OP_CLTV (τ) or OP_CSV (Δ) is a timelock threshold,
+      // not opaque data: decode it to the same ■(block)/Τ(time) mark the margin
+      // gives an nLockTime (absolute) or nSequence (relative), so a script's
+      // timelock reads in the book's own grammar rather than a bare number.
+      const nextOp = toks[i + 1]?.op;
+      if (nextOp === 0xb1 || nextOp === 0xb2) {
+        const v = scriptNumValue(t.push);
+        const info = v === null ? null : (nextOp === 0xb1 ? locktimeInfo(v) : csvMark(v));
+        if (info && info.mark) { parts.push(`<span class="op" title="${escapeHtml(info.title)}">${info.mark}</span>`); return; }
       }
       if (eligible) {
         const found = findAsciiStrings(t.push);

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -410,6 +410,18 @@ function asciiPush(hex) {
   return out;
 }
 
+// A short data push (1-4 bytes) minimally encoding a number -> its decimal, else
+// null. An Ordinals field tag (content type = 1, body = 0) is a small number
+// pushed as data, not an OP_N, so it would otherwise fall through to cover prose
+// -- a single byte becoming an absurd little sentence. Minimal (no trailing zero
+// byte), so the decimal alone reconstructs the wire bytes. Keys, hashes and
+// signatures are all ≥ 20 bytes, well past this window.
+function numberPush(hex) {
+  const n = hex.length / 2;
+  if (n < 1 || n > 4 || hex.slice(-2) === '00') return null;
+  return BigInt('0x' + reverseHexStr(hex)).toString();
+}
+
 // data push to Glossia prose. Options: `eligible` (an OP_RETURN payload, or a
 // coinbase) turns on inline ASCII quoting for legible pushes; `nested` reveals a
 // script pushed as data -- a P2SH redeemScript, always the final push -- by
@@ -467,6 +479,10 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
       // embedded message) reads as its own quoted text rather than cover prose.
       const text = asciiPush(t.push);
       if (text !== null) { parts.push(mark, `“${escapeHtml(text)}”`); return; }
+      // A short number pushed as data (an Ordinals field tag, a script number)
+      // reads as its literal digits, like the book's other structural numbers.
+      const num = numberPush(t.push);
+      if (num !== null) { parts.push(`<span class="op" title="pushed number — ${num}">${num}</span>`); return; }
       const compact = derToCompact(t.push);                   // a DER signature is stripped to r‖s‖sighash
       parts.push(mark + scriptDataMark(t.push, compact, prevOp, toks[i + 1]?.op), collect(compact || t.push));
     } else {

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -607,7 +607,7 @@ export function composeTransactionFields(parsed, bestOf = 1, lazyData = null) {
     }
     const seq = sequenceInfo(v.sequence);
     // The prevout is carried as a reference (txid + output index), not encoded:
-    // the book resolves it to a volume/book/chapter/verse citation for the left
+    // the book resolves it to a volume/book/chapter/section citation for the left
     // margin. A coinbase has none. Raw per-input witness bytes (segwit only) ride
     // along so each input's witness can become its own footnote.
     return {

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -570,35 +570,40 @@ function looksLikeScript(h) {
   return toks.some((t) => t.op !== undefined && SCRIPT_SIGNAL.has(t.op));
 }
 
-// Which witness item (if any) is the script to render as opcodes: a Taproot
-// tapscript (sitting just below its control block) or a P2WSH witnessScript
-// (the last item). Returns -1 when the witness is all data -- P2WPKH, a
-// key-path spend, a bare signature.
-function witnessScriptIndex(items) {
+// Which witness items are scripts to render as opcodes. A witness can carry more
+// than one -- a Taproot tapscript sits just below a control block (and a witness
+// may reveal several), a P2WSH witnessScript is the last item -- so return the
+// full set, not a single index. An item counts as a script if it either sits
+// directly below a control block, or parses cleanly as one on its own (a clean
+// opcode stream with a signature check or timelock). Control blocks, signatures
+// and keys are never scripts, so they are excluded. Empty for an all-data
+// witness -- P2WPKH, a key-path spend, a bare signature.
+function witnessScriptIndices(items) {
+  const idxs = new Set();
   const n = items.length;
-  if (n === 0) return -1;
+  if (n === 0) return idxs;
   let last = n - 1;
   if (n >= 2 && witFirst(items[last]) === 0x50) last -= 1;    // strip an optional annex
-  if (last >= 1 && isControlBlock(items[last])) return last - 1;
-  const tail = items[n - 1];
-  if (isPubkey(tail) || isSignature(tail)) return -1;
-  return looksLikeScript(tail) ? n - 1 : -1;
+  for (let i = 0; i <= last; i++) {
+    if (i + 1 <= last && isControlBlock(items[i + 1])) { idxs.add(i); continue; }  // a tapscript, below its control block
+    if (!isControlBlock(items[i]) && looksLikeScript(items[i])) idxs.add(i);       // a witnessScript, or a reveal
+  }
+  return idxs;
 }
 
 // An input's witness stack (hex items) -> its footnote display. `encode` turns
-// a data item's hex into Glossia prose; the one script item, if present,
-// becomes opcode notation, typed w (a P2WSH witnessScript) or t (a Taproot
-// tapscript, identified by the control block above it). Data items carry
-// their own type marks -- s a signature, p a key -- and items are separated
-// so each reads as its own stack element.
+// a data item's hex into Glossia prose; every script item becomes opcode
+// notation, typed w (a P2WSH witnessScript) or t (a Taproot tapscript, identified
+// by the control block above it). Data items carry their own type marks -- s a
+// signature, p a key -- and items are separated so each reads as its own element.
 export function renderWitness(items, encode) {
   if (!items || !items.length) return '∅';
-  const scriptIdx = witnessScriptIndex(items);
-  const isTapscript = scriptIdx >= 0 && scriptIdx + 1 < items.length && isControlBlock(items[scriptIdx + 1]);
+  const scriptIdxs = witnessScriptIndices(items);
   return items
     .map((hex, i) => {
       if (!hex) return '<span class="wit-empty">∅</span>';    // an empty stack item
-      if (i === scriptIdx) {
+      if (scriptIdxs.has(i)) {
+        const isTapscript = i + 1 < items.length && isControlBlock(items[i + 1]);
         return (isTapscript ? dataMark('t', 'tapscript — a Taproot leaf, revealed as opcodes') : dataMark('w', 'witness script — revealed as opcodes'))
           + ' ' + renderScript(hex, encode);
       }


### PR DESCRIPTION
Align the table-of-contents right side into clean columns: dates get a
fixed-width right-aligned column and references a consistent right edge,
both with tabular figures, so the volume·book·chapter citations line up
down the page. The date column is always reserved (empty for bookmark
rows) to keep alignment when a row has no date.

Strip the notation key down to its glyph tables: remove the intro lede
and every italic per-section explainer note (and the long common-script
-patterns paragraph), keeping the section headers, glyph tables, and
their inline one-line labels. Drop the now-unused CSS rules.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017wzyaf213K1uVb5xdArW5a