### PR TITLE
Label Bitcoin book nav buttons with their target chapter/section

### DIFF
--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -1434,7 +1434,9 @@ function renderFrontispiece(header) {
   const merkleProse = encodeSeedPhrase(reverseHex(header.merkleRoot), 'english', BEST_OF).prose;
   const items = [
     { text: `v${hf.version}`, title: 'block version' },
-    { text: prevProse, title: isGenesisPrev ? 'no earlier block — this is the genesis block' : null, copy: isGenesisPrev ? null : { hex: header.prevBlockHash, label: 'previous block hash' } },
+    // The previous-block hash is on-chain data, so it leads with the book's
+    // bold-gold h (hash) data mark, like the data marks in the body prose.
+    { text: prevProse, title: isGenesisPrev ? 'no earlier block — this is the genesis block' : null, dataMark: isGenesisPrev ? null : 'h', copy: isGenesisPrev ? null : { hex: header.prevBlockHash, label: 'previous block hash' } },
     // The merkle root is prefixed with ⋔ (the book's merkle mark); that mark is
     // the clickable handle for the copy menu, so the prose beside it reads plain.
     { text: merkleProse, mark: '⋔', copy: { hex: header.merkleRoot, label: 'merkle root' } },
@@ -1442,7 +1444,7 @@ function renderFrontispiece(header) {
     { text: hf.bits, title: hf.bitsTitle },
     { text: hf.nonce, title: hf.nonceTitle },
   ];
-  for (const { text, title, copy, mark } of items) {
+  for (const { text, title, copy, mark, dataMark } of items) {
     const span = document.createElement('span');
     span.className = 'cfx';
     if (mark && copy) {
@@ -1452,8 +1454,17 @@ function renderFrontispiece(header) {
       attachHashCopy(m, copy.hex, copy.label, text);   // the ⋔ mark opens the menu; prose is passed in
       span.append(m, ' ' + text);                      // prose shown beside it, not itself clickable
     } else {
-      span.textContent = text;
-      if (copy) attachHashCopy(span, copy.hex, copy.label);
+      if (dataMark) {
+        // A bold-gold data-type mark (h/s/…) leads the prose; the whole field
+        // stays the clickable hash target, so the prose to copy is passed in.
+        const d = document.createElement('span');
+        d.className = 'dt';
+        d.textContent = dataMark;
+        span.append(d, ' ' + text);
+      } else {
+        span.textContent = text;
+      }
+      if (copy) attachHashCopy(span, copy.hex, copy.label, dataMark ? text : undefined);
       else if (title) span.title = title;
     }
     el.append(span);

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -191,8 +191,10 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .chapter-num { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.3em; text-transform:uppercase; color: var(--accent); }
 /* Nav-button labels are references (Roman volume, β book, chapter, §section),
    already cased -- so they opt out of the buttons' default uppercasing, which
-   would turn the book's lowercase β into a Latin-looking capital Β. */
-.chapter-step { padding: 12px 16px; font-size: 15px; line-height: 1; text-transform: none; }
+   would turn the book's lowercase β into a Latin-looking capital Β. Snug padding
+   so the button hugs its reference; nowrap so a two-part label like "β59 ■2016"
+   stays on one line instead of stacking. */
+.chapter-step { padding: 5px 9px; font-size: 14px; line-height: 1.15; text-transform: none; white-space: nowrap; }
 .chapter-title { font: 500 37px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 22px; letter-spacing: -.01em; }
 .chapter-hash { font: italic 400 15px/1.5 'Newsreader',serif; color: var(--dim); margin: 0 auto 16px; max-width: 46ch; }
 /* The block header's own fields -- version, previous-block hash, merkle
@@ -279,7 +281,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    Previous / Next pushed to opposite edges, each labelled with the section (or
    adjacent chapter) it steps to. A rule separates it from the section above. */
 .section-nav { display:flex; align-items:center; gap:16px; margin-top: 44px; padding-top: 24px; border-top: 1px solid var(--rule); }
-.section-nav button { padding: 12px 20px; text-transform: none; }
+.section-nav button { padding: 7px 13px; text-transform: none; white-space: nowrap; }
 /* Next hugs the right edge, Previous the left -- and each keeps its side even
    when the other is hidden (an absent neighbour shows no button at all). */
 #page-next { margin-left: auto; }
@@ -409,6 +411,14 @@ button:disabled { opacity: .4; cursor: not-allowed; }
      initial (line-height .82) overhangs upward, so give the lead line room to
      keep the cap clear of the amount above it. */
   .tx-line.tx-body-lead { padding-top: .8em; }
+  /* At phone widths pin the two references to the edges (space-between) so the
+     Next button can never be pushed off-screen. The buttons keep their hugged
+     size (flex 0 0 auto); the centre locator is sized by the space left between
+     them (flex 1 1 0) and wraps within it, so it can never overflow the row. On
+     wider screens the nav stays centred and compact (see base rule). */
+  .chapter-nav { gap: 9px; justify-content: space-between; }
+  .chapter-step { flex: 0 0 auto; }
+  .chapter-num { letter-spacing: .14em; min-width: 0; flex: 1 1 0; text-align: center; }
 }
 
 /* A witness-bearing input carries a small superscript index inline; the matching
@@ -1791,6 +1801,12 @@ const clampIndex = (i, meta) => Math.min(Math.max(0, i || 0), meta.txCount - 1);
 // that, as a txid, which jumps straight to that transaction's section.
 async function openLookup(input, index = 0) {
   input = (input || '').trim();
+  // Forget any tip remembered from a prior forward step: an explicit lookup is a
+  // fresh start, and the chain tip may have advanced since. Otherwise a stale
+  // tipHeight would keep hiding the Next button after e.g. re-entering -1, even
+  // though a newer block now exists. It re-sets if a forward step runs off the
+  // real tip (see stepTx / goToChapter).
+  tipHeight = null;
   $('chapter').classList.add('hidden');
   $('block-btn').disabled = true;
   try {

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -208,7 +208,10 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    chapter hash. A small mono line, like the manuscript's other margin notes;
    each field carries its decoded form in `title` (a tooltip). */
 .chapter-frontispiece { margin: 0 auto 4px; max-width: 46ch; font: 500 11.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
-.chapter-frontispiece .cfx + .cfx::before { content: ' · '; }
+/* The middot separator stays dim even between gold fields. */
+.chapter-frontispiece .cfx + .cfx::before { content: ' · '; color: var(--meta); }
+/* The difficulty target (β) and nonce (η): proof-of-work marks, shown gold. */
+.chapter-frontispiece .cfx-gold { color: var(--accent); }
 /* The merkle root's ⋔ mark: the clickable handle for its hash menu (copy hex /
    prose), bold and accented (like the h data mark) so it reads as the actionable
    element while the root's prose beside it stays plain. */
@@ -1478,12 +1481,14 @@ function renderFrontispiece(header) {
       : { text: prevProse, mark: 'h', markClass: 'dt', copy: { hex: header.prevBlockHash, label: 'previous block hash' } },
     { text: merkleProse, mark: '⋔', markClass: 'merkle-mark', copy: { hex: header.merkleRoot, label: 'merkle root' } },
     { text: hf.timestamp, title: hf.timestampTitle },
-    { text: hf.bits, title: hf.bitsTitle },
-    { text: hf.nonce, title: hf.nonceTitle },
+    // The difficulty target (β) and nonce (η) are the proof-of-work marks, gold
+    // like their counterparts in the body prose's mining preamble.
+    { text: hf.bits, title: hf.bitsTitle, gold: true },
+    { text: hf.nonce, title: hf.nonceTitle, gold: true },
   ];
-  for (const { text, title, copy, mark, markClass } of items) {
+  for (const { text, title, copy, mark, markClass, gold } of items) {
     const span = document.createElement('span');
-    span.className = 'cfx';
+    span.className = gold ? 'cfx cfx-gold' : 'cfx';
     if (mark && copy) {
       fillMarkedHash(span, mark, markClass, copy.hex, copy.label, text);
     } else {

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -193,9 +193,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    already cased -- so they opt out of the buttons' default uppercasing, which
    would turn the book's lowercase β into a Latin-looking capital Β. */
 .chapter-step { padding: 12px 16px; font-size: 15px; line-height: 1; text-transform: none; }
-/* β marks a book (a difficulty-adjustment window, echoing the header's βₙ
-   difficulty target). Kept lowercase even inside an uppercased eyebrow/heading. */
-.beta-mark { text-transform: none; }
 .chapter-title { font: 500 37px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 22px; letter-spacing: -.01em; }
 .chapter-hash { font: italic 400 15px/1.5 'Newsreader',serif; color: var(--dim); margin: 0 auto 16px; max-width: 46ch; }
 /* The block header's own fields -- version, previous-block hash, merkle
@@ -518,7 +515,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
     <header class="chapter-head">
       <nav class="chapter-nav">
         <button type="button" id="chapter-prev" class="chapter-step hidden" aria-label="Previous chapter" title="Previous chapter"></button>
-        <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span class="beta-mark">β</span><span id="ch-book"></span><span id="ch-chapter-inline"></span></div>
+        <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span id="ch-book"></span><span id="ch-chapter-inline"></span></div>
         <button type="button" id="chapter-next" class="chapter-step hidden" aria-label="Next chapter" title="Next chapter"></button>
       </nav>
       <h1 class="chapter-title" id="ch-title"></h1>

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -1801,12 +1801,6 @@ const clampIndex = (i, meta) => Math.min(Math.max(0, i || 0), meta.txCount - 1);
 // that, as a txid, which jumps straight to that transaction's section.
 async function openLookup(input, index = 0) {
   input = (input || '').trim();
-  // Forget any tip remembered from a prior forward step: an explicit lookup is a
-  // fresh start, and the chain tip may have advanced since. Otherwise a stale
-  // tipHeight would keep hiding the Next button after e.g. re-entering -1, even
-  // though a newer block now exists. It re-sets if a forward step runs off the
-  // real tip (see stepTx / goToChapter).
-  tipHeight = null;
   $('chapter').classList.add('hidden');
   $('block-btn').disabled = true;
   try {
@@ -1817,6 +1811,11 @@ async function openLookup(input, index = 0) {
       if (input.startsWith('-')) {
         setStatus('<span class="spinner"></span>fetching latest block…');
         const tip = Number(await loadTipHeight());
+        // We just learned the current tip -- record it so the chapter/section
+        // Next buttons stay hidden when this resolves to the tip itself (-1). A
+        // fresh page load comes through here too, so it no longer shows a dead
+        // Next button at the latest block.
+        tipHeight = tip;
         height = String(tip + Number(input) + 1);
         if (Number(height) < 0) throw new Error(`Only ${tip + 1} blocks exist; ${input} reaches before Genesis.`);
       }

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -1257,24 +1257,44 @@ async function ensureTxids(st) {
   return st.txids;
 }
 
+// The immutable core of a block's metadata -- its info and header, everything
+// but the txid list. A block hash permanently determines this content, so it's
+// memoized by hash: revisiting a block (e.g. stepping Next then back) re-fetches
+// nothing. Keyed by hash, not height, so a tip reorg can never serve stale data
+// -- a different block is a different hash. The shared objects are read-only.
+const blockCoreCache = new Map();   // hash -> Promise<{ hash, height, block, txCount, header, headerVerified }>
+function loadBlockCore(hash) {
+  if (!blockCoreCache.has(hash)) {
+    blockCoreCache.set(hash, (async () => {
+      const [blockRes, headerRes] = await Promise.all([
+        esploraFetch(`${ESPLORA}/block/${hash}`),
+        esploraFetch(`${ESPLORA}/block/${hash}/header`),
+      ]);
+      if (!blockRes.ok) throw new Error(`Esplora returned ${blockRes.status} fetching block info.`);
+      if (!headerRes.ok) throw new Error(`Esplora returned ${headerRes.status} fetching the block header.`);
+      const block = await blockRes.json();
+      const headerHex = (await headerRes.text()).trim();
+      // Parsed from the raw 80-byte header, not trusted from the JSON above --
+      // same self-parsed, self-verified stance as a transaction's txid.
+      const header = parseBlockHeader(headerHex);
+      const headerVerified = (await computeBlockHash(headerHex)) === hash;
+      return { hash, height: block.height, block, txCount: block.tx_count, header, headerVerified };
+    })().catch((e) => { blockCoreCache.delete(hash); throw e; }));
+  }
+  return blockCoreCache.get(hash);
+}
+
 // `withTxids: false` leaves the (heavy) txid list unfetched -- used when opening
 // a single transaction, whose section index comes from its merkle proof instead.
 // The block's transaction count still comes from its info (tx_count), so section
-// bounds and Next work without the list.
+// bounds and Next work without the list. Core (info + header) and the txid list
+// are each memoized, so a re-visit re-fetches neither.
 async function loadBlockMeta(hash, { withTxids = true } = {}) {
-  const [[blockRes, headerRes], txids] = await Promise.all([
-    Promise.all([esploraFetch(`${ESPLORA}/block/${hash}`), esploraFetch(`${ESPLORA}/block/${hash}/header`)]),
+  const [core, txids] = await Promise.all([
+    loadBlockCore(hash),
     withTxids ? fetchTxids(hash) : Promise.resolve(null),
   ]);
-  if (!blockRes.ok) throw new Error(`Esplora returned ${blockRes.status} fetching block info.`);
-  if (!headerRes.ok) throw new Error(`Esplora returned ${headerRes.status} fetching the block header.`);
-  const block = await blockRes.json();
-  const headerHex = (await headerRes.text()).trim();
-  // Parsed from the raw 80-byte header, not trusted from the JSON above --
-  // same self-parsed, self-verified stance as a transaction's txid.
-  const header = parseBlockHeader(headerHex);
-  const headerVerified = (await computeBlockHash(headerHex)) === hash;
-  return { hash, height: block.height, block, txids, txCount: block.tx_count, header, headerVerified };
+  return { ...core, txids };
 }
 
 async function loadBlockByHeight(height) {
@@ -1334,14 +1354,27 @@ async function loadBlockByTxid(txid) {
   return { meta, index, txid };
 }
 
+// A confirmed transaction's raw hex is immutable -- the txid is its hash -- so
+// it's memoized. Re-opening a section, or stepping back to one, re-parses from
+// cache instead of re-fetching the (potentially large) hex.
+const txHexCache = new Map();   // txid -> Promise<hex>
+function loadTxHex(txid) {
+  if (!txHexCache.has(txid)) {
+    txHexCache.set(txid, (async () => {
+      const r = await esploraFetch(`${ESPLORA}/tx/${txid}/hex`);
+      if (!r.ok) throw new Error(`Esplora returned ${r.status} fetching tx ${txid.slice(0, 8)}…`);
+      return (await r.text()).trim();
+    })().catch((e) => { txHexCache.delete(txid); throw e; }));
+  }
+  return txHexCache.get(txid);
+}
+
 async function showCurrentTx() {
   setStatus('<span class="spinner"></span>fetching transaction…');
   // The current txid: from the loaded list when we have it, else the single
   // transaction we opened by id (before its block's list is ever fetched).
   const txid = state.txids ? state.txids[state.index] : state.txid;
-  const r = await esploraFetch(`${ESPLORA}/tx/${txid}/hex`);
-  if (!r.ok) throw new Error(`Esplora returned ${r.status} fetching tx ${txid.slice(0, 8)}…`);
-  const hex = (await r.text()).trim();
+  const hex = await loadTxHex(txid);
 
   if (!ready) await init().catch(() => {});
   setStatus('<span class="spinner"></span>encoding as prose…');

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -186,12 +186,21 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 /* Chapter (block) navigation: prev / next flanking the Volume · Book locator. */
 .chapter-nav { display:flex; align-items:center; justify-content:center; gap:16px; margin-bottom: 14px; }
 .chapter-num { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.3em; text-transform:uppercase; color: var(--accent); }
-/* Nav-button labels are references (Roman volume, β book, chapter, §section),
-   already cased -- so they opt out of the buttons' default uppercasing, which
-   would turn the book's lowercase β into a Latin-looking capital Β. Snug padding
-   so the button hugs its reference; nowrap so a two-part label like "β59 ■2016"
-   stays on one line instead of stacking. */
-.chapter-step { padding: 5px 9px; font-size: 14px; line-height: 1.15; text-transform: none; white-space: nowrap; }
+/* Chapter/section navigation reads as chevron-flanked references, not boxed
+   buttons: a left chevron leads a Previous reference, a right chevron trails a
+   Next one. Plain accent text (labels are already cased -- text-transform:none
+   keeps the book's lowercase β from becoming a Latin-looking capital Β); nowrap
+   so a two-part label like "β59 ■2016" stays on one line. */
+.chapter-step, .section-nav button {
+  background: transparent; border: none; border-radius: 0; padding: 2px 2px;
+  color: var(--accent); font: 600 14px/1.2 'IBM Plex Mono',monospace;
+  letter-spacing: .04em; text-transform: none; white-space: nowrap; cursor: pointer;
+}
+.chapter-step:hover:not(:disabled), .section-nav button:hover:not(:disabled) {
+  background: transparent; color: var(--accent-2); text-decoration: underline;
+}
+#chapter-prev::before, #page-prev::before { content: '‹\00a0'; }
+#chapter-next::after, #page-next::after { content: '\00a0›'; }
 .chapter-title { font: 500 37px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 22px; letter-spacing: -.01em; }
 .chapter-hash { font: italic 400 15px/1.5 'Newsreader',serif; color: var(--dim); margin: 0 auto 16px; max-width: 46ch; }
 /* The block header's own fields -- version, previous-block hash, merkle
@@ -282,7 +291,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    Previous / Next pushed to opposite edges, each labelled with the section (or
    adjacent chapter) it steps to. A rule separates it from the section above. */
 .section-nav { display:flex; align-items:center; gap:16px; margin-top: 44px; padding-top: 24px; border-top: 1px solid var(--rule); }
-.section-nav button { padding: 7px 13px; text-transform: none; white-space: nowrap; }
 /* Next hugs the right edge, Previous the left -- and each keeps its side even
    when the other is hidden (an absent neighbour shows no button at all). */
 #page-next { margin-left: auto; }

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -189,7 +189,13 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 /* Chapter (block) navigation: prev / next flanking the Volume · Book locator. */
 .chapter-nav { display:flex; align-items:center; justify-content:center; gap:16px; margin-bottom: 14px; }
 .chapter-num { font:600 11.5px/1 'IBM Plex Mono',monospace; letter-spacing:.3em; text-transform:uppercase; color: var(--accent); }
-.chapter-step { padding: 12px 16px; font-size: 15px; line-height: 1; }
+/* Nav-button labels are references (Roman volume, β book, chapter, §section),
+   already cased -- so they opt out of the buttons' default uppercasing, which
+   would turn the book's lowercase β into a Latin-looking capital Β. */
+.chapter-step { padding: 12px 16px; font-size: 15px; line-height: 1; text-transform: none; }
+/* β marks a book (a difficulty-adjustment window, echoing the header's βₙ
+   difficulty target). Kept lowercase even inside an uppercased eyebrow/heading. */
+.beta-mark { text-transform: none; }
 .chapter-title { font: 500 37px/1.2 'Newsreader', serif; color: var(--ink); margin: 0 0 22px; letter-spacing: -.01em; }
 .chapter-hash { font: italic 400 15px/1.5 'Newsreader',serif; color: var(--dim); margin: 0 auto 16px; max-width: 46ch; }
 /* The block header's own fields -- version, previous-block hash, merkle
@@ -276,7 +282,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    Previous / Next pushed to opposite edges, each labelled with the section (or
    adjacent chapter) it steps to. A rule separates it from the section above. */
 .section-nav { display:flex; align-items:center; gap:16px; margin-top: 44px; padding-top: 24px; border-top: 1px solid var(--rule); }
-.section-nav button { padding: 12px 20px; }
+.section-nav button { padding: 12px 20px; text-transform: none; }
 /* Next hugs the right edge, Previous the left -- and each keeps its side even
    when the other is hidden (an absent neighbour shows no button at all). */
 #page-next { margin-left: auto; }
@@ -483,7 +489,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <div class="card">
     <label for="block-input">Block height, hash, transaction id, or reference</label>
     <div class="lookup-row">
-      <input type="text" id="block-input" class="mono" value="0" placeholder="e.g. III 2, a height, a hash, or a transaction id" autocomplete="off" spellcheck="false">
+      <input type="text" id="block-input" class="mono" value="0" placeholder="e.g. III β2, a height, a hash, or a transaction id" autocomplete="off" spellcheck="false">
       <button type="button" id="block-btn">Read</button>
     </div>
     <div id="block-status" class="status-line hidden"></div>
@@ -512,7 +518,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
     <header class="chapter-head">
       <nav class="chapter-nav">
         <button type="button" id="chapter-prev" class="chapter-step hidden" aria-label="Previous chapter" title="Previous chapter"></button>
-        <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span id="ch-book"></span><span id="ch-chapter-inline"></span></div>
+        <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span class="beta-mark">β</span><span id="ch-book"></span><span id="ch-chapter-inline"></span></div>
         <button type="button" id="chapter-next" class="chapter-step hidden" aria-label="Next chapter" title="Next chapter"></button>
       </nav>
       <h1 class="chapter-title" id="ch-title"></h1>
@@ -792,7 +798,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Margin — the transaction's locktime &amp; other marks</h4>
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">□</span><span class="m">no locktime</span></div>
-          <div class="glyph-row"><span class="g">■ <i>v b c</i></span><span class="m">not before the cited chapter (volume book chapter)</span></div>
+          <div class="glyph-row"><span class="g">■ <i>v</i> β<i>b</i> <i>c</i></span><span class="m">not before the cited chapter (volume, β book, chapter)</span></div>
           <div class="glyph-row"><span class="g">Τ<i>t</i></span><span class="m">not before a UTC date</span></div>
           <div class="glyph-row"><span class="g">∅</span><span class="m"><b>empty</b> — a coinbase's absent prevout, a segwit input's zero-byte script, an empty witness item</span></div>
           <div class="glyph-row"><span class="g">§<i>n</i></span><span class="m">section — the transaction's position</span></div>
@@ -1109,7 +1115,8 @@ function fromRoman(s) {
 // Returns null when the string isn't a reference at all.
 function parseReference(input) {
   const s = input.trim().replace(/\s+/g, ' ');
-  const m = s.match(/^([ivxlcdm]+)(?:\s+(\d+))?(?:\s+(\d+))?(?:\s+§?(\d+)(?:\.\d+)?)?$/i);
+  // The book may be written β2 or a bare 2 -- the β sigil is optional on input.
+  const m = s.match(/^([ivxlcdm]+)(?:\s+β?(\d+))?(?:\s+(\d+))?(?:\s+§?(\d+)(?:\.\d+)?)?$/i);
   if (!m) return null;
   const volume = fromRoman(m[1].toUpperCase());
   if (!Number.isFinite(volume) || volume < 1) return null;
@@ -1154,7 +1161,7 @@ async function resolveForwardCitations(txid, cells, gen) {
         const link = document.createElement('a');
         link.className = 'cite-section-link';
         link.href = `?block=${height}&index=${pos}`;
-        link.textContent = `${toRoman(volume)} ${book} ${chapter} §${pos + 1}`;
+        link.textContent = `${toRoman(volume)} β${book} ${chapter} §${pos + 1}`;
         link.title = `spent by input ${sp.vin + 1} of ${sp.txid}`;
         link.addEventListener('click', (e) => { e.preventDefault(); goToSection(height, pos, `in-${sp.vin}`); });
         cell.append(link);
@@ -1172,7 +1179,7 @@ function renderCitation(citeBody, height, pos, vout) {
   const link = document.createElement('a');
   link.className = 'cite-section-link';
   link.href = `?block=${height}&index=${pos}`;
-  link.textContent = `${toRoman(volume)} ${book} ${chapter} §${pos + 1}.${vout}`;
+  link.textContent = `${toRoman(volume)} β${book} ${chapter} §${pos + 1}.${vout}`;
   link.title = `go to §${pos + 1}.${vout}`;
   link.addEventListener('click', (e) => { e.preventDefault(); goToSection(height, pos, `out-${vout}`); });
   citeBody.textContent = '';
@@ -1411,7 +1418,7 @@ function renderChapter(para) {
   // Keep the lookup field showing where we are, in the same reference form the
   // citations use, so it round-trips: any navigation refreshes it, and pressing
   // Read chapter on it returns to this very section.
-  $('block-input').value = `${toRoman(volume)} ${book} ${chapter} §${state.index + 1}`;
+  $('block-input').value = `${toRoman(volume)} β${book} ${chapter} §${state.index + 1}`;
 
   // The big title (and hash subtitle) introduce the chapter as a whole, so
   // they only belong on its first transaction. Every later transaction
@@ -1660,15 +1667,16 @@ function renderChapter(para) {
 // contents abbreviates consecutive entries: show a level (volume, book, chapter)
 // only when it -- or a coarser level -- differs from where the reader is now, so
 // a step within the same chapter reads as a bare "§4", one across a chapter as
-// "5 §1", one across a book as "2 5 §1", one across an era as "II 1 1 §1". A
-// chapter jump (section === null) always ends on the chapter, never a §section.
+// "5 §1", one across a book as "β2 5 §1", one across an era as "II β1 1 §1". The
+// book carries its β sigil (see reference() in btc-citation.js). A chapter jump
+// (section === null) always ends on the chapter, never a §section.
 function minSharedRef(cur, target, section) {
   const dv = target.volume !== cur.volume;
   const db = dv || target.book !== cur.book;
   const dc = db || target.chapter !== cur.chapter;
   const parts = [];
   if (dv) parts.push(toRoman(target.volume));
-  if (db) parts.push(String(target.book));
+  if (db) parts.push(`β${target.book}`);
   if (dc || section == null) parts.push(String(target.chapter));
   if (section != null) parts.push(`§${section}`);
   return parts.join(' ');
@@ -2130,7 +2138,7 @@ function suggestTitle(entry) {
   if (!place) return '';
   const { volume, book, chapter } = volumeBookChapter(place.height);
   const genesis = volume === 1 && book === 1 && chapter === 1;
-  if (place.pos != null) return `${toRoman(volume)} ${book} ${chapter} §${place.pos + 1}`;
+  if (place.pos != null) return `${toRoman(volume)} β${book} ${chapter} §${place.pos + 1}`;
   return genesis ? 'Genesis' : `Chapter ${chapter}`;
 }
 

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -1629,6 +1629,43 @@ function renderChapter(para) {
   $('page-next').disabled = tipHeight !== null && state.height >= tipHeight && state.index >= state.txCount - 1;
   $('chapter-prev').disabled = state.height === 0;                                  // genesis has no earlier chapter
   $('chapter-next').disabled = tipHeight !== null && state.height >= tipHeight;     // the tip has no later chapter
+
+  labelNav();
+}
+
+// Label each navigation button with the reference it leads to, so a reader can
+// see where an arrow goes before pressing it. Chapter arrows name the block
+// they jump to ("Chapter N"); section arrows name the transaction they step to
+// ("§ N") -- and where a step runs off the block's edge, they name the adjacent
+// chapter it crosses into instead. Recomputed on every render from the current
+// position; the block-crossing chapter numbers come straight from the height,
+// while a prior chapter's final section count isn't known until it loads, so
+// that one edge names only the chapter.
+function labelNav() {
+  const prevChapter = state.height > 0 ? volumeBookChapter(state.height - 1).chapter : null;
+  const nextChapter = volumeBookChapter(state.height + 1).chapter;
+
+  // Whole-chapter jumps: always to the block one height away.
+  const setBtn = (id, text, label) => {
+    const b = $(id);
+    b.textContent = text;
+    b.title = label;
+    b.setAttribute('aria-label', label);   // else the static aria-label hides the number from screen readers
+  };
+
+  if (prevChapter !== null) setBtn('chapter-prev', `← Ch. ${prevChapter}`, `Previous chapter (Chapter ${prevChapter})`);
+  else setBtn('chapter-prev', '←', 'Previous chapter');
+  setBtn('chapter-next', `Ch. ${nextChapter} →`, `Next chapter (Chapter ${nextChapter})`);
+
+  // Section steps: within the chapter they name the target section; at an edge
+  // they cross into the neighbouring chapter, so they name that chapter instead.
+  const idx = state.index;
+  if (idx > 0) setBtn('page-prev', `← § ${idx}`, `Previous section (§ ${idx})`);                       // target section = current 1-based index minus one
+  else if (state.height > 0) setBtn('page-prev', `← Ch. ${prevChapter}`, `Previous section (end of Chapter ${prevChapter})`);  // crosses to the previous chapter's final section
+  else setBtn('page-prev', '← Previous', 'Previous section');                                          // genesis §1: nothing before it
+
+  if (idx < state.txCount - 1) setBtn('page-next', `§ ${idx + 2} →`, `Next section (§ ${idx + 2})`);   // target section = current 1-based index plus one
+  else setBtn('page-next', `Ch. ${nextChapter} § 1 →`, `Next section (Chapter ${nextChapter}, § 1)`);  // crosses to the next chapter's first section
 }
 
 // Encode every witness-bearing input's witness into a numbered footnote and

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -1881,6 +1881,12 @@ async function openLookup(input, index = 0) {
   input = (input || '').trim();
   $('chapter').classList.add('hidden');
   $('block-btn').disabled = true;
+  // Learn the current chain tip on every lookup (in parallel with the block
+  // load) and record it, so the Next controls are exact -- shown below the tip,
+  // hidden at it -- rather than optimistic. A tip fetch that fails resolves to
+  // null and leaves the previous tipHeight untouched; only a -1 lookup, which
+  // needs the tip to resolve a relative height, treats that failure as an error.
+  const tipP = loadTipHeight().then((t) => { tipHeight = Number(t); return tipHeight; }, () => null);
   try {
     if (/^-?\d+$/.test(input)) {
       let height = input;
@@ -1888,12 +1894,8 @@ async function openLookup(input, index = 0) {
       // block, -2 the one before it, and so on.
       if (input.startsWith('-')) {
         setStatus('<span class="spinner"></span>fetching latest block…');
-        const tip = Number(await loadTipHeight());
-        // We just learned the current tip -- record it so the chapter/section
-        // Next buttons stay hidden when this resolves to the tip itself (-1). A
-        // fresh page load comes through here too, so it no longer shows a dead
-        // Next button at the latest block.
-        tipHeight = tip;
+        const tip = await tipP;   // the shared tip fetch (already recorded in tipHeight on success)
+        if (tip === null) throw new Error('Could not reach the chain tip to resolve a relative height.');
         height = String(tip + Number(input) + 1);
         if (Number(height) < 0) throw new Error(`Only ${tip + 1} blocks exist; ${input} reaches before Genesis.`);
       }
@@ -1918,6 +1920,7 @@ async function openLookup(input, index = 0) {
       const meta = await loadBlockByHeight(ref.height);
       state = { ...meta, index: clampIndex(ref.index, meta) };
     }
+    await tipP;   // record the fresh tip before labelNav decides Next visibility
     await showCurrentTx();
   } catch (e) {
     setStatus(e.message || 'Failed to load.', 'err');

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -102,7 +102,6 @@ body {
 a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
 .mono { font-family: 'IBM Plex Mono', monospace; }
-.muted { color: var(--dim); }
 .hidden { display: none !important; }
 
 .masthead { display:flex; align-items:baseline; justify-content:space-between; gap:12px; flex-wrap:wrap; margin-bottom:24px; }
@@ -141,7 +140,6 @@ button {
 }
 button:hover:not(:disabled) { background: var(--accent-2); }
 button:disabled { opacity: .4; cursor: not-allowed; }
-.hint { margin-top: 10px; font-size: 12.5px; color: var(--meta); }
 
 /* ── data-source picker: choose the Esplora-compatible endpoint, add custom ── */
 .endpoint-row { display:flex; align-items:center; gap:10px; margin-top:16px; flex-wrap:wrap; }
@@ -167,16 +165,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .endpoint-add-row #endpoint-label { flex:0 0 32%; }
 .endpoint-msg { margin-top:10px; font:500 12px/1.4 'IBM Plex Mono',monospace; color:var(--meta); }
 .endpoint-msg.err { color:var(--error); }
-
-.about { margin-top: 16px; }
-.about summary {
-  cursor: pointer; font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.1em; text-transform:uppercase;
-  color: var(--dim); list-style: none;
-}
-.about summary::-webkit-details-marker { display: none; }
-.about summary::before { content: '+ '; color: var(--accent); }
-.about[open] summary::before { content: '– '; }
-.about .hint { margin-top: 10px; }
 
 .status-line { margin-top: 16px; font: 500 13px/1.4 'IBM Plex Mono',monospace; }
 .status-line.err { color: var(--error); }
@@ -816,15 +804,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         </div>
       </div>
     </div>
-  </details>
-
-  <details class="about">
-    <summary>About</summary>
-    <p class="hint muted">Each transaction's base bytes (version, inputs, outputs, locktime — exactly what a txid hashes) become a paragraph, each input's witness a numbered footnote. Small structural numbers (version, indices, sequence, amounts, locktime) appear as literal digits, and scripts are written in the opcode notation of the Notation key above. The margins carry the citation graph: each input cites the section it spends from (that output's amount in parentheses beneath), and each spent output carries a forward citation — the section that later consumed it — beneath its amount. An unspent output has none.</p>
-    <p class="hint muted">Only genuine payload becomes prose. Serialization framing — input/output and witness-item counts, and witness items' length prefixes — is dropped, since it is reconstructable from structure; a script's push opcodes render as superscript byte counts (with ↧/⇊/⤋ arrows when the length rides in a 1/2/4-byte prefix). And a canonical ECDSA signature is stripped from its DER envelope down to just its <em>r</em>, <em>s</em> and sighash flag; a non-canonical, pre-BIP66 signature fails the re-encode check and is kept verbatim, so its bytes still reconstruct exactly. What remains in prose is the genuinely opaque material: prevout references, keys, hashes, and signature scalars.</p>
-    <p class="hint muted">A chapter opens with its block header, parsed from the raw 80-byte header (not the API's own decoded fields) and independently re-hashed to confirm it matches the requested block. The previous-block hash and merkle root — genuinely opaque 32-byte hashes — are Glossia-encoded like the chapter and section hashes above them; version, timestamp, the difficulty target and the nonce are small structural numbers, so they're decoded and shown literally, with the raw wire value and its meaning both on hover. The same treatment covers the earliest coinbases' mining preamble: the restated difficulty target and the extranonce decode to β and η marks rather than passing through the wordlist — which lets the genesis headline stand as the first words of the book.</p>
-    <p class="hint muted">Every Glossia-encoded hash — a block hash, a transaction id, the previous-block hash and merkle root above — is read as prose; the raw hex it encodes is never shown. Clicking it opens a menu: copy that hex, copy the prose, or — for a block hash or transaction id — bookmark it under a title of your choosing. A bookmarked hash flies a small bookmark ribbon at its top-right corner; bookmarks (block hashes and transaction ids — anything you can navigate back to) are kept in this browser, each with its title, and join your <b>Bookmarks</b> in the lookup card, which opens with a curated set of notable transactions. The full <a href="./bitcoin-contents.html">table of contents</a> lists them on their own page.</p>
-    <p class="hint muted">Fetched live from the <a href="https://github.com/blockstream/esplora/blob/master/API.md" target="_blank" rel="noopener">Blockstream Esplora API</a> (mainnet), falling back to the compatible <a href="https://mempool.space/docs/api/rest" target="_blank" rel="noopener">mempool.space API</a> when Blockstream rate-limits. Pick the data source — or add your own Esplora/Electrs endpoint — from the <b>Data source</b> menu above; custom endpoints are remembered in this browser.</p>
   </details>
 
   <div id="hash-menu" class="hash-menu hidden" role="menu">

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -275,8 +275,11 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 /* Per-section paging, at the foot of the section (after the witness footnotes):
    Previous / Next pushed to opposite edges, each labelled with the section (or
    adjacent chapter) it steps to. A rule separates it from the section above. */
-.section-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin-top: 44px; padding-top: 24px; border-top: 1px solid var(--rule); }
+.section-nav { display:flex; align-items:center; gap:16px; margin-top: 44px; padding-top: 24px; border-top: 1px solid var(--rule); }
 .section-nav button { padding: 12px 20px; }
+/* Next hugs the right edge, Previous the left -- and each keeps its side even
+   when the other is hidden (an absent neighbour shows no button at all). */
+#page-next { margin-left: auto; }
 /* The section heading -- the transaction's position within its block, "§ N" --
    centred beneath the chapter frontispiece. */
 .section-title { text-align:center; margin: 22px 0 0; font:600 13px/1 'IBM Plex Mono',monospace; letter-spacing:.28em; text-transform:uppercase; color:var(--accent); }
@@ -508,9 +511,9 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <article id="chapter" class="hidden">
     <header class="chapter-head">
       <nav class="chapter-nav">
-        <button type="button" id="chapter-prev" class="chapter-step" aria-label="Previous chapter" title="Previous chapter">←</button>
+        <button type="button" id="chapter-prev" class="chapter-step hidden" aria-label="Previous chapter" title="Previous chapter"></button>
         <div class="chapter-num">Volume <span id="ch-volume"></span> · Book <span id="ch-book"></span><span id="ch-chapter-inline"></span></div>
-        <button type="button" id="chapter-next" class="chapter-step" aria-label="Next chapter" title="Next chapter">→</button>
+        <button type="button" id="chapter-next" class="chapter-step hidden" aria-label="Next chapter" title="Next chapter"></button>
       </nav>
       <h1 class="chapter-title" id="ch-title"></h1>
       <div class="chapter-hash" id="ch-hash-short"></div>
@@ -528,8 +531,8 @@ button:disabled { opacity: .4; cursor: not-allowed; }
     <!-- Section paging sits at the foot of the section, after its witness
          footnotes: read the transaction through, then step to the next. -->
     <nav class="section-nav">
-      <button type="button" id="page-prev">← Previous</button>
-      <button type="button" id="page-next">Next →</button>
+      <button type="button" id="page-prev" class="hidden" aria-label="Previous section" title="Previous section"></button>
+      <button type="button" id="page-next" class="hidden" aria-label="Next section" title="Next section"></button>
     </nav>
   </article>
 
@@ -1265,6 +1268,24 @@ async function loadBlockByHeight(height) {
   return loadBlockMeta((await res.text()).trim());
 }
 
+// A block's transaction count by height, from its info alone (no txid list) and
+// memoized. Used only to label the Previous button when it steps back across a
+// block boundary: the section it lands on is the prior block's last transaction,
+// whose §number is that block's tx count.
+const txCountByHeight = new Map();
+function loadBlockTxCount(height) {
+  if (!txCountByHeight.has(height)) {
+    txCountByHeight.set(height, (async () => {
+      const hres = await esploraFetch(`${ESPLORA}/block-height/${height}`);
+      if (!hres.ok) throw new Error(`Esplora returned ${hres.status}.`);
+      const bres = await esploraFetch(`${ESPLORA}/block/${(await hres.text()).trim()}`);
+      if (!bres.ok) throw new Error(`Esplora returned ${bres.status}.`);
+      return (await bres.json()).tx_count;
+    })().catch((e) => { txCountByHeight.delete(height); throw e; }));
+  }
+  return txCountByHeight.get(height);
+}
+
 // The chain tip height, as plain text from Esplora. Opens the book at the most
 // recent chapter when the reader arrives without a specific target.
 async function loadTipHeight() {
@@ -1632,47 +1653,84 @@ function renderChapter(para) {
   footnotesLoaded = false;
   renderFootnotes(gen);
 
-  $('page-prev').disabled = state.height === 0 && state.index === 0;
-  $('page-next').disabled = tipHeight !== null && state.height >= tipHeight && state.index >= state.txCount - 1;
-  $('chapter-prev').disabled = state.height === 0;                                  // genesis has no earlier chapter
-  $('chapter-next').disabled = tipHeight !== null && state.height >= tipHeight;     // the tip has no later chapter
-
   labelNav();
 }
 
-// Label each navigation button with the reference it leads to, so a reader can
-// see where an arrow goes before pressing it. Chapter arrows name the block
-// they jump to ("Chapter N"); section arrows name the transaction they step to
-// ("§ N") -- and where a step runs off the block's edge, they name the adjacent
-// chapter it crosses into instead. Recomputed on every render from the current
-// position; the block-crossing chapter numbers come straight from the height,
-// while a prior chapter's final section count isn't known until it loads, so
-// that one edge names only the chapter.
-function labelNav() {
-  const prevChapter = state.height > 0 ? volumeBookChapter(state.height - 1).chapter : null;
-  const nextChapter = volumeBookChapter(state.height + 1).chapter;
+// The reference each nav button leads to, abbreviated the way a table of
+// contents abbreviates consecutive entries: show a level (volume, book, chapter)
+// only when it -- or a coarser level -- differs from where the reader is now, so
+// a step within the same chapter reads as a bare "§4", one across a chapter as
+// "5 §1", one across a book as "2 5 §1", one across an era as "II 1 1 §1". A
+// chapter jump (section === null) always ends on the chapter, never a §section.
+function minSharedRef(cur, target, section) {
+  const dv = target.volume !== cur.volume;
+  const db = dv || target.book !== cur.book;
+  const dc = db || target.chapter !== cur.chapter;
+  const parts = [];
+  if (dv) parts.push(toRoman(target.volume));
+  if (db) parts.push(String(target.book));
+  if (dc || section == null) parts.push(String(target.chapter));
+  if (section != null) parts.push(`§${section}`);
+  return parts.join(' ');
+}
 
-  // Whole-chapter jumps: always to the block one height away.
+// Label the chapter/section nav buttons, and hide any that lead nowhere (Genesis
+// has no earlier chapter/section; the chain tip's last section none later). Each
+// label is the minimum shared reference to its destination (see minSharedRef).
+function labelNav() {
+  const cur = volumeBookChapter(state.height);
+  const idx = state.index;
+  const atTip = tipHeight !== null && state.height >= tipHeight;
+  const gen = renderGen;   // a slow previous-count fetch must not overwrite a later section's label
+
   const setBtn = (id, text, label) => {
     const b = $(id);
     b.textContent = text;
     b.title = label;
-    b.setAttribute('aria-label', label);   // else the static aria-label hides the number from screen readers
+    b.setAttribute('aria-label', label);
+  };
+  const showBtn = (id, show) => {
+    const b = $(id);
+    b.classList.toggle('hidden', !show);
+    if (show) b.disabled = false;   // clear any transient load-time disable
   };
 
-  if (prevChapter !== null) setBtn('chapter-prev', `← Ch. ${prevChapter}`, `Previous chapter (Chapter ${prevChapter})`);
-  else setBtn('chapter-prev', '←', 'Previous chapter');
-  setBtn('chapter-next', `Ch. ${nextChapter} →`, `Next chapter (Chapter ${nextChapter})`);
+  // A missing neighbour hides its button rather than greying it out.
+  const hasPrevChapter = state.height > 0;
+  const hasNextChapter = !atTip;
+  const hasPrevSection = !(state.height === 0 && idx === 0);
+  const hasNextSection = !(atTip && idx >= state.txCount - 1);
+  showBtn('chapter-prev', hasPrevChapter);
+  showBtn('chapter-next', hasNextChapter);
+  showBtn('page-prev', hasPrevSection);
+  showBtn('page-next', hasNextSection);
 
-  // Section steps: within the chapter they name the target section; at an edge
-  // they cross into the neighbouring chapter, so they name that chapter instead.
-  const idx = state.index;
-  if (idx > 0) setBtn('page-prev', `← § ${idx}`, `Previous section (§ ${idx})`);                       // target section = current 1-based index minus one
-  else if (state.height > 0) setBtn('page-prev', `← Ch. ${prevChapter}`, `Previous section (end of Chapter ${prevChapter})`);  // crosses to the previous chapter's final section
-  else setBtn('page-prev', '← Previous', 'Previous section');                                          // genesis §1: nothing before it
+  // Chapter navigation -- the reference truncated at the chapter.
+  if (hasPrevChapter) setBtn('chapter-prev', minSharedRef(cur, volumeBookChapter(state.height - 1), null), `Previous chapter (${reference(state.height - 1)})`);
+  if (hasNextChapter) setBtn('chapter-next', minSharedRef(cur, volumeBookChapter(state.height + 1), null), `Next chapter (${reference(state.height + 1)})`);
 
-  if (idx < state.txCount - 1) setBtn('page-next', `§ ${idx + 2} →`, `Next section (§ ${idx + 2})`);   // target section = current 1-based index plus one
-  else setBtn('page-next', `Ch. ${nextChapter} § 1 →`, `Next section (Chapter ${nextChapter}, § 1)`);  // crosses to the next chapter's first section
+  // Section navigation -- the reference down to the §section.
+  if (hasPrevSection) {
+    if (idx > 0) {
+      setBtn('page-prev', minSharedRef(cur, cur, idx), `Previous section (${reference(state.height)} §${idx})`);   // same chapter, target section = current 1-based index minus one
+    } else {
+      // Steps back into the prior block's final section; its §number is that
+      // block's tx count, not known until it loads -- shown as § once resolved.
+      const t = volumeBookChapter(state.height - 1);
+      setBtn('page-prev', minSharedRef(cur, t, '…'), `Previous section (end of ${reference(state.height - 1)})`);
+      loadBlockTxCount(state.height - 1)
+        .then((n) => { if (gen === renderGen) setBtn('page-prev', minSharedRef(cur, t, n), `Previous section (${reference(state.height - 1)} §${n})`); })
+        .catch(() => {});
+    }
+  }
+  if (hasNextSection) {
+    if (idx < state.txCount - 1) {
+      setBtn('page-next', minSharedRef(cur, cur, idx + 2), `Next section (${reference(state.height)} §${idx + 2})`);   // same chapter, target section = current 1-based index plus one
+    } else {
+      const t = volumeBookChapter(state.height + 1);
+      setBtn('page-next', minSharedRef(cur, t, 1), `Next section (${reference(state.height + 1)} §1)`);   // crosses into the next block's first section
+    }
+  }
 }
 
 // Encode every witness-bearing input's witness into a numbered footnote and
@@ -1800,8 +1858,7 @@ async function stepTx(direction) {
   } catch (e) {
     if (direction > 0) tipHeight = state.height;
     setStatus(direction > 0 ? 'No next block yet — this is the current chain tip.' : (e.message || 'Failed to load previous block.'), 'err');
-    $('page-prev').disabled = state.height === 0 && state.index === 0;
-    $('page-next').disabled = direction > 0;
+    labelNav();   // re-show/hide from the (unchanged) position, now that the tip may be known
   }
 }
 
@@ -1824,8 +1881,7 @@ async function goToChapter(direction) {
   } catch (e) {
     if (direction > 0) tipHeight = state.height;   // asked past the tip -- remember it
     setStatus(direction > 0 ? 'No next chapter yet — this is the current chain tip.' : (e.message || 'Failed to load previous chapter.'), 'err');
-    $('chapter-prev').disabled = state.height === 0;
-    $('chapter-next').disabled = direction > 0;
+    labelNav();   // re-show/hide from the (unchanged) position, now that the tip may be known
   } finally {
     chapterLoading = false;
   }

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -486,7 +486,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
   <div class="card">
     <label for="block-input">Block height, hash, transaction id, or reference</label>
     <div class="lookup-row">
-      <input type="text" id="block-input" class="mono" value="0" placeholder="e.g. III β2, a height, a hash, or a transaction id" autocomplete="off" spellcheck="false">
+      <input type="text" id="block-input" class="mono" value="0" placeholder="e.g. III β2 ■5, a height, a hash, or a transaction id" autocomplete="off" spellcheck="false">
       <button type="button" id="block-btn">Read</button>
     </div>
     <div id="block-status" class="status-line hidden"></div>
@@ -795,7 +795,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
         <h4>Margin — the transaction's locktime &amp; other marks</h4>
         <div class="glyph-grid">
           <div class="glyph-row"><span class="g">□</span><span class="m">no locktime</span></div>
-          <div class="glyph-row"><span class="g">■ <i>v</i> β<i>b</i> <i>c</i></span><span class="m">not before the cited chapter (volume, β book, chapter)</span></div>
+          <div class="glyph-row"><span class="g"><i>v</i> β<i>b</i> ■<i>c</i></span><span class="m">not before the cited chapter (volume, β book, ■ chapter)</span></div>
           <div class="glyph-row"><span class="g">Τ<i>t</i></span><span class="m">not before a UTC date</span></div>
           <div class="glyph-row"><span class="g">∅</span><span class="m"><b>empty</b> — a coinbase's absent prevout, a segwit input's zero-byte script, an empty witness item</span></div>
           <div class="glyph-row"><span class="g">§<i>n</i></span><span class="m">section — the transaction's position</span></div>
@@ -1112,8 +1112,9 @@ function fromRoman(s) {
 // Returns null when the string isn't a reference at all.
 function parseReference(input) {
   const s = input.trim().replace(/\s+/g, ' ');
-  // The book may be written β2 or a bare 2 -- the β sigil is optional on input.
-  const m = s.match(/^([ivxlcdm]+)(?:\s+β?(\d+))?(?:\s+(\d+))?(?:\s+§?(\d+)(?:\.\d+)?)?$/i);
+  // The book (β2) and chapter (■5) sigils are optional on input -- a bare
+  // "III 2 5" resolves just as "III β2 ■5" does.
+  const m = s.match(/^([ivxlcdm]+)(?:\s+β?(\d+))?(?:\s+■?(\d+))?(?:\s+§?(\d+)(?:\.\d+)?)?$/i);
   if (!m) return null;
   const volume = fromRoman(m[1].toUpperCase());
   if (!Number.isFinite(volume) || volume < 1) return null;
@@ -1158,7 +1159,7 @@ async function resolveForwardCitations(txid, cells, gen) {
         const link = document.createElement('a');
         link.className = 'cite-section-link';
         link.href = `?block=${height}&index=${pos}`;
-        link.textContent = `${toRoman(volume)} β${book} ${chapter} §${pos + 1}`;
+        link.textContent = `${toRoman(volume)} β${book} ■${chapter} §${pos + 1}`;
         link.title = `spent by input ${sp.vin + 1} of ${sp.txid}`;
         link.addEventListener('click', (e) => { e.preventDefault(); goToSection(height, pos, `in-${sp.vin}`); });
         cell.append(link);
@@ -1176,7 +1177,7 @@ function renderCitation(citeBody, height, pos, vout) {
   const link = document.createElement('a');
   link.className = 'cite-section-link';
   link.href = `?block=${height}&index=${pos}`;
-  link.textContent = `${toRoman(volume)} β${book} ${chapter} §${pos + 1}.${vout}`;
+  link.textContent = `${toRoman(volume)} β${book} ■${chapter} §${pos + 1}.${vout}`;
   link.title = `go to §${pos + 1}.${vout}`;
   link.addEventListener('click', (e) => { e.preventDefault(); goToSection(height, pos, `out-${vout}`); });
   citeBody.textContent = '';
@@ -1415,7 +1416,7 @@ function renderChapter(para) {
   // Keep the lookup field showing where we are, in the same reference form the
   // citations use, so it round-trips: any navigation refreshes it, and pressing
   // Read chapter on it returns to this very section.
-  $('block-input').value = `${toRoman(volume)} β${book} ${chapter} §${state.index + 1}`;
+  $('block-input').value = `${toRoman(volume)} β${book} ■${chapter} §${state.index + 1}`;
 
   // The big title (and hash subtitle) introduce the chapter as a whole, so
   // they only belong on its first transaction. Every later transaction
@@ -1664,9 +1665,10 @@ function renderChapter(para) {
 // contents abbreviates consecutive entries: show a level (volume, book, chapter)
 // only when it -- or a coarser level -- differs from where the reader is now, so
 // a step within the same chapter reads as a bare "§4", one across a chapter as
-// "5 §1", one across a book as "β2 5 §1", one across an era as "II β1 1 §1". The
-// book carries its β sigil (see reference() in btc-citation.js). A chapter jump
-// (section === null) always ends on the chapter, never a §section.
+// "■5 §1", one across a book as "β2 ■5 §1", one across an era as "II β1 ■1 §1".
+// The book carries its β sigil and the chapter its ■ (see reference() in
+// btc-citation.js). A chapter jump (section === null) always ends on the ■chapter,
+// never a §section.
 function minSharedRef(cur, target, section) {
   const dv = target.volume !== cur.volume;
   const db = dv || target.book !== cur.book;
@@ -1674,7 +1676,7 @@ function minSharedRef(cur, target, section) {
   const parts = [];
   if (dv) parts.push(toRoman(target.volume));
   if (db) parts.push(`β${target.book}`);
-  if (dc || section == null) parts.push(String(target.chapter));
+  if (dc || section == null) parts.push(`■${target.chapter}`);
   if (section != null) parts.push(`§${section}`);
   return parts.join(' ');
 }
@@ -2135,7 +2137,7 @@ function suggestTitle(entry) {
   if (!place) return '';
   const { volume, book, chapter } = volumeBookChapter(place.height);
   const genesis = volume === 1 && book === 1 && chapter === 1;
-  if (place.pos != null) return `${toRoman(volume)} β${book} ${chapter} §${place.pos + 1}`;
+  if (place.pos != null) return `${toRoman(volume)} β${book} ■${chapter} §${place.pos + 1}`;
   return genesis ? 'Genesis' : `Chapter ${chapter}`;
 }
 

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -366,6 +366,11 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    transaction's data is on chain. In the pattern table the same letters go
    plain where a spend introduces them at validation (see .seq.exec .ph). */
 .dt { color: var(--accent); font-style: normal; font-weight: 700; }
+/* The current block hash's h mark: unlike the other header hashes, the block's
+   own hash is not recorded on chain until the next block cites it, so it drops
+   the on-chain bold gold for the book's plain, neutral not-yet-committed style
+   (cf. the pattern table's validation-side .seq.exec .ph marks). */
+.dt-uncommitted { color: var(--ink); font-style: normal; font-weight: 400; }
 /* A witness footnote is a stack of items; a thin middot separates each, and an
    empty stack item shows as ∅. */
 .wit-sep, .wit-empty { color: var(--meta); font-style: normal; }
@@ -1499,7 +1504,9 @@ function renderChapter(para) {
   $('ch-title').classList.toggle('hidden', !onFirstTx);
   $('ch-hash-short').classList.toggle('hidden', !onFirstTx);
   const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(state.hash)), 'english', BEST_OF);
-  fillMarkedHash($('ch-hash-short'), 'h', 'dt', state.hash, 'block hash', hashProse);
+  // The block's own hash isn't on chain until the next block cites it, so its h
+  // mark is the neutral not-yet-committed style, not the on-chain bold gold.
+  fillMarkedHash($('ch-hash-short'), 'h', 'dt-uncommitted', state.hash, 'block hash', hashProse);
   $('ch-frontispiece').classList.toggle('hidden', !onFirstTx);
   if (onFirstTx) renderFrontispiece(state.header);
 

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -1356,17 +1356,31 @@ async function loadBlockByTxid(txid) {
 
 // A confirmed transaction's raw hex is immutable -- the txid is its hash -- so
 // it's memoized. Re-opening a section, or stepping back to one, re-parses from
-// cache instead of re-fetching the (potentially large) hex.
-const txHexCache = new Map();   // txid -> Promise<hex>
+// cache instead of re-fetching the (potentially large) hex. Unlike the block
+// core (small, kept unbounded), a single tx hex can run to kilobytes -- an
+// inscription witness, megabytes -- so this cache is bounded by a small LRU: the
+// least-recently-viewed entries fall out once the cap is reached, which is fine
+// since navigation only ever needs a handful at once. A Map keeps insertion
+// order, so re-inserting on a hit marks it most-recently-used and the oldest key
+// is always first.
+const TX_HEX_CACHE_MAX = 64;
+const txHexCache = new Map();   // txid -> Promise<hex>, ordered least- to most-recently-used
 function loadTxHex(txid) {
-  if (!txHexCache.has(txid)) {
-    txHexCache.set(txid, (async () => {
-      const r = await esploraFetch(`${ESPLORA}/tx/${txid}/hex`);
-      if (!r.ok) throw new Error(`Esplora returned ${r.status} fetching tx ${txid.slice(0, 8)}…`);
-      return (await r.text()).trim();
-    })().catch((e) => { txHexCache.delete(txid); throw e; }));
+  const cached = txHexCache.get(txid);
+  if (cached) {
+    txHexCache.delete(txid);
+    txHexCache.set(txid, cached);   // move to the most-recently-used end
+    return cached;
   }
-  return txHexCache.get(txid);
+  const p = (async () => {
+    const r = await esploraFetch(`${ESPLORA}/tx/${txid}/hex`);
+    if (!r.ok) throw new Error(`Esplora returned ${r.status} fetching tx ${txid.slice(0, 8)}…`);
+    return (await r.text()).trim();
+  })().catch((e) => { txHexCache.delete(txid); throw e; });
+  txHexCache.set(txid, p);
+  // Evict least-recently-used entries past the cap (Map iterates oldest-first).
+  while (txHexCache.size > TX_HEX_CACHE_MAX) txHexCache.delete(txHexCache.keys().next().value);
+  return p;
 }
 
 async function showCurrentTx() {

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -203,6 +203,10 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    each field carries its decoded form in `title` (a tooltip). */
 .chapter-frontispiece { margin: 0 auto 4px; max-width: 46ch; font: 500 11.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
 .chapter-frontispiece .cfx + .cfx::before { content: ' · '; }
+/* The merkle root's ⋔ mark: the clickable handle for its hash menu (copy hex /
+   prose), accented so it reads as the actionable element while the root's prose
+   beside it stays plain. */
+.merkle-mark { color: var(--accent); }
 
 /* A Glossia-encoded hash (a block hash, a txid, a merkle root): the prose is
    the visible text; clicking anywhere on it opens a menu to copy the exact hex
@@ -1414,8 +1418,10 @@ async function showCurrentTx() {
 // is never revealed on the page. A hash that's a lookup target (a block hash,
 // previous-block hash, or txid) can be bookmarked; a merkle root, which leads
 // nowhere, is copy-only.
-function attachHashCopy(el, hex, label) {
-  const prose = el.textContent;          // the visible prose for this hash
+function attachHashCopy(el, hex, label, prose = el.textContent) {
+  // `prose` is the readable form the menu offers to copy. It defaults to the
+  // element's own text, but when the hit target is a separate mark (the merkle
+  // root's ⋔) the prose lives beside it and is passed in explicitly.
   // This chapter's own hashes are bookmarkable; a merkle root leads nowhere, and
   // the previous-block hash just points back a chapter, so both are copy-only.
   const nav = label !== 'merkle root' && label !== 'previous block hash';
@@ -1450,17 +1456,27 @@ function renderFrontispiece(header) {
   const items = [
     { text: `v${hf.version}`, title: 'block version' },
     { text: prevProse, title: isGenesisPrev ? 'no earlier block — this is the genesis block' : null, copy: isGenesisPrev ? null : { hex: header.prevBlockHash, label: 'previous block hash' } },
-    { text: merkleProse, copy: { hex: header.merkleRoot, label: 'merkle root' } },
+    // The merkle root is prefixed with ⋔ (the book's merkle mark); that mark is
+    // the clickable handle for the copy menu, so the prose beside it reads plain.
+    { text: merkleProse, mark: '⋔', copy: { hex: header.merkleRoot, label: 'merkle root' } },
     { text: hf.timestamp, title: hf.timestampTitle },
     { text: hf.bits, title: hf.bitsTitle },
     { text: hf.nonce, title: hf.nonceTitle },
   ];
-  for (const { text, title, copy } of items) {
+  for (const { text, title, copy, mark } of items) {
     const span = document.createElement('span');
     span.className = 'cfx';
-    span.textContent = text;
-    if (copy) attachHashCopy(span, copy.hex, copy.label);
-    else if (title) span.title = title;
+    if (mark && copy) {
+      const m = document.createElement('span');
+      m.className = 'merkle-mark';
+      m.textContent = mark;
+      attachHashCopy(m, copy.hex, copy.label, text);   // the ⋔ mark opens the menu; prose is passed in
+      span.append(m, ' ' + text);                      // prose shown beside it, not itself clickable
+    } else {
+      span.textContent = text;
+      if (copy) attachHashCopy(span, copy.hex, copy.label);
+      else if (title) span.title = title;
+    }
     el.append(span);
   }
 }

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -192,9 +192,9 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .chapter-frontispiece { margin: 0 auto 4px; max-width: 46ch; font: 500 11.5px/1.7 'IBM Plex Mono',monospace; color: var(--meta); }
 .chapter-frontispiece .cfx + .cfx::before { content: ' · '; }
 /* The merkle root's ⋔ mark: the clickable handle for its hash menu (copy hex /
-   prose), accented so it reads as the actionable element while the root's prose
-   beside it stays plain. */
-.merkle-mark { color: var(--accent); }
+   prose), bold and accented (like the h data mark) so it reads as the actionable
+   element while the root's prose beside it stays plain. */
+.merkle-mark { color: var(--accent); font-weight: 700; }
 
 /* A Glossia-encoded hash (a block hash, a txid, a merkle root): the prose is
    the visible text; clicking anywhere on it opens a menu to copy the exact hex
@@ -1398,9 +1398,9 @@ async function showCurrentTx() {
 // previous-block hash, or txid) can be bookmarked; a merkle root, which leads
 // nowhere, is copy-only.
 function attachHashCopy(el, hex, label, prose = el.textContent) {
-  // `prose` is the readable form the menu offers to copy. It defaults to the
-  // element's own text, but when the hit target is a separate mark (the merkle
-  // root's ⋔) the prose lives beside it and is passed in explicitly.
+  // `prose` is the readable form the menu offers to copy. The hit target is the
+  // hash's leading mark (h, or ⋔ for a merkle root), so the prose lives beside it
+  // and is passed in explicitly (see fillMarkedHash) rather than read off `el`.
   // This chapter's own hashes are bookmarkable; a merkle root leads nowhere, and
   // the previous-block hash just points back a chapter, so both are copy-only.
   const nav = label !== 'merkle root' && label !== 'previous block hash';
@@ -1418,6 +1418,18 @@ function attachHashCopy(el, hex, label, prose = el.textContent) {
   el.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(e); } });
 }
 
+// Render a Glossia-encoded hash into `el` as its bold-gold data mark (h, or ⋔
+// for the merkle root) followed by the plain prose. The mark is the clickable
+// handle for the copy/bookmark menu; the prose itself is never interactive.
+function fillMarkedHash(el, mark, markClass, hex, label, prose) {
+  el.textContent = '';
+  const m = document.createElement('span');
+  m.className = markClass;
+  m.textContent = mark;
+  attachHashCopy(m, hex, label, prose);
+  el.append(m, ' ' + prose);
+}
+
 // The block header itself, in wire order, as a small mono line under the
 // chapter hash: version, previous-block hash, merkle root, timestamp,
 // difficulty target, nonce. The two hashes are Glossia-encoded here (like
@@ -1432,40 +1444,27 @@ function renderFrontispiece(header) {
   // The merkle root isn't proof-of-work-constrained, so unlike a block hash
   // it has no expected run of zero bytes worth trimming.
   const merkleProse = encodeSeedPhrase(reverseHex(header.merkleRoot), 'english', BEST_OF).prose;
+  // Each on-chain hash leads with a bold-gold mark (h for a hash, ⋔ for the
+  // merkle root) that carries the copy menu; the prose beside it is not itself
+  // clickable. The rest of the fields are plain decoded numbers.
   const items = [
     { text: `v${hf.version}`, title: 'block version' },
-    // The previous-block hash is on-chain data, so it leads with the book's
-    // bold-gold h (hash) data mark, like the data marks in the body prose.
-    { text: prevProse, title: isGenesisPrev ? 'no earlier block — this is the genesis block' : null, dataMark: isGenesisPrev ? null : 'h', copy: isGenesisPrev ? null : { hex: header.prevBlockHash, label: 'previous block hash' } },
-    // The merkle root is prefixed with ⋔ (the book's merkle mark); that mark is
-    // the clickable handle for the copy menu, so the prose beside it reads plain.
-    { text: merkleProse, mark: '⋔', copy: { hex: header.merkleRoot, label: 'merkle root' } },
+    isGenesisPrev
+      ? { text: prevProse, title: 'no earlier block — this is the genesis block' }
+      : { text: prevProse, mark: 'h', markClass: 'dt', copy: { hex: header.prevBlockHash, label: 'previous block hash' } },
+    { text: merkleProse, mark: '⋔', markClass: 'merkle-mark', copy: { hex: header.merkleRoot, label: 'merkle root' } },
     { text: hf.timestamp, title: hf.timestampTitle },
     { text: hf.bits, title: hf.bitsTitle },
     { text: hf.nonce, title: hf.nonceTitle },
   ];
-  for (const { text, title, copy, mark, dataMark } of items) {
+  for (const { text, title, copy, mark, markClass } of items) {
     const span = document.createElement('span');
     span.className = 'cfx';
     if (mark && copy) {
-      const m = document.createElement('span');
-      m.className = 'merkle-mark';
-      m.textContent = mark;
-      attachHashCopy(m, copy.hex, copy.label, text);   // the ⋔ mark opens the menu; prose is passed in
-      span.append(m, ' ' + text);                      // prose shown beside it, not itself clickable
+      fillMarkedHash(span, mark, markClass, copy.hex, copy.label, text);
     } else {
-      if (dataMark) {
-        // A bold-gold data-type mark (h/s/…) leads the prose; the whole field
-        // stays the clickable hash target, so the prose to copy is passed in.
-        const d = document.createElement('span');
-        d.className = 'dt';
-        d.textContent = dataMark;
-        span.append(d, ' ' + text);
-      } else {
-        span.textContent = text;
-      }
-      if (copy) attachHashCopy(span, copy.hex, copy.label, dataMark ? text : undefined);
-      else if (title) span.title = title;
+      span.textContent = text;
+      if (title) span.title = title;
     }
     el.append(span);
   }
@@ -1500,8 +1499,7 @@ function renderChapter(para) {
   $('ch-title').classList.toggle('hidden', !onFirstTx);
   $('ch-hash-short').classList.toggle('hidden', !onFirstTx);
   const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(state.hash)), 'english', BEST_OF);
-  $('ch-hash-short').textContent = hashProse;
-  attachHashCopy($('ch-hash-short'), state.hash, 'block hash');
+  fillMarkedHash($('ch-hash-short'), 'h', 'dt', state.hash, 'block hash', hashProse);
   $('ch-frontispiece').classList.toggle('hidden', !onFirstTx);
   if (onFirstTx) renderFrontispiece(state.header);
 
@@ -1509,8 +1507,7 @@ function renderChapter(para) {
   // to internal byte order first (like the block hash) so it carries the txid's
   // actual bytes; every byte kept, since a txid has no droppable leading zeros.
   const { prose: txidProse } = encodeSeedPhrase(reverseHex(para.txid), 'english', BEST_OF);
-  $('section-hash').textContent = txidProse;
-  attachHashCopy($('section-hash'), para.txid, 'transaction id');
+  fillMarkedHash($('section-hash'), 'h', 'dt', para.txid, 'transaction id', txidProse);
 
   const body = $('ch-paragraphs');
   body.innerHTML = '';

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -272,11 +272,14 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .hash-menu-title .hash-title-row .ghost { background: transparent; color: var(--dim); border: 1px solid var(--input-bd); }
 .hash-menu-title .hash-title-row .ghost:hover { background: transparent; color: var(--ink); border-color: var(--accent); }
 
-/* Per-section navigation: Previous / Next flanking the section title -- the
-   transaction's position within its block, rendered as "Section N". */
-.section-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin: 22px 0 0; }
+/* Per-section paging, at the foot of the section (after the witness footnotes):
+   Previous / Next pushed to opposite edges, each labelled with the section (or
+   adjacent chapter) it steps to. A rule separates it from the section above. */
+.section-nav { display:flex; align-items:center; justify-content:space-between; gap:16px; margin-top: 44px; padding-top: 24px; border-top: 1px solid var(--rule); }
 .section-nav button { padding: 12px 20px; }
-.section-title { flex:1; text-align:center; margin:0; font:600 13px/1 'IBM Plex Mono',monospace; letter-spacing:.28em; text-transform:uppercase; color:var(--accent); }
+/* The section heading -- the transaction's position within its block, "§ N" --
+   centred beneath the chapter frontispiece. */
+.section-title { text-align:center; margin: 22px 0 0; font:600 13px/1 'IBM Plex Mono',monospace; letter-spacing:.28em; text-transform:uppercase; color:var(--accent); }
 .section-num { display:block; }
 /* A curated transaction's name, beneath its § number -- the section's answer to
    a chapter's event title (serif, mixed case, quieter than the accent numeral). */
@@ -316,8 +319,9 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 .tx-in-cite.tx-version { color: var(--meta); letter-spacing: .03em; }
 .cite-section-link { color: inherit; text-decoration: none; }
 .cite-section-link:hover { color: var(--accent); text-decoration: underline; }
-/* The amount of the output this input spends, under its reference. */
-.cite-amount { margin-top: .1em; font: italic 400 12px/1.3 'Newsreader',serif; color: var(--meta); font-variant-numeric: tabular-nums; }
+/* The amount of the output this input spends, under its reference. Right-aligned
+   to the body gutter, like the reference above it and the output amounts opposite. */
+.cite-amount { margin-top: .1em; text-align: right; font: italic 400 12px/1.3 'Newsreader',serif; color: var(--meta); font-variant-numeric: tabular-nums; }
 /* An output's forward citation -- the section that later spent it -- under its
    amount in the right margin, mirroring the left margin's provenance cites.
    Empty for an unspent output. */
@@ -392,7 +396,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
      amounts follow their output -- position alone carries the sense. */
   .tx-flow { grid-template-columns: 1fr; }
   .tx-inputs, .tx-margin-cites, .tx-outputs, .tx-locktime { grid-column: 1; grid-row: auto; display: block; }
-  .tx-in-cite { text-align: left; margin: 0 0 .2em; }
+  .tx-in-cite, .cite-amount { text-align: left; margin: 0 0 .2em; }
   .tx-out-value, .tx-locktime { text-align: left; margin: 0 0 .55em; }
   /* Stacked into one column, the drop-cap's first body line now sits directly
      below its input's citation/amount rather than beside it. The floated
@@ -511,11 +515,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <h1 class="chapter-title" id="ch-title"></h1>
       <div class="chapter-hash" id="ch-hash-short"></div>
       <div class="chapter-frontispiece" id="ch-frontispiece"></div>
-      <nav class="section-nav">
-        <button type="button" id="page-prev">← Previous</button>
-        <h2 class="section-title" id="section-title"></h2>
-        <button type="button" id="page-next">Next →</button>
-      </nav>
+      <h2 class="section-title" id="section-title"></h2>
       <div class="section-hash" id="section-hash"></div>
     </header>
 
@@ -524,6 +524,13 @@ button:disabled { opacity: .4; cursor: not-allowed; }
     <div class="chapter-footnotes hidden" id="ch-footnotes-section">
       <div id="ch-footnotes"></div>
     </div>
+
+    <!-- Section paging sits at the foot of the section, after its witness
+         footnotes: read the transaction through, then step to the next. -->
+    <nav class="section-nav">
+      <button type="button" id="page-prev">← Previous</button>
+      <button type="button" id="page-next">Next →</button>
+    </nav>
   </article>
 
   <details class="notation">
@@ -774,7 +781,7 @@ button:disabled { opacity: .4; cursor: not-allowed; }
           <div class="glyph-row"><span class="g">†</span><span class="m"><b>replaceable</b> (opt-in RBF)</span></div>
           <div class="glyph-row"><span class="g">■<i>N</i></span><span class="m">relative: N blocks after confirmation (a count of chapters)</span></div>
           <div class="glyph-row"><span class="g">Τ<i>Δt</i></span><span class="m">relative: a duration after confirmation (d h m s)</span></div>
-          <div class="glyph-row"><span class="g">(₿<i>n</i>)</span><span class="m">the <b>amount spent</b> by this input — value flowing in; an output's amount stands bare (₿<i>n</i>, no parentheses)</span></div>
+          <div class="glyph-row"><span class="g">(<i>n</i> ₿)</span><span class="m">the <b>amount spent</b> by this input — value flowing in; an output's amount stands bare (<i>n</i> ₿, no parentheses)</span></div>
         </div>
       </div>
 

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -141,9 +141,18 @@ button {
 button:hover:not(:disabled) { background: var(--accent-2); }
 button:disabled { opacity: .4; cursor: not-allowed; }
 
+/* ── Settings popover (top-right): holds the data-source picker ── */
+.settings-menu { position:relative; }
+.settings-panel {
+  position:absolute; z-index:45; top:calc(100% + 10px); right:0; text-align:left;
+  width:min(340px, 86vw); padding:15px 16px 16px;
+  background:var(--card); border:1px solid var(--card-bd); border-radius:8px;
+  box-shadow:0 16px 40px -10px rgba(0,0,0,.75);
+}
+.settings-title { font:600 11px/1 'IBM Plex Mono',monospace; letter-spacing:.1em; text-transform:uppercase; color:var(--dim); margin-bottom:11px; }
+
 /* ── data-source picker: choose the Esplora-compatible endpoint, add custom ── */
-.endpoint-row { display:flex; align-items:center; gap:10px; margin-top:16px; flex-wrap:wrap; }
-.inline-label { font:500 11px/1 'IBM Plex Mono',monospace; letter-spacing:.06em; text-transform:uppercase; color:var(--dim); }
+.endpoint-row { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
 .endpoint-select {
   flex:1; min-width:170px; background:var(--input-bg); border:1px solid var(--input-bd); border-radius:4px;
   color:var(--ink-soft); font:400 12.5px/1.4 'IBM Plex Mono',monospace; padding:8px 10px; cursor:pointer;
@@ -489,7 +498,21 @@ button:disabled { opacity: .4; cursor: not-allowed; }
 <div class="wrap">
   <div class="masthead">
     <span class="title">The <span class="beta">β</span>itcoin <span class="beta">β</span>ook</span>
-    <span class="home"><button type="button" id="install-btn" class="install-btn" aria-label="Install the Bitcoin Book as an app">Install</button><a href="./bitcoin-contents.html">Contents</a> · <a href="./index.html">Glossia</a></span>
+    <span class="home"><button type="button" id="install-btn" class="install-btn" aria-label="Install the Bitcoin Book as an app">Install</button><a href="./bitcoin-contents.html">Contents</a> · <span class="settings-menu"><a href="#" id="settings-link" role="button" aria-haspopup="dialog" aria-expanded="false">Settings</a><div id="settings-panel" class="settings-panel hidden" role="dialog" aria-label="Settings">
+      <div class="settings-title">Data source</div>
+      <div class="endpoint-row">
+        <select id="endpoint-select" class="endpoint-select" aria-label="Data source endpoint"></select>
+        <button type="button" id="endpoint-add" class="ghost-btn">+ Add</button>
+        <button type="button" id="endpoint-remove" class="ghost-btn" disabled>Remove</button>
+      </div>
+      <div id="endpoint-add-row" class="endpoint-add-row hidden">
+        <input type="text" id="endpoint-label" class="mono" placeholder="Label (optional)" autocomplete="off" spellcheck="false">
+        <input type="text" id="endpoint-url" class="mono" placeholder="https://your-node/api" autocomplete="off" spellcheck="false">
+        <button type="button" id="endpoint-save">Save</button>
+        <button type="button" id="endpoint-cancel" class="ghost-btn">Cancel</button>
+      </div>
+      <div id="endpoint-msg" class="endpoint-msg hidden"></div>
+    </div></span></span>
   </div>
 
   <div class="card">
@@ -499,20 +522,6 @@ button:disabled { opacity: .4; cursor: not-allowed; }
       <button type="button" id="block-btn">Read</button>
     </div>
     <div id="block-status" class="status-line hidden"></div>
-
-    <div class="endpoint-row">
-      <span class="inline-label">Data source</span>
-      <select id="endpoint-select" class="endpoint-select" aria-label="Data source endpoint"></select>
-      <button type="button" id="endpoint-add" class="ghost-btn">+ Add</button>
-      <button type="button" id="endpoint-remove" class="ghost-btn" disabled>Remove</button>
-    </div>
-    <div id="endpoint-add-row" class="endpoint-add-row hidden">
-      <input type="text" id="endpoint-label" class="mono" placeholder="Label (optional)" autocomplete="off" spellcheck="false">
-      <input type="text" id="endpoint-url" class="mono" placeholder="https://your-node/api" autocomplete="off" spellcheck="false">
-      <button type="button" id="endpoint-save">Save</button>
-      <button type="button" id="endpoint-cancel" class="ghost-btn">Cancel</button>
-    </div>
-    <div id="endpoint-msg" class="endpoint-msg hidden"></div>
 
     <details id="contents" class="contents">
       <summary>Bookmarks</summary>
@@ -2126,6 +2135,29 @@ $('endpoint-remove').addEventListener('click', () => {
 });
 
 renderEndpoints();
+
+// ── Settings popover ──────────────────────────────────────────────────────
+// The masthead "Settings" link toggles a small popover holding the data-source
+// picker; it dismisses on an outside click or Escape.
+const settingsLink = $('settings-link');
+const settingsPanel = $('settings-panel');
+function closeSettings() {
+  settingsPanel.classList.add('hidden');
+  settingsLink.setAttribute('aria-expanded', 'false');
+  closeAddForm();   // collapse the add-endpoint form when the popover closes
+}
+settingsLink.addEventListener('click', (e) => {
+  e.preventDefault();
+  const nowHidden = settingsPanel.classList.toggle('hidden');
+  settingsLink.setAttribute('aria-expanded', nowHidden ? 'false' : 'true');
+  if (nowHidden) closeAddForm();
+});
+document.addEventListener('click', (e) => {
+  if (settingsPanel.classList.contains('hidden')) return;
+  if (settingsPanel.contains(e.target) || settingsLink.contains(e.target)) return;
+  closeSettings();
+});
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !settingsPanel.classList.contains('hidden')) closeSettings(); });
 
 // ── Hash menu + bookmarks ─────────────────────────────────────────────────
 // Clicking any Glossia-encoded hash opens a small menu (Copy hex / Bookmark).

--- a/web/bitcoin-book.html
+++ b/web/bitcoin-book.html
@@ -366,11 +366,13 @@ button:disabled { opacity: .4; cursor: not-allowed; }
    transaction's data is on chain. In the pattern table the same letters go
    plain where a spend introduces them at validation (see .seq.exec .ph). */
 .dt { color: var(--accent); font-style: normal; font-weight: 700; }
-/* The current block hash's h mark: unlike the other header hashes, the block's
-   own hash is not recorded on chain until the next block cites it, so it drops
-   the on-chain bold gold for the book's plain, neutral not-yet-committed style
-   (cf. the pattern table's validation-side .seq.exec .ph marks). */
-.dt-uncommitted { color: var(--ink); font-style: normal; font-weight: 400; }
+/* A derived hash identity -- the block's own hash, a transaction's own txid --
+   is computed from data, not a stored on-chain field like the previous-block
+   hash or merkle root (and the block hash isn't itself recorded on chain until
+   the next block cites it). So its h mark drops the on-chain bold gold for the
+   book's plain, neutral not-yet-committed style (cf. the pattern table's
+   validation-side .seq.exec .ph marks). */
+.dt-derived { color: var(--ink); font-style: normal; font-weight: 400; }
 /* A witness footnote is a stack of items; a thin middot separates each, and an
    empty stack item shows as ∅. */
 .wit-sep, .wit-empty { color: var(--meta); font-style: normal; }
@@ -1504,9 +1506,9 @@ function renderChapter(para) {
   $('ch-title').classList.toggle('hidden', !onFirstTx);
   $('ch-hash-short').classList.toggle('hidden', !onFirstTx);
   const { prose: hashProse } = encodeSeedPhrase(trimTrailingZeroBytes(reverseHex(state.hash)), 'english', BEST_OF);
-  // The block's own hash isn't on chain until the next block cites it, so its h
-  // mark is the neutral not-yet-committed style, not the on-chain bold gold.
-  fillMarkedHash($('ch-hash-short'), 'h', 'dt-uncommitted', state.hash, 'block hash', hashProse);
+  // The block's own hash is a derived identity, not a stored on-chain field, so
+  // its h mark is the neutral derived style, not the on-chain bold gold.
+  fillMarkedHash($('ch-hash-short'), 'h', 'dt-derived', state.hash, 'block hash', hashProse);
   $('ch-frontispiece').classList.toggle('hidden', !onFirstTx);
   if (onFirstTx) renderFrontispiece(state.header);
 
@@ -1514,7 +1516,9 @@ function renderChapter(para) {
   // to internal byte order first (like the block hash) so it carries the txid's
   // actual bytes; every byte kept, since a txid has no droppable leading zeros.
   const { prose: txidProse } = encodeSeedPhrase(reverseHex(para.txid), 'english', BEST_OF);
-  fillMarkedHash($('section-hash'), 'h', 'dt', para.txid, 'transaction id', txidProse);
+  // A txid is a derived identity too (like the block hash), so its h mark takes
+  // the same neutral derived style rather than the on-chain bold gold.
+  fillMarkedHash($('section-hash'), 'h', 'dt-derived', para.txid, 'transaction id', txidProse);
 
   const body = $('ch-paragraphs');
   body.innerHTML = '';

--- a/web/bitcoin-contents.html
+++ b/web/bitcoin-contents.html
@@ -110,6 +110,9 @@ a:hover { text-decoration: underline; }
 .toc-vol:first-child { margin-top:8px; padding-top:0; border-top:none; }
 .toc-book { margin:15px 0 1px; padding-left:16px;
   font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.16em; text-transform:uppercase; color:var(--meta); }
+/* β marks a book (a difficulty-adjustment window); kept lowercase inside the
+   uppercased Book heading, where an uppercased β would read as a Latin B. */
+.beta-mark { text-transform:none; }
 
 /* A contents row: title on the left, its remaining reference on the right; the
    whole row navigates into the book, the manuscript's own citation form. */
@@ -224,10 +227,10 @@ async function resolveBookmark(b) {
 
 // The tail of an entry's citation -- the part its heading hasn't already named.
 // Under a Book heading only the chapter (and a transaction's §section) remains;
-// directly under a Volume, the book leads it. Spaced like the book's own
-// citations (e.g. "29 596", "1 §1").
+// directly under a Volume, the β-marked book leads it. Spaced like the book's
+// own citations (e.g. "β29 596", "1 §1").
 function tailRef({ book, chapter, section }, underBook) {
-  let s = (underBook ? [chapter] : [book, chapter]).join(' ');
+  let s = (underBook ? [chapter] : [`β${book}`, chapter]).join(' ');
   if (section != null) s += ` §${section}`;
   return s;
 }
@@ -273,7 +276,9 @@ function render() {
       const bk = entries[k].place.book;
       let jb = k + 1; while (jb < jv && entries[jb].place.book === bk) jb++;
       if (jb - k >= 2) {
-        toc.append(head('toc-book', `Book ${bk}`));
+        const bookHead = head('toc-book', '');
+        bookHead.innerHTML = `Book <span class="beta-mark">β</span>${bk}`;   // β kept lowercase under the heading's uppercasing
+        toc.append(bookHead);
         for (let m = k; m < jb; m++) toc.append(entryEl(entries[m], true));
       } else {
         toc.append(entryEl(entries[k], false));

--- a/web/bitcoin-contents.html
+++ b/web/bitcoin-contents.html
@@ -110,9 +110,6 @@ a:hover { text-decoration: underline; }
 .toc-vol:first-child { margin-top:8px; padding-top:0; border-top:none; }
 .toc-book { margin:15px 0 1px; padding-left:16px;
   font:600 10px/1 'IBM Plex Mono',monospace; letter-spacing:.16em; text-transform:uppercase; color:var(--meta); }
-/* β marks a book (a difficulty-adjustment window); kept lowercase inside the
-   uppercased Book heading, where an uppercased β would read as a Latin B. */
-.beta-mark { text-transform:none; }
 
 /* A contents row: title on the left, its remaining reference on the right; the
    whole row navigates into the book, the manuscript's own citation form. */
@@ -276,9 +273,7 @@ function render() {
       const bk = entries[k].place.book;
       let jb = k + 1; while (jb < jv && entries[jb].place.book === bk) jb++;
       if (jb - k >= 2) {
-        const bookHead = head('toc-book', '');
-        bookHead.innerHTML = `Book <span class="beta-mark">β</span>${bk}`;   // β kept lowercase under the heading's uppercasing
-        toc.append(bookHead);
+        toc.append(head('toc-book', `Book ${bk}`));   // spelled out, no β; the β sigil rides only the compact tail references
         for (let m = k; m < jb; m++) toc.append(entryEl(entries[m], true));
       } else {
         toc.append(entryEl(entries[k], false));

--- a/web/bitcoin-contents.html
+++ b/web/bitcoin-contents.html
@@ -223,11 +223,11 @@ async function resolveBookmark(b) {
 }
 
 // The tail of an entry's citation -- the part its heading hasn't already named.
-// Under a Book heading only the chapter (and a transaction's §section) remains;
+// Under a Book heading only the ■chapter (and a transaction's §section) remains;
 // directly under a Volume, the β-marked book leads it. Spaced like the book's
-// own citations (e.g. "β29 596", "1 §1").
+// own citations (e.g. "β29 ■596", "■1 §1").
 function tailRef({ book, chapter, section }, underBook) {
-  let s = (underBook ? [chapter] : [`β${book}`, chapter]).join(' ');
+  let s = (underBook ? [`■${chapter}`] : [`β${book}`, `■${chapter}`]).join(' ');
   if (section != null) s += ` §${section}`;
   return s;
 }

--- a/web/btc-citation.js
+++ b/web/btc-citation.js
@@ -48,10 +48,11 @@ export function toRoman(n) {
 }
 
 // The scripture-style reference for a block height: Roman volume, the book
-// marked with β, then the chapter (e.g. "III β2 5"). β is the book's own sigil
-// because a book is a difficulty-adjustment window and β is the difficulty mark
-// (the header's βₙ target). A transaction adds a §section to this.
+// marked with β, the chapter with ■ (e.g. "III β2 ■5"). Each level below the
+// volume carries the sigil of what it is: β is the difficulty mark, and a book
+// is a difficulty-adjustment window; ■ is the block mark (the timelock glyph),
+// and a chapter is a block. A transaction adds a §section to this.
 export function reference(height) {
   const { volume, book, chapter } = volumeBookChapter(height);
-  return `${toRoman(volume)} β${book} ${chapter}`;
+  return `${toRoman(volume)} β${book} ■${chapter}`;
 }

--- a/web/btc-citation.js
+++ b/web/btc-citation.js
@@ -47,9 +47,11 @@ export function toRoman(n) {
   return out || '0';
 }
 
-// The scripture-style reference for a block height: Roman volume, then book and
-// chapter (e.g. "III 2 5"). A transaction adds a §section to this.
+// The scripture-style reference for a block height: Roman volume, the book
+// marked with β, then the chapter (e.g. "III β2 5"). β is the book's own sigil
+// because a book is a difficulty-adjustment window and β is the difficulty mark
+// (the header's βₙ target). A transaction adds a §section to this.
 export function reference(height) {
   const { volume, book, chapter } = volumeBookChapter(height);
-  return `${toRoman(volume)} ${book} ${chapter}`;
+  return `${toRoman(volume)} β${book} ${chapter}`;
 }

--- a/web/btc-contents.js
+++ b/web/btc-contents.js
@@ -16,7 +16,6 @@ export const NOTABLE = [
   { title: 'The Times 03/Jan/2009 Chancellor on brink of second bailout for banks', id: '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b' },
   { title: 'Hal Finney transaction', id: 'f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16' },
   { title: 'Bitcoin Pizza Day', id: '57043' },
-  { title: 'Value overflow incident', id: '74638', index: 1 },   // §2: the tx that minted ~184.4 billion BTC via an output-value overflow
   { title: '100K block milestone', id: '100000' },
   { title: 'Eligius', id: '139690' },
   { title: 'First P2SH spend', id: 'e5779b9e78f9650debc2893fd9636d827b26b4ddfa6a8172fe8708c924f5c39d' },

--- a/web/btc-contents.js
+++ b/web/btc-contents.js
@@ -16,6 +16,10 @@ export const NOTABLE = [
   { title: 'The Times 03/Jan/2009 Chancellor on brink of second bailout for banks', id: '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b' },
   { title: 'Hal Finney transaction', id: 'f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16' },
   { title: 'Bitcoin Pizza Day', id: '57043' },
+  // The overflow block/tx were orphaned by the corrective fork; canonical height
+  // 74,638 is the honest re-mined block that excised the ~184.4B-BTC overflow, so
+  // this entry points at the block itself (no §section) -- the supply cap's repair.
+  { title: 'Supply cap bug fix', id: '74638' },
   { title: '100K block milestone', id: '100000' },
   { title: 'Eligius', id: '139690' },
   { title: 'First P2SH spend', id: 'e5779b9e78f9650debc2893fd9636d827b26b4ddfa6a8172fe8708c924f5c39d' },

--- a/web/btc-contents.js
+++ b/web/btc-contents.js
@@ -16,6 +16,7 @@ export const NOTABLE = [
   { title: 'The Times 03/Jan/2009 Chancellor on brink of second bailout for banks', id: '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b' },
   { title: 'Hal Finney transaction', id: 'f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16' },
   { title: 'Bitcoin Pizza Day', id: '57043' },
+  { title: 'Value overflow incident', id: '74638', index: 1 },   // §2: the tx that minted ~184.4 billion BTC via an output-value overflow
   { title: '100K block milestone', id: '100000' },
   { title: 'Eligius', id: '139690' },
   { title: 'First P2SH spend', id: 'e5779b9e78f9650debc2893fd9636d827b26b4ddfa6a8172fe8708c924f5c39d' },

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -164,11 +164,11 @@ export function groupDigits(s) {
 // comma-grouped, and the fraction is always the full eight decimal places, so a
 // right-aligned column of amounts aligns on the point. 50 BTC reads 50.00000000 ₿,
 // a lone satoshi 0.00000001 ₿. An exactly-zero amount (e.g. an OP_RETURN data
-// carrier) reads as a bare 0 rather than a row of zeros. BigInt keeps large sat
+// carrier) reads as a bare 0 ₿ rather than a row of zeros. BigInt keeps large sat
 // counts exact.
 export function formatBtc(sats) {
   const s = BigInt(sats);
-  if (s === 0n) return '0';
+  if (s === 0n) return '0 ₿';
   const whole = (s / 100000000n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   const frac = (s % 100000000n).toString().padStart(8, '0');
   return `${whole}.${frac} ₿`;

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -60,7 +60,7 @@ function locktimeInfo(locktime) {
   if (locktime === 0) return { mark: '□', title: 'no locktime — final with respect to time' };
   if (locktime < LOCKTIME_THRESHOLD) {
     const { volume, book, chapter } = volumeBookChapter(locktime);
-    return { mark: `■ ${toRoman(volume)} ${book} ${chapter}`, title: `locktime: not before block ${locktime} — volume ${volume}, book ${book}, chapter ${chapter}` };
+    return { mark: `■ ${toRoman(volume)} β${book} ${chapter}`, title: `locktime: not before block ${locktime} — volume ${volume}, book ${book}, chapter ${chapter}` };
   }
   const date = new Date(locktime * 1000).toISOString().slice(0, 16).replace('T', ' ');
   return { mark: `Τ${date}`, title: `locktime: not before ${date} UTC (unix ${locktime})` };

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -159,16 +159,19 @@ export function groupDigits(s) {
   return s.replace(/\B(?=(\d{3})+(?!\d))/g, '·');
 }
 
-// A satoshi amount -> its value in bitcoin, prefixed with the ₿ sign and exact
-// to the satoshi. English number formatting: the whole-bitcoin part is
+// A satoshi amount -> its value in bitcoin, with the ₿ sign trailing the figure
+// and exact to the satoshi. English number formatting: the whole-bitcoin part is
 // comma-grouped, and the fraction is always the full eight decimal places, so a
-// column of amounts aligns on the point. 50 BTC reads ₿50.00000000, a lone
-// satoshi ₿0.00000001. BigInt keeps large sat counts exact.
+// right-aligned column of amounts aligns on the point. 50 BTC reads 50.00000000 ₿,
+// a lone satoshi 0.00000001 ₿. An exactly-zero amount (e.g. an OP_RETURN data
+// carrier) reads as a bare 0 rather than a row of zeros. BigInt keeps large sat
+// counts exact.
 export function formatBtc(sats) {
   const s = BigInt(sats);
+  if (s === 0n) return '0';
   const whole = (s / 100000000n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   const frac = (s % 100000000n).toString().padStart(8, '0');
-  return `₿${whole}.${frac}`;
+  return `${whole}.${frac} ₿`;
 }
 
 // Quoted script text comes directly from raw blockchain data -- a miner's

--- a/web/btc-prose.js
+++ b/web/btc-prose.js
@@ -29,10 +29,12 @@ function toRoman(n) {
 
 // The timelock fields get symbols rather than digit strings, on a small grammar
 // that separates the whole transaction's status (nLockTime) from each input's
-// (nSequence), sharing ■ (block) / Τ (temporal) for the block/time distinction:
-//   Transaction (nLockTime):  □ none · ■n absolute block height · Τn absolute unix time
+// (nSequence), sharing ■ (block) / Τ (temporal) for the block/time distinction.
+// ■ is also the chapter sigil in references, so an absolute block-height lock is
+// written as the chapter reference it names rather than a leading ■n:
+//   Transaction (nLockTime):  □ none · v βb ■c absolute block (a chapter) · Τn absolute unix time
 //   Input (nSequence):        ○ final · † replaceable (opt-in RBF) ·
-//                             ■n relative block delay · Τn relative time delay
+//                             ■n relative block delay (a count of chapters) · Τn relative time delay
 // The square reads as the whole document, the circle as one input. A coinbase's
 // null prevout is flagged with isNullPrevout so the renderer can mark it (∅);
 // other prevouts are carried as references and resolved to a citation
@@ -52,15 +54,16 @@ function durationFrom512s(n) {
   return parts.join('');
 }
 
-// nLockTime -> { mark, title }: □ (none), ■ + citation (absolute block --
-// the block is a chapter of the book, so it's cited as volume book chapter
-// rather than a bare height), Τ + UTC date (absolute time -- rendered
-// physically, the raw unix value in the hover).
+// nLockTime -> { mark, title }: □ (none), a chapter reference for an absolute
+// block height (the block is a chapter, cited as volume book ■chapter rather than
+// a bare height -- the chapter's own ■ block-mark carries the "block" sense the
+// leading ■ used to, so no separate operator is needed), Τ + UTC date for an
+// absolute time (rendered physically, the raw unix value in the hover).
 function locktimeInfo(locktime) {
   if (locktime === 0) return { mark: '□', title: 'no locktime — final with respect to time' };
   if (locktime < LOCKTIME_THRESHOLD) {
     const { volume, book, chapter } = volumeBookChapter(locktime);
-    return { mark: `■ ${toRoman(volume)} β${book} ${chapter}`, title: `locktime: not before block ${locktime} — volume ${volume}, book ${book}, chapter ${chapter}` };
+    return { mark: `${toRoman(volume)} β${book} ■${chapter}`, title: `locktime: not before block ${locktime} — volume ${volume}, book ${book}, chapter ${chapter}` };
   }
   const date = new Date(locktime * 1000).toISOString().slice(0, 16).replace('T', ' ');
   return { mark: `Τ${date}`, title: `locktime: not before ${date} UTC (unix ${locktime})` };


### PR DESCRIPTION
The chapter and section navigation buttons showed only bare arrows and
generic "Previous"/"Next" text, giving no hint of where each one leads.
Label each with the reference it navigates to: chapter arrows name the
block they jump to (e.g. "Ch. 334"), section arrows name the transaction
they step to (e.g. "§ 3"), and at a block's edge the section arrows name
the adjacent chapter they cross into. Labels and ARIA/title text are
recomputed on every render from the current position; chapter numbers for
neighbours come straight from the height (correct across book/era
boundaries), while a prior chapter's final section count isn't known
until it loads, so that one edge names only the chapter.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V2DeJXPyuLHb3oJucKxhmb