### PR TITLE
Render an input's sequence mark after its reference, matching wire order

### DIFF
--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -711,7 +711,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">†</span><span class="m"><b>replaceable</b> (opt-in RBF)</span></div>
           <div class="glyph-row"><span class="g">■<i>N</i></span><span class="m">relative: N blocks after confirmation (a count of chapters)</span></div>
           <div class="glyph-row"><span class="g">Τ<i>Δt</i></span><span class="m">relative: a duration after confirmation (d h m s)</span></div>
-          <div class="glyph-row"><span class="g">(<i>n</i>)</span><span class="m">the <b>amount spent</b> by this input — value flowing in; an output's amount stands bare</span></div>
+          <div class="glyph-row"><span class="g">(₿<i>n</i>)</span><span class="m">the <b>amount spent</b> by this input — value flowing in; an output's amount stands bare (₿<i>n</i>, no parentheses)</span></div>
         </div>
       </div>
 
@@ -756,7 +756,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 <script type="module">
 import { init, encodeSeedPhrase } from './glossia-msg.js';
 import { parseTransaction, computeTxid, parseBlockHeader, computeBlockHash } from './btc-tx.js';
-import { composeTransactionFields, composeBlockHeaderFields, groupDigits, renderWitness } from './btc-prose.js';
+import { composeTransactionFields, composeBlockHeaderFields, groupDigits, formatBtc, renderWitness } from './btc-prose.js';
 import { volumeBookChapter, heightOf, toRoman, reference } from './btc-citation.js';
 import { NOTABLE, isBlockId, refFromProof, entryHref } from './btc-contents.js';
 
@@ -1134,8 +1134,8 @@ async function resolveCitations(pending, gen) {
       // the mark for value flowing IN, where an output's amount (value flowing
       // out) stands bare.
       if (amtVal && outputs && outputs[vout]) {
-        amtVal.textContent = `(${groupDigits(String(outputs[vout].value))})`;
-        amtVal.title = 'the amount this input spends, in satoshis';
+        amtVal.textContent = `(${formatBtc(outputs[vout].value)})`;
+        amtVal.title = `the amount this input spends: ${groupDigits(String(outputs[vout].value))} satoshis`;
       }
     } catch (e) {
       if (gen !== renderGen) return;
@@ -1509,6 +1509,7 @@ function renderChapter(para) {
     const valueCell = document.createElement('div');
     valueCell.className = 'tx-note tx-out-value';
     valueCell.textContent = out.value;
+    valueCell.title = out.valueTitle;
     // Forward citation placeholder: filled with the section that later spent
     // this output, once the outspends resolve. An unspent output keeps it
     // empty -- still-live value has no forward reference.

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -329,6 +329,10 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   border-left: 2px solid var(--accent); border-radius: 1px;
   font: italic 400 17.5px/1.6 'Newsreader',serif; color: var(--ink-soft);
 }
+/* A tab inside a quoted embedded message (see quoteText in btc-prose.js): a
+   fixed-width gap, so column-aligned text keeps its spacing instead of
+   collapsing to a single space. */
+.tab { display: inline-block; width: 4ch; }
 .tx-line.tx-body-lead::first-letter {
   font-size: 3.4em; float: left; line-height: .82; padding: .04em .07em 0 0;
   font-weight: 500; color: var(--accent);

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -476,47 +476,47 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <div class="pattern-table">
           <span class="phead"></span><span class="phead">UTXO</span><span class="phead">Validator</span><span class="phead">STXO</span><span class="phead">Witness</span>
           <span class="pname">P2PK</span>
-            <span class="seq"><span class="op op-push">⁶⁵</span><span class="ph">p</span> <span class="op">∇</span></span>
+            <span class="seq"><span class="ph">p</span><span class="op op-push">⁶⁵</span> <span class="op">∇</span></span>
             <span class="seq exec"><span class="ph">s</span> <span class="ph chain">p</span> <span class="op">∇</span></span>
             <span class="seq"><span class="ph">s</span></span>
             <span class="seq none">—</span>
           <span class="pname">P2PKH</span>
-            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">h</span> <span class="op">≡</span> <span class="op">∇</span></span>
+            <span class="seq"><span class="op">⧉</span> <span class="op">⌖</span> <span class="ph">h</span><span class="op op-push">²⁰</span> <span class="op">≡</span> <span class="op">∇</span></span>
             <span class="seq exec"><span class="ph">s</span> <span class="ph">p</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">≡</span> <span class="op">∇</span></span>
             <span class="seq"><span class="ph">s</span> <span class="ph">p</span></span>
             <span class="seq none">—</span>
           <span class="pname">Multisig</span>
-            <span class="seq"><span class="op">②</span> <span class="op op-push">³³</span><span class="ph">p<sub>1</sub></span> <span class="op op-push">³³</span><span class="ph">p<sub>2</sub></span> <span class="op op-push">³³</span><span class="ph">p<sub>3</sub></span> <span class="op">③</span> <span class="op">◇</span></span>
+            <span class="seq"><span class="op">②</span> <span class="ph">p<sub>1</sub></span><span class="op op-push">³³</span> <span class="ph">p<sub>2</sub></span><span class="op op-push">³³</span> <span class="ph">p<sub>3</sub></span><span class="op op-push">³³</span> <span class="op">③</span> <span class="op">◇</span></span>
             <span class="seq exec"><span class="op">⓪</span> <span class="ph">s<sub>1</sub></span> <span class="ph">s<sub>2</sub></span> <span class="op">②</span> <span class="ph">p<sub>1</sub></span> <span class="ph">p<sub>2</sub></span> <span class="ph">p<sub>3</sub></span> <span class="op">③</span> <span class="op">◇</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">s<sub>1</sub></span> <span class="ph">s<sub>2</sub></span></span>
             <span class="seq none">—</span>
           <span class="pname">P2SH</span>
-            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">h</span> <span class="op">=</span></span>
+            <span class="seq"><span class="op">⌖</span> <span class="ph">h</span><span class="op op-push">²⁰</span> <span class="op">=</span></span>
             <span class="seq exec"><span class="ph">r</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(r)</span></span>
             <span class="seq"><span class="op">(r)</span></span>
             <span class="seq none">—</span>
           <span class="pname">P2SH · 2-of-3</span>
-            <span class="seq"><span class="op">⌖</span> <span class="op op-push">²⁰</span><span class="ph">h</span> <span class="op">=</span></span>
+            <span class="seq"><span class="op">⌖</span> <span class="ph">h</span><span class="op op-push">²⁰</span> <span class="op">=</span></span>
             <span class="seq exec"><span class="op">②</span> <span class="ph">p<sub>1</sub></span> <span class="ph">p<sub>2</sub></span> <span class="ph">p<sub>3</sub></span> <span class="op">③</span> <span class="op">◇</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(</span><span class="op">②</span> <span class="ph">p<sub>1</sub></span> <span class="ph">p<sub>2</sub></span> <span class="ph">p<sub>3</sub></span> <span class="op">③</span> <span class="op">◇</span><span class="op">)</span></span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">s<sub>1</sub></span> <span class="ph">s<sub>2</sub></span> <span class="op">②</span> <span class="ph">p<sub>1</sub></span> <span class="ph">p<sub>2</sub></span> <span class="ph">p<sub>3</sub></span> <span class="op">③</span> <span class="op">◇</span></span>
             <span class="seq none">—</span>
           <span class="pname">P2WPKH</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">²⁰</span><span class="ph">h</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">h</span><span class="op op-push">²⁰</span></span>
             <span class="seq exec"><span class="ph">s</span> <span class="ph">p</span> <span class="op">⧉</span> <span class="op">⌖</span> <span class="ph chain">h</span> <span class="op">≡</span> <span class="op">∇</span></span>
             <span class="seq none">∅</span>
             <span class="seq"><span class="ph">s</span> <span class="ph">p</span></span>
           <span class="pname">P2WSH</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">h</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">h</span><span class="op op-push">³²</span></span>
             <span class="seq exec"><span class="ph">w</span> <span class="op">Σ</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(w)</span></span>
             <span class="seq none">∅</span>
             <span class="seq"><span class="op">(w)</span></span>
           <span class="pname">P2TR key</span>
-            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">p</span></span>
+            <span class="seq"><span class="op">①</span> <span class="ph">p</span><span class="op op-push">³²</span></span>
             <span class="seq exec"><span class="ph">s</span> <span class="op">∇</span></span>
             <span class="seq none">∅</span>
             <span class="seq"><span class="ph">s</span></span>
           <span class="pname">P2TR script</span>
-            <span class="seq"><span class="op">①</span> <span class="op op-push">³²</span><span class="ph">p</span></span>
+            <span class="seq"><span class="op">①</span> <span class="ph">p</span><span class="op op-push">³²</span></span>
             <span class="seq exec"><span class="ph">t</span> <span class="op">⋔</span> <span class="ph chain">p</span> <span class="op">=</span> <span class="op">(t)</span></span>
             <span class="seq none">∅</span>
             <span class="seq"><span class="ph">s</span> <span class="ph">t</span> <span class="ph">c</span></span>
@@ -535,27 +535,27 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <div class="pattern-table">
           <span class="phead"></span><span class="phead">UTXO</span><span class="phead">Validator</span><span class="phead">STXO</span><span class="phead">Witness</span>
           <span class="pname">Channel open · 2-of-2</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">h</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">h</span><span class="op op-push">³²</span></span>
             <span class="seq exec"><span class="op">②</span> <span class="ph">p<sub>1</sub></span> <span class="ph">p<sub>2</sub></span> <span class="op">②</span> <span class="op">◇</span> <span class="op">Σ</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(</span><span class="op">②</span> <span class="ph">p<sub>1</sub></span> <span class="ph">p<sub>2</sub></span> <span class="op">②</span> <span class="op">◇</span><span class="op">)</span></span>
             <span class="seq none">∅</span>
             <span class="seq"><span class="op">⓪</span> <span class="ph">s<sub>1</sub></span> <span class="ph">s<sub>2</sub></span></span>
           <span class="pname">Force close · to_local</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">h</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">h</span><span class="op op-push">³²</span></span>
             <span class="seq exec"><span class="op">⟨</span> <span class="ph">p<sub>r</sub></span> <span class="op">│</span> <span class="op">■</span> <span class="op">Δ</span> <span class="op">⌄</span> <span class="ph">p<sub>1</sub></span> <span class="op">⟩</span> <span class="op">∇</span> <span class="op">Σ</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(</span><span class="op">⟨</span> <span class="ph">p<sub>r</sub></span> <span class="op">│</span> <span class="op">■</span> <span class="op">Δ</span> <span class="op">⌄</span> <span class="ph">p<sub>1</sub></span> <span class="op">⟩</span> <span class="op">∇</span><span class="op">)</span></span>
             <span class="seq none">∅</span>
             <span class="seq"><span class="ph">s<sub>1</sub></span> <span class="op">⓪</span> · <span class="ph">s<sub>r</sub></span> <span class="op">①</span></span>
           <span class="pname">Force close · to_remote</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">h</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">h</span><span class="op op-push">³²</span></span>
             <span class="seq exec"><span class="ph">p<sub>2</sub></span> <span class="op">▼</span> <span class="op">①</span> <span class="op">Δ</span> <span class="op">Σ</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(</span><span class="ph">p<sub>2</sub></span> <span class="op">▼</span> <span class="op">①</span> <span class="op">Δ</span><span class="op">)</span></span>
             <span class="seq none">∅</span>
             <span class="seq"><span class="ph">s<sub>2</sub></span></span>
           <span class="pname">Force close · anchor</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">h</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">h</span><span class="op op-push">³²</span></span>
             <span class="seq exec"><span class="ph">p</span> <span class="op">∇</span> <span class="op">⧉?</span> <span class="op">¬⟨</span> <span class="op">⑯</span> <span class="op">Δ</span> <span class="op">⟩</span> <span class="op">Σ</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(</span><span class="ph">p</span> <span class="op">∇</span> <span class="op">⧉?</span> <span class="op">¬⟨</span> <span class="op">⑯</span> <span class="op">Δ</span> <span class="op">⟩</span><span class="op">)</span></span>
             <span class="seq none">∅</span>
             <span class="seq"><span class="ph">s</span> · <span class="op">∅</span></span>
           <span class="pname">Force close · HTLC</span>
-            <span class="seq"><span class="op">⓪</span> <span class="op op-push">³²</span><span class="ph">h</span></span>
+            <span class="seq"><span class="op">⓪</span> <span class="ph">h</span><span class="op op-push">³²</span></span>
             <span class="seq exec"><span class="op">⟨</span> <span class="ph">p<sub>r</sub></span> <span class="op">│</span> <span class="op">⟨</span> <span class="op">Σ</span> <span class="ph">h</span> <span class="op">≡</span> <span class="ph">p<sub>1</sub></span> <span class="op">│</span> <span class="op">τ</span> <span class="op">⌄</span> <span class="ph">p<sub>2</sub></span> <span class="op">⟩</span> <span class="op">⟩</span> <span class="op">∇</span> <span class="op">Σ</span> <span class="ph chain">h</span> <span class="op">=</span> <span class="op">(</span><span class="op">⟨</span> <span class="ph">p<sub>r</sub></span> <span class="op">│</span> <span class="op">⟨</span> <span class="op">Σ</span> <span class="ph">h</span> <span class="op">≡</span> <span class="ph">p<sub>1</sub></span> <span class="op">│</span> <span class="op">τ</span> <span class="op">⌄</span> <span class="ph">p<sub>2</sub></span> <span class="op">⟩</span> <span class="op">⟩</span> <span class="op">∇</span><span class="op">)</span></span>
             <span class="seq none">∅</span>
             <span class="seq"><span class="ph">s<sub>1</sub></span> <span class="ph">h</span> <span class="op">①</span> <span class="op">⓪</span> · <span class="ph">s<sub>2</sub></span> <span class="op">⓪</span> <span class="op">⓪</span> · <span class="ph">s<sub>r</sub></span> <span class="op">①</span></span>
@@ -704,7 +704,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g"><b>⋔</b></span><span class="m"><b>merkle proof</b> — the revealed leaf's path in the taptree</span></div>
           <div class="glyph-row"><span class="g"><b>a</b></span><span class="m"><b>annex</b> (reserved Taproot spend data)</span></div>
         </div>
-        <p class="notation-note"><b>Bold</b> where the datum is on chain — a lock, or what a spend writes; <b>plain</b> where a spend introduces it at validation.</p>
+        <p class="notation-note">A push of known length carries its byte count as a superscript on the mark — <b>h</b>²⁰, <b>p</b>⁶⁵; a bare, untyped push keeps its count leading (²⁰). <b>Bold</b> where the datum is on chain — a lock, or what a spend writes; <b>plain</b> where a spend introduces it at validation.</p>
       </div>
 
       <div class="notation-group">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -290,7 +290,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .tx-out-value  { grid-column: 2; text-align: right; }
 .tx-locktime { grid-column: right; grid-row: 3; text-align: right; font-style: normal; }
 .tx-note { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--dim); }
-/* The input's sequence mark, shown in the margin just after the reference:
+/* The input's sequence mark, leading the amount line beneath the reference:
    ●/○ final/respects-locktime, † replaceable (a shade warmer), ■n / Τn a
    relative block / time delay. */
 .tx-seq { font-style: normal; color: var(--meta); }
@@ -1122,19 +1122,20 @@ async function goToSection(height, index, scrollId) {
 // Fill each pending citation cell once its reference resolves; skip if the
 // reader has since paged to another section (gen no longer current).
 async function resolveCitations(pending, gen) {
-  await Promise.all(pending.map(async ({ citeBody, cite, amtEl, txid, vout }) => {
+  await Promise.all(pending.map(async ({ citeBody, cite, amtVal, txid, vout }) => {
     try {
       const { height, pos, outputs } = await resolveCitation(txid);
       if (gen !== renderGen) return;
       renderCitation(citeBody, height, pos, vout);
       cite.classList.remove('resolving');
       cite.title = `${txid}:${vout}`;
-      // The amount of the referenced output -- what this input spends -- sits
-      // under the reference, in parentheses: the mark for value flowing IN,
-      // where an output's amount (value flowing out) stands bare.
-      if (amtEl && outputs && outputs[vout]) {
-        amtEl.textContent = `(${groupDigits(String(outputs[vout].value))})`;
-        amtEl.title = 'the amount this input spends, in satoshis';
+      // The amount of the referenced output -- what this input spends -- sits on
+      // the line beneath the reference, after the sequence mark, in parentheses:
+      // the mark for value flowing IN, where an output's amount (value flowing
+      // out) stands bare.
+      if (amtVal && outputs && outputs[vout]) {
+        amtVal.textContent = `(${groupDigits(String(outputs[vout].value))})`;
+        amtVal.title = 'the amount this input spends, in satoshis';
       }
     } catch (e) {
       if (gen !== renderGen) return;
@@ -1400,7 +1401,7 @@ function renderChapter(para) {
     q.innerHTML = html;
     container.append(q);
   };
-  // The input's sequence mark, shown in the margin just after its reference:
+  // The input's sequence mark, leading the amount line beneath its reference:
   // ● final · ○ respects locktime · † replaceable · † ■n / † Τn replaceable with
   // a relative block / time delay. The † is kept a shade warmer than the delay
   // it precedes, so it reads as its own mark.
@@ -1454,24 +1455,29 @@ function renderChapter(para) {
     cite.id = `in-${inputIndex++}`;   // an output's forward citation scrolls here so the spending input leads the page
     const citeBody = document.createElement('span');
     citeBody.className = 'cite-body';
-    let amtEl = null;
     if (inp.isNullPrevout) {
       citeBody.textContent = '∅';   // coinbase: no previous output
     } else {
       citeBody.textContent = '⋯';   // placeholder until the reference resolves
       cite.classList.add('resolving');
-      amtEl = document.createElement('div');   // the spent output's amount, filled on resolve
-      amtEl.className = 'cite-amount';
-      pendingCites.push({ citeBody, cite, amtEl, txid: inp.prevTxid, vout: inp.prevVout });
     }
-    // The reference leads, then -- for a witness-bearing input -- its footnote
-    // superscript (numbered in input order), then the sequence mark, which trails
-    // the prevout on the wire (prevout · scriptSig · sequence); the amount of the
-    // output it spends sits underneath.
+    // The reference leads the citation, then -- for a witness-bearing input --
+    // its footnote superscript (numbered in input order).
     cite.append(citeBody);
     if (inp.witnessHex) { footnotes.push({ n: footnotes.length + 1, items: inp.witnessItems, zero: inp.witnessZero }); cite.append(witnessRef(footnotes.length)); }
-    cite.append(' ', seqSpan(inp));
-    if (amtEl) cite.append(amtEl);
+    // A second line sits beneath the reference: the sequence mark leads it, then
+    // the amount of the output this input spends (filled on resolve, into its own
+    // span so the mark survives). A coinbase has no prevout, so its line carries
+    // the sequence mark alone.
+    const amtLine = document.createElement('div');
+    amtLine.className = 'cite-amount';
+    amtLine.append(seqSpan(inp));
+    if (!inp.isNullPrevout) {
+      const amtVal = document.createElement('span');   // the spent output's amount, filled on resolve
+      amtLine.append(' ', amtVal);
+      pendingCites.push({ citeBody, cite, amtVal, txid: inp.prevTxid, vout: inp.prevVout });
+    }
+    cite.append(amtLine);
     // A witness spend has an empty scriptSig (no body content). An input that
     // renders a scriptSig gets an aligned row: its left cell carries any pending
     // witness-input citations that preceded it (in order) stacked above its own,

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -268,7 +268,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .cite-section-link { color: inherit; text-decoration: none; }
 .cite-section-link:hover { color: var(--accent); text-decoration: underline; }
 /* The amount of the output this input spends, under its reference. */
-.cite-amount { margin-top: .1em; font: italic 400 12px/1.3 'Newsreader',serif; color: var(--meta); }
+.cite-amount { margin-top: .1em; font: italic 400 12px/1.3 'Newsreader',serif; color: var(--meta); font-variant-numeric: tabular-nums; }
 /* An output's forward citation -- the section that later spent it -- under its
    amount in the right margin, mirroring the left margin's provenance cites.
    Empty for an unspent output. */
@@ -286,8 +286,9 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 }
 .tx-out-script { grid-column: 1; min-width: 0; }
 /* Amounts and the closing locktime right-align to the page edge, like a ledger
-   column, and the amount digits are grouped in threes (see btc-prose.js). */
-.tx-out-value  { grid-column: 2; text-align: right; }
+   column; amounts read in bitcoin (₿) with a fixed eight decimals and tabular
+   figures, so the column aligns on the point (see formatBtc in btc-prose.js). */
+.tx-out-value  { grid-column: 2; text-align: right; font-variant-numeric: tabular-nums; }
 .tx-locktime { grid-column: right; grid-row: 3; text-align: right; font-style: normal; }
 .tx-note { font: italic 400 13.5px/1.4 'Newsreader',serif; color: var(--dim); }
 /* The input's sequence mark, leading the amount line beneath the reference:

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -1468,11 +1468,13 @@ function renderChapter(para) {
       amtEl.className = 'cite-amount';
       pendingCites.push({ citeBody, cite, amtEl, txid: inp.prevTxid, vout: inp.prevVout });
     }
-    // The input's sequence mark leads, then the reference and -- for a
-    // witness-bearing input -- its footnote superscript, numbered in input order;
-    // the amount of the output it spends sits underneath.
-    cite.append(seqSpan(inp), ' ', citeBody);
+    // The reference leads, then -- for a witness-bearing input -- its footnote
+    // superscript (numbered in input order), then the sequence mark, which trails
+    // the prevout on the wire (prevout · scriptSig · sequence); the amount of the
+    // output it spends sits underneath.
+    cite.append(citeBody);
     if (inp.witnessHex) { footnotes.push({ n: footnotes.length + 1, items: inp.witnessItems, zero: inp.witnessZero }); cite.append(witnessRef(footnotes.length)); }
+    cite.append(' ', seqSpan(inp));
     if (amtEl) cite.append(amtEl);
     // A witness spend has an empty scriptSig (no body content). An input that
     // renders a scriptSig gets an aligned row: its left cell carries any pending

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -302,10 +302,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    we haven't given a glyph falls back to Bitcoin Core's OP_* name in small mono. */
 .op { color: var(--accent); font-style: normal; }
 .op-name { font: 600 .62em/1 'IBM Plex Mono',monospace; letter-spacing:.04em; color: var(--dim); font-style: normal; vertical-align: .14em; white-space: nowrap; }
-/* A decoded value riding a mark (the coinbase preamble's βtarget and
-   ηextranonce): mono like an OP_ name, but a size up -- it's a number to
-   read, not a fallback label. */
-.op-num { font: 500 .72em/1 'IBM Plex Mono',monospace; color: var(--dim); font-style: normal; vertical-align: .1em; white-space: nowrap; margin-left: .08em; }
 /* A push opcode's mark (↧ₙ and the OP_PUSHDATA variants): quieter than the
    operational opcodes -- it frames the data that follows rather than acting
    on the stack, so it shouldn't compete with the prose it introduces. */
@@ -614,7 +610,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Coinbase — the mining preamble</h4>
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b> — a valid hash opens with n zero bits</span></div>
-          <div class="glyph-row"><span class="g">η<i>n</i></span><span class="m"><b>extranonce</b> — search space beyond the header's η</span></div>
+          <div class="glyph-row"><span class="g">η<sub><i>n</i></sub></span><span class="m"><b>extranonce</b> — search space beyond the header's η</span></div>
         </div>
       </div>
 

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -624,7 +624,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">v<i>n</i></span><span class="m">block <b>version</b></span></div>
           <div class="glyph-row"><span class="g">∅</span><span class="m">no previous block — the genesis chapter</span></div>
           <div class="glyph-row"><span class="g">β<i>n</i></span><span class="m">the <b>difficulty target</b>, as in the preamble</span></div>
-          <div class="glyph-row"><span class="g">η<i>n</i></span><span class="m">the <b>nonce</b> the miner landed on</span></div>
+          <div class="glyph-row"><span class="g">η<sub><i>n</i></sub></span><span class="m">the <b>nonce</b> the miner landed on</span></div>
         </div>
       </div>
 
@@ -1292,7 +1292,7 @@ function renderFrontispiece(header) {
     { text: merkleProse, copy: { hex: header.merkleRoot, label: 'merkle root' } },
     { text: hf.timestamp, title: hf.timestampTitle },
     { text: hf.bits, title: hf.bitsTitle },
-    { text: `η${hf.nonce}`, title: `nonce ${hf.nonce} — the value the miner incremented while searching for a hash below the difficulty target` },
+    { text: hf.nonce, title: hf.nonceTitle },
   ];
   for (const { text, title, copy } of items) {
     const span = document.createElement('span');

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -371,8 +371,10 @@ const markToken = (glyph, text, title) => `<span class="op" title="${title}">${g
 //
 // A pushed datum whose kind is recognizable carries its type mark from the
 // Notation key -- p public key, s signature, h hash, r redeem script,
-// w witness script, t tapscript -- set just before its prose, so a script
-// reads as its pattern (⁶⁵p ∇) without consulting the key. Classification
+// w witness script, t tapscript -- set just before its prose, with the push's
+// byte count riding on the mark itself as a superscript that follows it, so a
+// script reads as its pattern (p⁶⁵ ∇) without consulting the key. (A bare,
+// untyped push keeps its superscript leading, before the prose.) Classification
 // is display-only annotation: it never changes what gets encoded.
 const dataMark = (sym, title) => `<span class="dt" title="${title}">${sym}</span>`;
 
@@ -489,7 +491,7 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
       if (!t.push) { parts.push(mark); return; }              // a zero-length extended push -- the mark alone
       if (i === redeemIdx && looksLikeScript(t.push)) {
         // reveal the redeemScript, typed r
-        parts.push(mark + dataMark('r', 'redeem script — revealed as opcodes'), renderScript(t.push, collect));
+        parts.push(dataMark('r', 'redeem script — revealed as opcodes') + mark, renderScript(t.push, collect));
         return;
       }
       // A push directly before OP_CLTV (τ) or OP_CSV (Δ) is a timelock threshold,
@@ -515,7 +517,11 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
       const num = numberPush(t.push);
       if (num !== null) { parts.push(`<span class="op" title="pushed number — ${num}">${num}</span>`); return; }
       const compact = derToCompact(t.push);                   // a DER signature is stripped to r‖s‖sighash
-      parts.push(mark + scriptDataMark(t.push, compact, prevOp, toks[i + 1]?.op), collect(compact || t.push));
+      // A typed push carries its byte-count superscript on the type mark itself
+      // (p⁶⁵), so the datum's kind leads and its length rides after it; a bare
+      // push keeps the superscript leading, before its prose.
+      const dtMark = scriptDataMark(t.push, compact, prevOp, toks[i + 1]?.op);
+      parts.push(dtMark ? dtMark + mark : mark, collect(compact || t.push));
     } else {
       pre = 'done';
       parts.push(collect(t.trunc));                           // malformed tail -- carry it as prose

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -179,10 +179,14 @@ function escapeHtml(s) {
   return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
 
-// A decoded text run, escaped for HTML with its line breaks rendered: a CR, LF
-// or CRLF each become a <br>, so a multi-line embedded message keeps its lines
-// instead of collapsing to one. Escapes first, so the only tags are the breaks.
-const quoteText = (s) => escapeHtml(s).replace(/\r\n?|\n/g, '<br>');
+// A decoded text run, escaped for HTML with its whitespace rendered: a CR, LF or
+// CRLF each become a <br>, and a tab becomes a fixed-width gap, so a multi-line
+// or column-aligned embedded message keeps its shape instead of collapsing to a
+// single line of single spaces. Escapes first, so the only tags are the ones
+// added here.
+const quoteText = (s) => escapeHtml(s)
+  .replace(/\r\n?|\n/g, '<br>')
+  .replace(/\t/g, '<span class="tab"></span>');
 
 // ─── script → opcode notation ──────────────────────────────────────────
 //

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -160,15 +160,15 @@ export function groupDigits(s) {
 }
 
 // A satoshi amount -> its value in bitcoin, prefixed with the ₿ sign and exact
-// to the satoshi: the whole-bitcoin part is digit-grouped like any other figure
-// in the book, and only the decimal places the amount actually uses are shown
-// (trailing zeros trimmed). ₿ marks the unit, so 50 BTC reads ₿50 and a lone
-// satoshi reads ₿0.00000001. BigInt keeps large sat counts exact.
+// to the satoshi. English number formatting: the whole-bitcoin part is
+// comma-grouped, and the fraction is always the full eight decimal places, so a
+// column of amounts aligns on the point. 50 BTC reads ₿50.00000000, a lone
+// satoshi ₿0.00000001. BigInt keeps large sat counts exact.
 export function formatBtc(sats) {
   const s = BigInt(sats);
-  const whole = groupDigits((s / 100000000n).toString());
-  const frac = (s % 100000000n).toString().padStart(8, '0').replace(/0+$/, '');
-  return `₿${whole}${frac ? `.${frac}` : ''}`;
+  const whole = (s / 100000000n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const frac = (s % 100000000n).toString().padStart(8, '0');
+  return `₿${whole}.${frac}`;
 }
 
 // Quoted script text comes directly from raw blockchain data -- a miner's

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -159,6 +159,18 @@ export function groupDigits(s) {
   return s.replace(/\B(?=(\d{3})+(?!\d))/g, '·');
 }
 
+// A satoshi amount -> its value in bitcoin, prefixed with the ₿ sign and exact
+// to the satoshi: the whole-bitcoin part is digit-grouped like any other figure
+// in the book, and only the decimal places the amount actually uses are shown
+// (trailing zeros trimmed). ₿ marks the unit, so 50 BTC reads ₿50 and a lone
+// satoshi reads ₿0.00000001. BigInt keeps large sat counts exact.
+export function formatBtc(sats) {
+  const s = BigInt(sats);
+  const whole = groupDigits((s / 100000000n).toString());
+  const frac = (s % 100000000n).toString().padStart(8, '0').replace(/0+$/, '');
+  return `₿${whole}${frac ? `.${frac}` : ''}`;
+}
+
 // Quoted script text comes directly from raw blockchain data -- a miner's
 // coinbase tag, an OP_RETURN message -- not our own wordlist, so unlike the
 // Glossia-generated prose it's untrusted content and must be escaped before
@@ -735,7 +747,7 @@ export function composeTransactionFields(parsed, bestOf = 1, lazyData = null) {
     // caller supplies `lazyData`; an ASCII payload is still quoted inline by
     // `eligible` before either encoder is reached, so only opaque bytes defer.
     const encodeData = (isOpReturn && lazyData) ? lazyData : collect;
-    return { script: renderScript(o.scriptPubKey, encodeData, { eligible: isOpReturn }), scriptAscii: null, value: groupDigits(String(o.value)) };
+    return { script: renderScript(o.scriptPubKey, encodeData, { eligible: isOpReturn }), scriptAscii: null, value: formatBtc(o.value), valueTitle: `${groupDigits(String(o.value))} satoshis` };
   });
 
   const lock = locktimeInfo(parsed.locktime);

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -17,7 +17,7 @@
 // margin layout.
 
 import { encodeSeedPhrase } from './glossia-msg.js';
-import { findAsciiStrings, tokenizeScript, bitsToTargetHex, bitsToDifficulty } from './btc-tx.js';
+import { findTextRuns, readableUtf8Text, tokenizeScript, bitsToTargetHex, bitsToDifficulty } from './btc-tx.js';
 import { volumeBookChapter } from './btc-citation.js';
 
 const ROMAN = [[1000, 'M'], [900, 'CM'], [500, 'D'], [400, 'CD'], [100, 'C'], [90, 'XC'], [50, 'L'], [40, 'XL'], [10, 'X'], [9, 'IX'], [5, 'V'], [4, 'IV'], [1, 'I']];
@@ -412,22 +412,17 @@ function scriptDataMark(push, compact, prevOp, nextOp) {
   return '';
 }
 
-// A data push whose bytes are ALL printable ASCII (e.g. an Ordinals inscription's
-// "ord" tag, its content type or a text body) -> its decoded string, else null.
-// Requiring the WHOLE push to be printable -- not merely a run within it -- keeps
-// keys, hashes and signatures (dense binary, and all ≥ 20 bytes) from ever being
-// mistaken for text, so this is safe to apply to any script, not just an OP_RETURN
-// payload. The floor is 3 so a short protocol tag like Ordinals' "ord" is caught.
-const ASCII_PUSH_MIN = 3;
-function asciiPush(hex) {
-  if (!hex || hex.length / 2 < ASCII_PUSH_MIN) return null;
-  let out = '';
-  for (let i = 0; i < hex.length; i += 2) {
-    const b = parseInt(hex.slice(i, i + 2), 16);
-    if (b < 0x20 || b > 0x7e) return null;
-    out += String.fromCharCode(b);
-  }
-  return out;
+// A data push that is valid UTF-8 and wholly human-readable (an Ordinals
+// inscription's "ord" tag, its content type or a text body, an embedded message)
+// -> its decoded string, else null. Non-English text and emoji come through;
+// binary (keys, hashes, sigs, images -- all ≥ 20 bytes and dense) fails UTF-8
+// validation or trips a control byte and stays prose. The floor is 3 so a short
+// protocol tag like Ordinals' "ord" is caught while a 1-2 byte push falls to
+// numberPush; the whole-push requirement lives in readableUtf8Text.
+const TEXT_PUSH_MIN = 3;
+function textPush(hex) {
+  if (!hex || hex.length / 2 < TEXT_PUSH_MIN) return null;
+  return readableUtf8Text(hex);
 }
 
 // A short data push (1-4 bytes) minimally encoding a number -> its decimal, else
@@ -522,12 +517,12 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
         if (info && info.mark) { parts.push(`<span class="op" title="${escapeHtml(info.title)}">${info.mark}</span>`); return; }
       }
       if (eligible) {
-        const found = findAsciiStrings(t.push);
+        const found = findTextRuns(t.push);
         if (found.length) { parts.push(mark, found.map((s) => `“${escapeHtml(s)}”`).join(' ')); return; }
       }
-      // A wholly-ASCII push (an inscription's content type, a text body, an
-      // embedded message) reads as its own quoted text rather than cover prose.
-      const text = asciiPush(t.push);
+      // A wholly-readable push (an inscription's content type, a text body, an
+      // embedded UTF-8 message) reads as its own quoted text rather than cover prose.
+      const text = textPush(t.push);
       if (text !== null) { parts.push(mark, `“${escapeHtml(text)}”`); return; }
       // A short number pushed as data (an Ordinals field tag, a script number)
       // reads as its literal digits, like the book's other structural numbers.
@@ -708,7 +703,7 @@ export function composeTransactionFields(parsed, bestOf = 1, lazyData = null) {
       if (isCleanScript(v.scriptSig)) {
         script = renderScript(v.scriptSig, collect, { eligible: true, preamble: true });
       } else {
-        const found = findAsciiStrings(v.scriptSig);
+        const found = findTextRuns(v.scriptSig);
         if (found.length) {
           scriptAscii = found.map((s) => escapeHtml(s)).join(' ');
           script = found.map((s) => `“${escapeHtml(s)}”`).join(' ');

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -367,9 +367,10 @@ function extranonceFromPush(push) {
   return BigInt('0x' + reverseHexStr(push)).toString();
 }
 
-// A decoded mark: glyph + value (when there is one to show), both carrying
-// the same explanatory title.
-const markToken = (glyph, text, title) => `<span class="op" title="${title}">${glyph}</span>${text ? `<span class="op-num" title="${title}">${text}</span>` : ''}`;
+// A decoded mark: a glyph carrying an explanatory title. Any quantity the mark
+// summarizes (β's leading-zero count, η's nonce/extranonce) rides the glyph as a
+// subscript, baked in by the caller, so the mark reads as one unit.
+const markToken = (glyph, title) => `<span class="op" title="${title}">${glyph}</span>`;
 
 // ─── data type marks ───────────────────────────────────────────────────
 //
@@ -479,7 +480,7 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
         const bits = compactBitsFromPush(t.push);
         if (bits !== null) {
           const info = bitsInfo(bits);
-          parts.push(markToken(info.sym, '', `the difficulty target this block was mined against — ${info.title}`));
+          parts.push(markToken(info.sym, `the difficulty target this block was mined against — ${info.title}`));
           pre = 'extranonce';
           return;
         }
@@ -487,7 +488,7 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
         pre = 'done';
         const n = extranonceFromPush(t.push);
         if (n !== null) {
-          parts.push(markToken('η', n, `extranonce ${n} — the counter the miner rolled once the header's 32-bit nonce (η) was exhausted`));
+          parts.push(markToken(`η${toSubscript(n)}`, `extranonce ${n} — the counter the miner rolled once the header's 32-bit nonce (η) was exhausted`));
           return;
         }
       }

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -179,6 +179,11 @@ function escapeHtml(s) {
   return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
 
+// A decoded text run, escaped for HTML with its line breaks rendered: a CR, LF
+// or CRLF each become a <br>, so a multi-line embedded message keeps its lines
+// instead of collapsing to one. Escapes first, so the only tags are the breaks.
+const quoteText = (s) => escapeHtml(s).replace(/\r\n?|\n/g, '<br>');
+
 // ─── script → opcode notation ──────────────────────────────────────────
 //
 // A scriptSig / scriptPubKey is rendered as its sequence of opcodes and data
@@ -517,13 +522,13 @@ function renderScript(hex, collect, { eligible = false, nested = false, preamble
         if (info && info.mark) { parts.push(`<span class="op" title="${escapeHtml(info.title)}">${info.mark}</span>`); return; }
       }
       if (eligible) {
-        const found = findTextRuns(t.push);
-        if (found.length) { parts.push(mark, found.map((s) => `“${escapeHtml(s)}”`).join(' ')); return; }
+        const found = findTextRuns(t.push, { segment: false });   // t.push is a payload, not a script
+        if (found.length) { parts.push(mark, found.map((s) => `“${quoteText(s)}”`).join(' ')); return; }
       }
       // A wholly-readable push (an inscription's content type, a text body, an
       // embedded UTF-8 message) reads as its own quoted text rather than cover prose.
       const text = textPush(t.push);
-      if (text !== null) { parts.push(mark, `“${escapeHtml(text)}”`); return; }
+      if (text !== null) { parts.push(mark, `“${quoteText(text)}”`); return; }
       // A short number pushed as data (an Ordinals field tag, a script number)
       // reads as its literal digits, like the book's other structural numbers.
       const num = numberPush(t.push);
@@ -705,8 +710,8 @@ export function composeTransactionFields(parsed, bestOf = 1, lazyData = null) {
       } else {
         const found = findTextRuns(v.scriptSig);
         if (found.length) {
-          scriptAscii = found.map((s) => escapeHtml(s)).join(' ');
-          script = found.map((s) => `“${escapeHtml(s)}”`).join(' ');
+          scriptAscii = found.map((s) => quoteText(s)).join(' ');
+          script = found.map((s) => `“${quoteText(s)}”`).join(' ');
         } else {
           script = collect(v.scriptSig);
         }

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -144,7 +144,11 @@ export function composeBlockHeaderFields(header) {
     version: String(header.version),
     timestamp: time.mark, timestampTitle: time.title,
     bits: bits.sym, bitsTitle: bits.title,
-    nonce: String(header.nonce),
+    // The nonce rides its η mark as a subscript, the same house convention β's
+    // leading-zero count follows -- a mark with its quantity tucked under it,
+    // not a bare inline number. The exact value stays legible in the title.
+    nonce: `η${toSubscript(header.nonce)}`,
+    nonceTitle: `nonce ${header.nonce} — the value the miner incremented while searching for a hash below the difficulty target`,
   };
 }
 

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -291,22 +291,54 @@ export async function withAddresses(tx) {
   return { ...tx, vout };
 }
 
-// ─── embedded ASCII text ───────────────────────────────────────────────
+// ─── embedded human-readable text ──────────────────────────────────────
 //
 // scriptSig and scriptPubKey bytes are usually cryptographic material --
 // signatures, pubkeys, hashes -- effectively random. But two spots
 // routinely carry deliberate human-readable text: a coinbase input's
 // scriptSig (mining pool tags like "/ViaBTC/") and OP_RETURN outputs
-// (arbitrary embedded messages). This scans any byte string for runs of
-// printable ASCII, so those can be surfaced instead of run through the
+// (arbitrary embedded messages, often UTF-8). This scans any byte string for
+// runs of readable text, so those can be surfaced instead of run through the
 // wordlist as if they were opaque.
 //
+// "Readable" means valid UTF-8 decoding to printable characters plus tab and
+// newline -- so non-English text and emoji come through -- while a C0/C1
+// control, a DEL, or any invalid UTF-8 byte ends a run (real cryptographic
+// material and image bytes are riddled with those).
+//
 // A minimum run length matters: a single random byte has roughly a 37%
-// chance of falling in the printable range (0x20-0x7E is 95 of 256 values),
-// so short "printable-looking" runs turn up by pure chance in genuine
-// cryptographic material. Requiring several consecutive printable bytes
-// keeps that noise out.
-const ASCII_MIN_RUN = 5;
+// chance of falling in the printable ASCII range (0x20-0x7E is 95 of 256
+// values), so short "printable-looking" runs turn up by pure chance in
+// genuine cryptographic material. Requiring several consecutive readable
+// characters keeps that noise out.
+const TEXT_MIN_RUN = 5;
+
+// A code point we'll surface as text: any printable character, plus tab and
+// newline. Excludes the C0 controls (bar tab/newline), DEL, and the C1 controls
+// (0x80-0x9F) -- all common in binary, rare in genuine text.
+const isReadableCp = (cp) => cp === 0x09 || cp === 0x0a || (cp >= 0x20 && cp !== 0x7f && !(cp >= 0x80 && cp <= 0x9f));
+
+// Decode one UTF-8 scalar at offset i -> { cp, len }, or null if the bytes there
+// aren't a valid, minimally-encoded UTF-8 sequence. Overlong forms, surrogate
+// halves and out-of-range code points are rejected, so this never accepts binary
+// that a lenient decoder would paper over with U+FFFD.
+function utf8At(bytes, i) {
+  const b0 = bytes[i];
+  if (b0 < 0x80) return { cp: b0, len: 1 };
+  const cont = (j) => i + j < bytes.length && (bytes[i + j] & 0xc0) === 0x80;
+  if (b0 >= 0xc2 && b0 <= 0xdf && cont(1)) {
+    return { cp: ((b0 & 0x1f) << 6) | (bytes[i + 1] & 0x3f), len: 2 };
+  }
+  if (b0 >= 0xe0 && b0 <= 0xef && cont(1) && cont(2)) {
+    const cp = ((b0 & 0x0f) << 12) | ((bytes[i + 1] & 0x3f) << 6) | (bytes[i + 2] & 0x3f);
+    return (cp < 0x800 || (cp >= 0xd800 && cp <= 0xdfff)) ? null : { cp, len: 3 };
+  }
+  if (b0 >= 0xf0 && b0 <= 0xf4 && cont(1) && cont(2) && cont(3)) {
+    const cp = ((b0 & 0x07) << 18) | ((bytes[i + 1] & 0x3f) << 12) | ((bytes[i + 2] & 0x3f) << 6) | (bytes[i + 3] & 0x3f);
+    return (cp < 0x10000 || cp > 0x10ffff) ? null : { cp, len: 4 };
+  }
+  return null;
+}
 
 // Parse a script into its push-data segments, ignoring non-push opcodes
 // (OP_DUP, OP_HASH160, OP_CHECKSIG, the OP_RETURN marker itself, etc.).
@@ -338,23 +370,43 @@ function scriptPushes(bytes) {
   return pushes;
 }
 
-export function findAsciiStrings(hex, minRun = ASCII_MIN_RUN) {
+// The maximal runs of readable UTF-8 text in a byte string, each at least
+// `minRun` characters, scanning every script push independently (see
+// scriptPushes) so a push's length-prefix byte never glues onto real text. An
+// unreadable character or an invalid UTF-8 byte ends the current run.
+export function findTextRuns(hex, minRun = TEXT_MIN_RUN) {
   const bytes = hexToBytes(hex);
-  const segments = scriptPushes(bytes) || [bytes];   // fall back to the raw blob if it isn't clean script
+  const pushes = scriptPushes(bytes);
+  // Scan each script push, or the raw blob when the bytes aren't clean script
+  // (null) or carry no pushes at all (an empty list -- e.g. data that parses as
+  // a run of non-push opcodes, like raw UTF-8), so text is never dropped.
+  const segments = pushes && pushes.length ? pushes : [bytes];
   const found = [];
   for (const seg of segments) {
-    let start = -1;
-    for (let i = 0; i <= seg.length; i++) {
-      const printable = i < seg.length && seg[i] >= 0x20 && seg[i] <= 0x7e;
-      if (printable) {
-        if (start === -1) start = i;
-      } else if (start !== -1) {
-        if (i - start >= minRun) found.push(String.fromCharCode(...seg.subarray(start, i)));
-        start = -1;
-      }
+    let run = '', count = 0;
+    const flush = () => { if (count >= minRun) found.push(run); run = ''; count = 0; };
+    let i = 0;
+    while (i < seg.length) {
+      const d = utf8At(seg, i);
+      if (d && isReadableCp(d.cp)) { run += String.fromCodePoint(d.cp); count++; i += d.len; }
+      else { flush(); i += d ? d.len : 1; }   // skip a readable-but-control char, or one bad byte
     }
+    flush();
   }
   return found;
+}
+
+// A whole byte string that is valid UTF-8 and entirely readable -> its decoded
+// text, else null. Requiring the WHOLE input to pass -- not merely a run within
+// it -- keeps keys, hashes and signatures (dense binary) from being mistaken for
+// text, so it is safe to apply to any push, not just an OP_RETURN payload.
+export function readableUtf8Text(hex) {
+  const bytes = hexToBytes(hex);
+  let str;
+  try { str = new TextDecoder('utf-8', { fatal: true }).decode(bytes); }
+  catch { return null; }
+  for (const ch of str) if (!isReadableCp(ch.codePointAt(0))) return null;
+  return str;
 }
 
 // ─── script tokenizer ────────────────────────────────────────────────────

--- a/web/btc-tx.js
+++ b/web/btc-tx.js
@@ -301,10 +301,10 @@ export async function withAddresses(tx) {
 // runs of readable text, so those can be surfaced instead of run through the
 // wordlist as if they were opaque.
 //
-// "Readable" means valid UTF-8 decoding to printable characters plus tab and
-// newline -- so non-English text and emoji come through -- while a C0/C1
-// control, a DEL, or any invalid UTF-8 byte ends a run (real cryptographic
-// material and image bytes are riddled with those).
+// "Readable" means valid UTF-8 decoding to printable characters plus tab,
+// newline and carriage return -- so non-English text and emoji come through --
+// while any other C0/C1 control, a DEL, or an invalid UTF-8 byte ends a run
+// (real cryptographic material and image bytes are riddled with those).
 //
 // A minimum run length matters: a single random byte has roughly a 37%
 // chance of falling in the printable ASCII range (0x20-0x7E is 95 of 256
@@ -313,10 +313,10 @@ export async function withAddresses(tx) {
 // characters keeps that noise out.
 const TEXT_MIN_RUN = 5;
 
-// A code point we'll surface as text: any printable character, plus tab and
-// newline. Excludes the C0 controls (bar tab/newline), DEL, and the C1 controls
+// A code point we'll surface as text: any printable character, plus tab, newline
+// and carriage return. Excludes the other C0 controls, DEL, and the C1 controls
 // (0x80-0x9F) -- all common in binary, rare in genuine text.
-const isReadableCp = (cp) => cp === 0x09 || cp === 0x0a || (cp >= 0x20 && cp !== 0x7f && !(cp >= 0x80 && cp <= 0x9f));
+const isReadableCp = (cp) => cp === 0x09 || cp === 0x0a || cp === 0x0d || (cp >= 0x20 && cp !== 0x7f && !(cp >= 0x80 && cp <= 0x9f));
 
 // Decode one UTF-8 scalar at offset i -> { cp, len }, or null if the bytes there
 // aren't a valid, minimally-encoded UTF-8 sequence. Overlong forms, surrogate
@@ -371,15 +371,18 @@ function scriptPushes(bytes) {
 }
 
 // The maximal runs of readable UTF-8 text in a byte string, each at least
-// `minRun` characters, scanning every script push independently (see
-// scriptPushes) so a push's length-prefix byte never glues onto real text. An
-// unreadable character or an invalid UTF-8 byte ends the current run.
-export function findTextRuns(hex, minRun = TEXT_MIN_RUN) {
+// `minRun` characters. An unreadable character or an invalid UTF-8 byte ends the
+// current run. When `segment` is set (a whole scriptSig, e.g. a coinbase), each
+// script push is scanned independently (see scriptPushes) so a push's
+// length-prefix byte never glues onto real text; when it's off (the bytes are
+// already a single push's data, e.g. an OP_RETURN payload), the blob is scanned
+// as-is -- re-parsing raw data as script would mis-split it, since a byte like
+// 0x0a (newline) doubles as a push opcode.
+export function findTextRuns(hex, { minRun = TEXT_MIN_RUN, segment = true } = {}) {
   const bytes = hexToBytes(hex);
-  const pushes = scriptPushes(bytes);
-  // Scan each script push, or the raw blob when the bytes aren't clean script
-  // (null) or carry no pushes at all (an empty list -- e.g. data that parses as
-  // a run of non-push opcodes, like raw UTF-8), so text is never dropped.
+  const pushes = segment ? scriptPushes(bytes) : null;
+  // Scan each script push, or the raw blob when segmentation is off, the bytes
+  // aren't clean script (null), or a push-less blob yields no segments.
   const segments = pushes && pushes.length ? pushes : [bytes];
   const found = [];
   for (const seg of segments) {


### PR DESCRIPTION
On the wire an input serializes as prevout, then scriptSig, then sequence,
so the sequence mark should trail the prevout reference rather than lead it.
The seqSpan and CSS comments already described it as sitting "just after the
reference"; only the DOM append order disagreed. Move the sequence mark to
follow the reference (and its witness footnote superscript).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017L65hefRkNPZRfxg1HvBqg