### PR TITLE
Checksum-seeded cover: groundwork and a prose Bitcoin address format (#76)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -84,6 +84,23 @@ languages that ship a `semantics.yaml`; absent → behaves exactly as before.
   debug is ~40× slower for the sequence enumeration, and always confirm the binary under test
   was actually rebuilt before trusting a measurement.
 
+## Per-call caches (use the `_cached` variants in hot paths)
+
+Everything the encode path loads is a pure function of `(language, dialect, wordlist)`,
+and all of it used to be reparsed on every call — `build_zone_generator` alone cost
+~12 ms, ~6 ms of which was reparsing English's 100 KB `semantics.yaml`. Measure with
+`cargo run --release --example encode_prep_cost`.
+
+| uncached | cached | why it matters |
+|---|---|---|
+| `load_semantics` | `load_semantics_cached` → `Option<Arc<_>>` | 6.05 → 0.00 ms; env escape hatch is checked *outside* the cache so it still toggles |
+| `Grammar::from_language_dialect` | `..._cached` → `Arc<Grammar>` | 1.49 → 0.00 ms |
+| `DialectConfig::from_language_dialect` | `..._cached` → `Arc<DialectConfig>` | 1.47 → 0.00 ms; scale dialects are deliberately NOT cached (construction injects derived payload words as a side effect) |
+| `load_cover_words_by_pos_for_wordlist` | same name — the YAML parse behind it is cached, the payload filter stays per-call | 1.82 → 0.08 ms |
+
+The uncached forms are kept for callers that need an owned, mutable value. Every
+cache builds its value *outside* the lock, so a parse panic cannot poison it.
+
 ## Documentation
 
 All project documentation lives in `docs/src/` (mdBook format). When creating or updating documentation, write to files in that directory and update `docs/src/SUMMARY.md` as needed.

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -61,6 +61,15 @@ jobs:
       - name: Build docs
         run: mdbook build docs -d ../web/docs
 
+      # Stamp the deployed pages with the commit they were built from. A cached
+      # page that looks current is indistinguishable from a current one, so the
+      # footer says which build is on screen instead of leaving it to be guessed.
+      - name: Stamp build
+        run: |
+          SHA='${{ github.sha }}'
+          sed -i "s|<meta name=\"glossia-build\" content=\"dev\">|<meta name=\"glossia-build\" content=\"${SHA:0:7}\">|" web/index.html
+          grep -o 'glossia-build" content="[^"]*"' web/index.html
+
       # Deploy the production site to the root of gh-pages. clean-exclude keeps
       # the pr-preview/ directory (managed by the PR Preview workflow) intact so
       # production deploys don't wipe live preview deployments.

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -69,6 +69,16 @@ jobs:
         if: github.event.action != 'closed'
         run: mdbook build docs -d ../web/docs
 
+      # Stamp the deployed pages with the commit they were built from. A cached
+      # page that looks current is indistinguishable from a current one, so the
+      # footer says which build is on screen instead of leaving it to be guessed.
+      - name: Stamp build
+        if: github.event.action != 'closed'
+        run: |
+          SHA='${{ github.event.pull_request.head.sha }}'
+          sed -i "s|<meta name=\"glossia-build\" content=\"dev\">|<meta name=\"glossia-build\" content=\"${SHA:0:7}\">|" web/index.html
+          grep -o 'glossia-build" content="[^"]*"' web/index.html
+
       # On open/synchronize/reopen: deploy web/ to gh-pages under
       # pr-preview/pr-<N>/ and comment the URL. On close: remove that directory.
       - name: Deploy PR preview

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ wasm-opt = [
 
 [dependencies]
 rand = "0.8"
+rand_chacha = "0.3"
 anyhow = "1.0"
 regex = "1.10"
 pest = "2.7"

--- a/examples/addr_to_payload.py
+++ b/examples/addr_to_payload.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Bitcoin address -> prose-address payload bytes.
+
+Payload layout (proposed v1):
+    [0]     version      profile id: grammar + semantics + RNG + cover mode
+    [1]     script_type  1=P2PKH 2=P2SH 3=P2WPKH 4=P2WSH 5=P2TR
+    [2..4]  wordlist_len u16 big-endian, payload wordlist size (allows extension)
+    [4..]   program      the hash160 / witness program (opcodes implied by type)
+
+Storing type+program rather than the full scriptPubKey saves the opcode bytes:
+a P2PKH scriptPubKey is 25 bytes but its hash160 is only 20.
+"""
+
+B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+BECH32 = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+
+
+def b58check_decode(s):
+    n = 0
+    for c in s:
+        n = n * 58 + B58.index(c)
+    raw = n.to_bytes(25, 'big')
+    import hashlib
+    body, chk = raw[:21], raw[21:]
+    d = hashlib.sha256(hashlib.sha256(body).digest()).digest()[:4]
+    assert d == chk, f'base58 checksum failed for {s}'
+    return body[0], body[1:]
+
+
+def bech32_polymod(values):
+    gen = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+    chk = 1
+    for v in values:
+        b = chk >> 25
+        chk = (chk & 0x1ffffff) << 5 ^ v
+        for i in range(5):
+            chk ^= gen[i] if ((b >> i) & 1) else 0
+    return chk
+
+
+def bech32_hrp_expand(hrp):
+    return [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]
+
+
+def convertbits(data, frombits, tobits, pad=True):
+    acc, bits, ret = 0, 0, []
+    maxv = (1 << tobits) - 1
+    for value in data:
+        acc = (acc << frombits) | value
+        bits += frombits
+        while bits >= tobits:
+            bits -= tobits
+            ret.append((acc >> bits) & maxv)
+    if pad and bits:
+        ret.append((acc << (tobits - bits)) & maxv)
+    return ret
+
+
+def bech32_decode(addr):
+    hrp, data_part = addr.rsplit('1', 1)
+    data = [BECH32.index(c) for c in data_part]
+    const = bech32_polymod(bech32_hrp_expand(hrp) + data)
+    witver = data[0]
+    expected = 1 if witver == 0 else 0x2bc830a3   # bech32 vs bech32m
+    assert const == expected, f'bech32 checksum failed for {addr} (got {const:#x})'
+    program = bytes(convertbits(data[1:-6], 5, 8, False))
+    return witver, program
+
+
+ADDRESSES = [
+    ('P2PKH  (genesis coinbase)', '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'),
+    ('P2SH', '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'),
+    ('P2WPKH (BIP173 vector)', 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'),
+    ('P2WSH  (BIP173 vector)',
+     'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3'),
+    ('P2TR   (BIP86 vector)',
+     'bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9'),
+]
+
+VERSION = 1
+WORDLIST_LEN = 2048   # english bip39
+
+for label, addr in ADDRESSES:
+    if addr[0] in '13':
+        ver, program = b58check_decode(addr)
+        stype = 1 if ver == 0x00 else 2
+    else:
+        witver, program = bech32_decode(addr)
+        stype = {0: (3 if len(program) == 20 else 4), 1: 5}[witver]
+    header = bytes([VERSION, stype]) + WORDLIST_LEN.to_bytes(2, 'big')
+    payload = header + program
+    print(f'{label}\t{addr}\t{payload.hex()}\t{len(payload)}')

--- a/examples/addr_to_payload.py
+++ b/examples/addr_to_payload.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python3
-"""Bitcoin address -> prose-address payload bytes.
+"""Bitcoin address -> (script type, entropy-carrying program bytes).
 
-Payload layout (proposed v1):
-    [0]     version      profile id: grammar + semantics + RNG + cover mode
-    [1]     script_type  1=P2PKH 2=P2SH 3=P2WPKH 4=P2WSH 5=P2TR
-    [2..4]  wordlist_len u16 big-endian, payload wordlist size (allows extension)
-    [4..]   program      the hash160 / witness program (opcodes implied by type)
-
-Storing type+program rather than the full scriptPubKey saves the opcode bytes:
-a P2PKH scriptPubKey is 25 bytes but its hash160 is only 20.
+Emits TSV for prose_address_v2.py. Script opcodes are NOT encoded -- they are
+rendered verbatim as Unicode symbols -- so Glossia carries only the program
+(the hash160 or witness program), 20 or 32 bytes.
 """
 
 B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
@@ -77,16 +72,11 @@ ADDRESSES = [
      'bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9'),
 ]
 
-VERSION = 1
-WORDLIST_LEN = 2048   # english bip39
-
 for label, addr in ADDRESSES:
     if addr[0] in '13':
         ver, program = b58check_decode(addr)
-        stype = 1 if ver == 0x00 else 2
+        stype = 'P2PKH' if ver == 0x00 else 'P2SH'
     else:
         witver, program = bech32_decode(addr)
-        stype = {0: (3 if len(program) == 20 else 4), 1: 5}[witver]
-    header = bytes([VERSION, stype]) + WORDLIST_LEN.to_bytes(2, 'big')
-    payload = header + program
-    print(f'{label}\t{addr}\t{payload.hex()}\t{len(payload)}')
+        stype = ('P2WPKH' if len(program) == 20 else 'P2WSH') if witver == 0 else 'P2TR'
+    print(f'{label}\t{addr}\t{stype}\t{program.hex()}')

--- a/examples/api_smoke.rs
+++ b/examples/api_smoke.rs
@@ -6,7 +6,7 @@
 //!
 //! Run: cargo run --release --example api_smoke
 
-use glossia::codec::{checksum_seed, crc32, hex_decode, payload_tokens};
+use glossia::codec::{checksum_seed, crc32, hex_decode, payload_tokens, payload_tokens_with_markup, Markup};
 use glossia::generator::data::load_payload_words_for_wordlist;
 use glossia::pipeline::encode_words_into_language;
 use std::collections::HashSet;
@@ -88,9 +88,27 @@ fn main() {
     );
     println!("{artifact}\n");
 
-    // Decode through the canonical tokenizer, including the opcode symbol.
+    // Declare the format's opcode sigils, validated against the payload alphabet.
+    // Declaring them means decoding strips them by name rather than guessing from
+    // Unicode category -- so even a letter-like sigil is safe, and one that would
+    // collide with payload text is rejected up front.
+    let sigils = ['\u{29C9}', '\u{2317}', '\u{225F}', '\u{2713}', '\u{29B5}',
+                  '\u{25BD}', '\u{25B3}', '\u{03B2}'];
+    let markup = Markup::new(sigils, &wl).expect("sigils must not collide with payload alphabet");
+    match Markup::new(['e'], &wl) {
+        Err(bad) => println!("rejected as markup (payload letters): {bad:?}"),
+        Ok(_) => println!("WARNING: 'e' wrongly accepted as markup"),
+    }
+    // Adjacent, no space -- the case plain normalization loses.
+    let flush = format!("\u{03B2}{}", artifact.trim_start_matches("\u{25BD} "));
     let set: HashSet<String> = wl.iter().map(|w| w.to_lowercase()).collect();
-    let harvested = payload_tokens(&artifact, |w| set.contains(w));
+    println!(
+        "flush sigil: plain harvest {} words, declared-markup harvest {} words",
+        payload_tokens(&flush, |w| set.contains(w)).len(),
+        payload_tokens_with_markup(&flush, &markup, |w| set.contains(w)).len()
+    );
+
+    let harvested = payload_tokens_with_markup(&artifact, &markup, |w| set.contains(w));
     let idx: Vec<usize> = harvested
         .iter()
         .map(|w| wl.iter().position(|x| x.to_lowercase() == *w).unwrap())

--- a/examples/api_smoke.rs
+++ b/examples/api_smoke.rs
@@ -1,0 +1,114 @@
+//! Smoke test for the composed encode API (glossia#76).
+//!
+//! Demonstrates the two stages composing: pack bits into payload words yourself,
+//! then hand those words to the generator for cover insertion. The format header
+//! rides in the bit-packing slack, so it costs no words.
+//!
+//! Run: cargo run --release --example api_smoke
+
+use glossia::codec::{checksum_seed, crc32, hex_decode, payload_tokens};
+use glossia::generator::data::load_payload_words_for_wordlist;
+use glossia::pipeline::encode_words_into_language;
+use std::collections::HashSet;
+
+/// Pack program bytes followed by a header into fixed-width word indices,
+/// filling the slack exactly.
+fn pack(program: &[u8], bits_per_word: usize, header: u32, header_bits: usize) -> Vec<usize> {
+    let data_bits = program.len() * 8;
+    let n_words = (data_bits + header_bits) / bits_per_word;
+    assert_eq!(n_words * bits_per_word, data_bits + header_bits, "must fill exactly");
+
+    let bit = |i: usize| -> usize {
+        if i < data_bits {
+            ((program[i / 8] >> (7 - (i % 8))) & 1) as usize
+        } else {
+            let h = i - data_bits;
+            ((header >> (header_bits - 1 - h)) & 1) as usize
+        }
+    };
+    (0..n_words)
+        .map(|w| (0..bits_per_word).fold(0, |acc, b| (acc << 1) | bit(w * bits_per_word + b)))
+        .collect()
+}
+
+fn unpack(
+    indices: &[usize],
+    bits_per_word: usize,
+    n_bytes: usize,
+    header_bits: usize,
+) -> (Vec<u8>, u32) {
+    let mut bits = Vec::with_capacity(indices.len() * bits_per_word);
+    for &i in indices {
+        for b in (0..bits_per_word).rev() {
+            bits.push((i >> b) & 1);
+        }
+    }
+    let program = (0..n_bytes)
+        .map(|i| (0..8).fold(0u8, |acc, b| (acc << 1) | bits[i * 8 + b] as u8))
+        .collect();
+    let header = (0..header_bits).fold(0u32, |acc, b| (acc << 1) | bits[n_bytes * 8 + b] as u32);
+    (program, header)
+}
+
+fn main() {
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+    let bits_per_word = wl.len().trailing_zeros() as usize; // 2048 -> 11
+    let log2_wl = bits_per_word as u32;
+    let version = 1u32;
+    println!("wordlist {} words, {bits_per_word} bits/word (log2 = {log2_wl})\n", wl.len());
+
+    // P2WPKH witness program (BIP173 vector): 20 bytes.
+    let program = hex_decode("751e76e8199196d454941c45d1b3a323f1433bd6").unwrap();
+    let header_bits = 15 * bits_per_word - program.len() * 8; // 165 - 160 = 5
+    let header = (log2_wl << (header_bits - 4)) | (version & ((1 << (header_bits - 4)) - 1));
+
+    let indices = pack(&program, bits_per_word, header, header_bits);
+    let words: Vec<String> = indices.iter().map(|&i| wl[i].clone()).collect();
+
+    // Checksum covers program + header, i.e. exactly the encoded bits.
+    let mut checked = program.clone();
+    checked.extend_from_slice(&[log2_wl as u8, version as u8]);
+    let seed = checksum_seed(&checked, 0);
+
+    let (text, counter) =
+        encode_words_into_language(&words, "english", "default", "body", seed, 4).unwrap();
+    let artifact = format!("\u{25BD} {text}");
+
+    println!("crc32   {:08x}", crc32(&checked));
+    println!("seed    {seed:#018x}   winning counter {counter}");
+    println!(
+        "header  {header_bits} bits, free (160 + {header_bits} = {} = {} words)",
+        160 + header_bits,
+        (160 + header_bits) / bits_per_word
+    );
+    println!(
+        "size    {} payload / {} total words\n",
+        words.len(),
+        text.split_whitespace().count()
+    );
+    println!("{artifact}\n");
+
+    // Decode through the canonical tokenizer, including the opcode symbol.
+    let set: HashSet<String> = wl.iter().map(|w| w.to_lowercase()).collect();
+    let harvested = payload_tokens(&artifact, |w| set.contains(w));
+    let idx: Vec<usize> = harvested
+        .iter()
+        .map(|w| wl.iter().position(|x| x.to_lowercase() == *w).unwrap())
+        .collect();
+    let (prog2, hdr2) = unpack(&idx, bits_per_word, program.len(), header_bits);
+
+    println!("harvested {} words, order preserved: {}", harvested.len(), harvested == words);
+    println!("program round-trip: {}", if prog2 == program { "exact" } else { "MISMATCH" });
+    println!(
+        "header  log2={} version={}",
+        hdr2 >> (header_bits - 4),
+        hdr2 & ((1 << (header_bits - 4)) - 1)
+    );
+
+    // Verification by re-render: the winning counter reproduces the rendering.
+    let (again, _) = encode_words_into_language(
+        &words, "english", "default", "body", seed.wrapping_add(counter), 1,
+    )
+    .unwrap();
+    println!("re-render from seed+counter matches: {}", again == text);
+}

--- a/examples/bestof_header.rs
+++ b/examples/bestof_header.rs
@@ -1,0 +1,179 @@
+//! Encode the fluency budget in 2 header bits: 00→1, 01→4, 10→8, 11→16 (#76).
+//!
+//! Recording the sample size the encoder used means the verifier runs exactly
+//! that budget rather than trying every budget it might have used (1+4+8+16 = 29
+//! generations). The encoder keeps its fluency search; verification stays a
+//! single deterministic encode.
+//!
+//! Note the header is inside the checksummed bits, so the budget field feeds back
+//! into the seed: each candidate N gives a different header, hence a different
+//! checksum, hence different prose. The encoder must therefore evaluate each N
+//! against its own seed, which is what this does.
+//!
+//! Run: cargo run --release --example bestof_header
+
+use glossia::codec::{checksum_seed, hex_decode};
+use glossia::generator::data::load_payload_words_for_wordlist;
+use glossia::pipeline::encode_words_into_language;
+use std::time::Instant;
+
+const BPW: usize = 11;
+/// 2-bit field -> sample size.
+const BUDGETS: [usize; 4] = [1, 4, 8, 16];
+
+fn header_bits(n: usize) -> usize { (n * 8).div_ceil(BPW) * BPW - n * 8 }
+
+/// Header layout under test:
+///   20-byte (5 slack bits): [log2-8 : 3][best_of : 2]        — version dropped
+///   32-byte (8 slack bits): [log2 : 4][version : 2][best_of : 2]
+fn build_header(program_len: usize, budget_code: u32, version: u32) -> u32 {
+    match header_bits(program_len) {
+        5 => (((BPW as u32) - 8) << 2) | budget_code,
+        8 => ((BPW as u32) << 4) | (version << 2) | budget_code,
+        hb => panic!("unexpected slack: {hb} bits"),
+    }
+}
+
+fn pack(program: &[u8], header: u32, wl: &[String]) -> Vec<String> {
+    let hb = header_bits(program.len());
+    let db = program.len() * 8;
+    let bit = |i: usize| -> usize {
+        if i < db { ((program[i / 8] >> (7 - (i % 8))) & 1) as usize }
+        else { ((header >> (hb - 1 - (i - db))) & 1) as usize }
+    };
+    (0..(db + hb) / BPW)
+        .map(|w| (0..BPW).fold(0, |a, b| (a << 1) | bit(w * BPW + b)))
+        .map(|i| wl[i].clone())
+        .collect()
+}
+
+fn seed_for(program: &[u8], header: u32) -> u64 {
+    let mut c = program.to_vec();
+    c.extend_from_slice(&header.to_be_bytes());
+    checksum_seed(&c, 0)
+}
+
+fn render(program: &[u8], header: u32, budget: usize, wl: &[String]) -> String {
+    let words = pack(program, header, wl);
+    encode_words_into_language(&words, "english", "default", "body",
+                               seed_for(program, header), budget)
+        .map(|(t, _)| t).unwrap_or_default()
+}
+
+fn main() {
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+    let programs: Vec<Vec<u8>> = [
+        "751e76e8199196d454941c45d1b3a323f1433bd6",
+        "62e907b15cbf27d5425399ebf6f0fb50ebb88f18",
+        "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb",
+        "da4710964f7852695de2da025290e24af6d8c281de5a0b902b7135fd9fd74d21",
+        "1863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+    ].iter().map(|h| hex_decode(h).unwrap()).collect();
+
+    println!("HEADER BIT BUDGET\n");
+    println!("  20-byte program: 5 slack bits  = [log2-8 : 3][best_of : 2]  — no room for a version field");
+    println!("  32-byte program: 8 slack bits  = [log2 : 4][version : 2][best_of : 2]");
+    println!("\n  A 3-bit offset log2 covers 2^8..2^15, which spans both shipped wordlists");
+    println!("  (bip39 = 2^11, latin = 2^15). Anything outside that needs the wider layout.\n");
+
+    println!("WORD COUNT BY BUDGET (each N has its own header, hence its own prose)\n");
+    println!("  {:<10} {:>7} {:>7} {:>7} {:>7}   {:>10}", "program", "N=1", "N=4", "N=8", "N=16", "best");
+    let mut totals = [0usize; 4];
+    let mut wins = [0usize; 4];
+    for p in &programs {
+        let mut counts = [0usize; 4];
+        for (k, &n) in BUDGETS.iter().enumerate() {
+            let h = build_header(p.len(), k as u32, 1);
+            counts[k] = render(p, h, n, &wl).split_whitespace().count();
+            totals[k] += counts[k];
+        }
+        let best = counts.iter().enumerate().min_by_key(|(_, c)| **c).unwrap().0;
+        wins[best] += 1;
+        println!("  {:<10} {:>7} {:>7} {:>7} {:>7}   N={:<8}",
+                 format!("{}B", p.len()), counts[0], counts[1], counts[2], counts[3], BUDGETS[best]);
+    }
+    println!("\n  totals    {:>7} {:>7} {:>7} {:>7}", totals[0], totals[1], totals[2], totals[3]);
+    println!("  chosen as best: N=1 x{}, N=4 x{}, N=8 x{}, N=16 x{}",
+             wins[0], wins[1], wins[2], wins[3]);
+    let best_total: usize = totals.iter().copied().min().unwrap();
+    println!("\n  fixed at N=1        : {} words", totals[0]);
+    println!("  per-address choice  : {} words (each address takes its own best)",
+             {
+                 let mut s = 0;
+                 for p in &programs {
+                     let mut c = usize::MAX;
+                     for (k, &n) in BUDGETS.iter().enumerate() {
+                         let h = build_header(p.len(), k as u32, 1);
+                         c = c.min(render(p, h, n, &wl).split_whitespace().count());
+                     }
+                     s += c;
+                 }
+                 s
+             });
+    println!("  best single budget  : {best_total} words");
+
+    // ── verification cost ───────────────────────────────────────────────
+    let p = &programs[0];
+    println!("\nVERIFICATION COST\n");
+    for (k, &n) in BUDGETS.iter().enumerate() {
+        let h = build_header(p.len(), k as u32, 1);
+        let t = Instant::now();
+        for _ in 0..5 { let _ = render(p, h, n, &wl); }
+        println!("  budget recorded as N={:<3} -> verifier does {:>2} generation(s): {:?}",
+                 n, n, t.elapsed() / 5);
+    }
+    let t = Instant::now();
+    for (k, &n) in BUDGETS.iter().enumerate() {
+        let h = build_header(p.len(), k as u32, 1);
+        let _ = render(p, h, n, &wl);
+    }
+    println!("\n  without the field, a verifier must try every budget: {:?}", t.elapsed());
+    println!("  ...which is also wrong, since each N yields DIFFERENT prose — the");
+    println!("  verifier would accept any of four renderings for one address.");
+
+    // ── the cheaper reading of the same 2 bits ──────────────────────────
+    //
+    // The field sits inside the checksummed bits, so changing it changes the seed:
+    // the four values are four DIFFERENT prose pools, not four sample sizes of one
+    // pool. That is why quality is non-monotonic in N. But it also means most of
+    // the gain comes from having four pools to choose from, not from sampling each
+    // deeply — so interpret the 2 bits as a pure SEED SELECTOR and render every
+    // variant with best_of=1. The encoder still picks the shortest of four; the
+    // verifier always does exactly one generation.
+    println!("\n{}", "═".repeat(70));
+    println!("\nSAME 2 BITS AS A PURE SEED SELECTOR (every variant at best_of=1)\n");
+    println!("  {:<10} {:>7} {:>7} {:>7} {:>7}   {:>8}", "program", "sel=0", "sel=1", "sel=2", "sel=3", "best");
+    let mut sel_total = 0usize;
+    let mut budget_total = 0usize;
+    for p in &programs {
+        let mut counts = [0usize; 4];
+        for k in 0..4 {
+            let h = build_header(p.len(), k as u32, 1);
+            counts[k] = render(p, h, 1, &wl).split_whitespace().count();
+        }
+        let best = *counts.iter().min().unwrap();
+        sel_total += best;
+        let mut bb = usize::MAX;
+        for (k, &n) in BUDGETS.iter().enumerate() {
+            let h = build_header(p.len(), k as u32, 1);
+            bb = bb.min(render(p, h, n, &wl).split_whitespace().count());
+        }
+        budget_total += bb;
+        println!("  {:<10} {:>7} {:>7} {:>7} {:>7}   {:>8}",
+                 format!("{}B", p.len()), counts[0], counts[1], counts[2], counts[3], best);
+    }
+
+    let t = Instant::now();
+    for _ in 0..5 { let _ = render(&programs[0], build_header(programs[0].len(), 0, 1), 1, &wl); }
+    let verify_sel = t.elapsed() / 5;
+
+    println!("\n  COMPARISON over {} addresses\n", programs.len());
+    println!("  {:<28} {:>8}  {:>18}", "design", "words", "verify cost");
+    println!("  {:<28} {:>8}  {:>18}", "no field, fixed N=1", totals[0], format!("{verify_sel:?}"));
+    println!("  {:<28} {:>8}  {:>18}", "2 bits = seed selector", sel_total, format!("{verify_sel:?} (constant)"));
+    println!("  {:<28} {:>8}  {:>18}", "2 bits = sample budget", budget_total, "31-290ms (varies)");
+    println!("\n  The selector captures {:.0}% of the budget field's saving at constant,",
+             (totals[0] - sel_total) as f64 / (totals[0] - budget_total).max(1) as f64 * 100.0);
+    println!("  minimum verification cost — and keeps the encoder's search at 4 generations");
+    println!("  instead of 29.");
+}

--- a/examples/bestof_sweep.rs
+++ b/examples/bestof_sweep.rs
@@ -1,0 +1,191 @@
+//! Optimal best-of-N as a function of payload BYTE COUNT (#76).
+//!
+//! For each (byte count, N) pair, sample many payloads and measure the density
+//! that best-of-N achieves — payload words / total words, the fraction of the
+//! prose that is actually address data.
+//!
+//! Method note: the candidate pool is generated ONCE per payload, at best_of=1,
+//! over seeds base+0..base+K-1. best-of-N then means "the best of the first N of
+//! those", which is exactly what `generate_text_best_of` picks. That makes the
+//! curve properly nested and monotone, and costs K generations per payload rather
+//! than sum(N) — and it holds the header (hence the seed) fixed, so N is not
+//! confounded with the seed the way it is when the budget lives in the header.
+//!
+//! Run: cargo run --release --example bestof_sweep [samples] [max_n]
+
+use glossia::codec::checksum_seed;
+use glossia::generator::data::load_payload_words_for_wordlist;
+use glossia::pipeline::encode_words_into_language;
+use std::sync::{Arc, Mutex};
+
+const BPW: usize = 11;
+const BYTE_COUNTS_ALL: [usize; 11] = [4, 8, 12, 16, 20, 24, 28, 32, 40, 48, 64];
+/// The two sizes the address format actually uses.
+const BYTE_COUNTS_ADDR: [usize; 2] = [20, 32];
+const NS_ALL: [usize; 6] = [1, 2, 4, 8, 16, 32];
+const NS_DEEP: [usize; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
+
+/// Slack bits after packing `n` bytes, widened to a whole extra word when the
+/// natural slack cannot hold the 5-bit header.
+fn header_bits(n: usize) -> usize {
+    let mut hb = (n * 8).div_ceil(BPW) * BPW - n * 8;
+    if hb < 5 { hb += BPW; }
+    hb
+}
+fn word_count(n: usize) -> usize { (n * 8 + header_bits(n)) / BPW }
+
+fn pack(program: &[u8], wl: &[String]) -> Vec<String> {
+    let hb = header_bits(program.len());
+    let header = ((BPW as u32) << (hb - 4)) | 1;
+    let db = program.len() * 8;
+    let bit = |i: usize| -> usize {
+        if i < db { ((program[i / 8] >> (7 - (i % 8))) & 1) as usize }
+        else { ((header >> (hb - 1 - (i - db))) & 1) as usize }
+    };
+    (0..(db + hb) / BPW)
+        .map(|w| (0..BPW).fold(0, |a, b| (a << 1) | bit(w * BPW + b)))
+        .map(|i| wl[i].clone())
+        .collect()
+}
+
+/// Deterministic pseudo-random payload bytes, so the sweep is reproducible.
+fn payload_bytes(n: usize, nonce: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(n);
+    let mut x = nonce.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    while out.len() < n {
+        x ^= x << 13; x ^= x >> 7; x ^= x << 17;
+        out.extend_from_slice(&x.to_le_bytes());
+    }
+    out.truncate(n);
+    out
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let samples: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(24);
+    let max_n: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(32);
+    // "addr" restricts the sweep to the two address sizes so N can be pushed deeper.
+    let focus = args.get(3).map(|s| s == "addr").unwrap_or(false);
+    let byte_counts: &[usize] = if focus { &BYTE_COUNTS_ADDR } else { &BYTE_COUNTS_ALL };
+    let ns: &[usize] = if focus { &NS_DEEP } else { &NS_ALL };
+
+    let wl = Arc::new(load_payload_words_for_wordlist("english", "bip39").unwrap());
+    let threads = std::thread::available_parallelism().map_or(4, |n| n.get()).min(8);
+    eprintln!("sweeping {} byte counts x {samples} payloads x {max_n} candidates on {threads} threads...",
+              byte_counts.len());
+
+    // results[byte_idx][sample] = densities of the K candidates, in seed order
+    let results: Arc<Mutex<Vec<Vec<Vec<f64>>>>> =
+        Arc::new(Mutex::new(vec![vec![Vec::new(); samples]; byte_counts.len()]));
+
+    let jobs: Vec<(usize, usize)> = (0..byte_counts.len())
+        .flat_map(|b| (0..samples).map(move |s| (b, s)))
+        .collect();
+    let jobs = Arc::new(Mutex::new(jobs));
+
+    let mut handles = Vec::new();
+    for _ in 0..threads {
+        let (wl, results, jobs) = (wl.clone(), results.clone(), jobs.clone());
+        let byte_counts_t: Vec<usize> = byte_counts.to_vec();
+        handles.push(std::thread::spawn(move || loop {
+            let job = { jobs.lock().unwrap().pop() };
+            let Some((bi, si)) = job else { break };
+            let nbytes = byte_counts_t[bi];
+            let program = payload_bytes(nbytes, (bi as u64) << 32 | si as u64);
+            let words = pack(&program, &wl);
+            let mut checked = program.clone();
+            checked.extend_from_slice(&[BPW as u8, 1u8]);
+            let base = checksum_seed(&checked, 0);
+
+            let mut densities = Vec::with_capacity(max_n);
+            for k in 0..max_n {
+                let d = encode_words_into_language(
+                    &words, "english", "default", "body", base.wrapping_add(k as u64), 1)
+                    .map(|(t, _)| words.len() as f64 / t.split_whitespace().count().max(1) as f64)
+                    .unwrap_or(0.0);
+                densities.push(d);
+            }
+            results.lock().unwrap()[bi][si] = densities;
+        }));
+    }
+    for h in handles { h.join().unwrap(); }
+    let results = Arc::try_unwrap(results).unwrap().into_inner().unwrap();
+
+    // ── density table ───────────────────────────────────────────────────
+    println!("\nDENSITY (payload words / total words), mean over {samples} payloads\n");
+    print!("  {:>6} {:>6}", "bytes", "words");
+    for &n in ns { print!("{:>9}", format!("N={n}")); }
+    println!("{:>10}", "gain");
+    let mut best_n_for = Vec::new();
+    for (bi, &nbytes) in byte_counts.iter().enumerate() {
+        print!("  {:>6} {:>6}", nbytes, word_count(nbytes));
+        let mut means = Vec::new();
+        for &n in ns.iter() {
+            let n = n.min(max_n);
+            let m: f64 = results[bi].iter()
+                .map(|ds| ds[..n].iter().cloned().fold(f64::MIN, f64::max))
+                .sum::<f64>() / samples as f64;
+            means.push(m);
+            print!("{:>9.3}", m);
+        }
+        let gain = (means[means.len() - 1] - means[0]) / means[0] * 100.0;
+        println!("{:>9.1}%", gain);
+
+        // Smallest N whose mean density is within 1% (relative) of the N=max value.
+        let target = means[means.len() - 1] * 0.99;
+        let pick = ns.iter().zip(means.iter()).find(|(_, m)| **m >= target).map(|(n, _)| *n).unwrap();
+        best_n_for.push((nbytes, pick, means[0], means[means.len() - 1]));
+    }
+
+    // ── total words, the number a reader sees ───────────────────────────
+    println!("\nTOTAL WORDS, mean over {samples} payloads\n");
+    print!("  {:>6}", "bytes");
+    for &n in ns { print!("{:>9}", format!("N={n}")); }
+    println!("{:>10}", "saved");
+    for (bi, &nbytes) in byte_counts.iter().enumerate() {
+        print!("  {:>6}", nbytes);
+        let pw = word_count(nbytes) as f64;
+        let mut firstw = 0.0;
+        let mut lastw = 0.0;
+        for (j, &n) in ns.iter().enumerate() {
+            let n = n.min(max_n);
+            let m: f64 = results[bi].iter()
+                .map(|ds| pw / ds[..n].iter().cloned().fold(f64::MIN, f64::max))
+                .sum::<f64>() / samples as f64;
+            if j == 0 { firstw = m; }
+            lastw = m;
+            print!("{:>9.1}", m);
+        }
+        println!("{:>9.1}", firstw - lastw);
+    }
+
+    // ── marginal analysis ───────────────────────────────────────────────
+    //
+    // Density never plateaus: it is the max of N draws, so it keeps creeping up
+    // roughly logarithmically. "Where does it converge" therefore has no answer —
+    // the question is where the words saved stop paying for the verification
+    // cost, which is linear in N (the verifier must reproduce the encoder's
+    // selection, so it repeats all N generations).
+    println!("\nMARGINAL COST OF EACH DOUBLING\n");
+    println!("  {:>6} {:>8} {:>10} {:>12} {:>14}", "bytes", "N", "words", "words saved", "verify cost");
+    for (bi, &nbytes) in byte_counts.iter().enumerate() {
+        let pw = word_count(nbytes) as f64;
+        let mut prev = f64::NAN;
+        for &n in ns.iter() {
+            let n = n.min(max_n);
+            let d: f64 = results[bi].iter()
+                .map(|ds| ds[..n].iter().cloned().fold(f64::MIN, f64::max))
+                .sum::<f64>() / samples as f64;
+            let w = pw / d;
+            let saved = if prev.is_nan() { 0.0 } else { prev - w };
+            println!("  {:>6} {:>8} {:>10.1} {:>12} {:>14}",
+                     if prev.is_nan() { nbytes.to_string() } else { String::new() },
+                     n, w,
+                     if prev.is_nan() { "—".to_string() } else { format!("{saved:.2}") },
+                     format!("{}x", n));
+            prev = w;
+        }
+        println!();
+    }
+    println!("  Address sizes: 20 bytes (P2PKH/P2SH/P2WPKH) and 32 (P2WSH/P2TR).");
+}

--- a/examples/bit_flip_legibility.rs
+++ b/examples/bit_flip_legibility.rs
@@ -16,7 +16,7 @@ use glossia::codec::{checksum_seed, hex_decode};
 use glossia::generator::data::load_payload_words_for_wordlist;
 use glossia::pipeline::encode_words_into_language;
 
-const COUNTER_RANGE: u64 = 1;
+const BEST_OF: u64 = 4;
 
 fn pack(program: &[u8], bits_per_word: usize, header: u32, header_bits: usize) -> Vec<usize> {
     let data_bits = program.len() * 8;
@@ -33,15 +33,14 @@ fn pack(program: &[u8], bits_per_word: usize, header: u32, header_bits: usize) -
         .collect()
 }
 
-/// Render a payload with checksum-seeded cover. No counter sweep — the address
-/// determines its prose exactly.
+/// Render a payload with checksum-seeded cover at the locked best-of-4.
 fn render(program: &[u8], header: u32, header_bits: usize, wl: &[String], bpw: usize) -> (String, Vec<String>) {
     let idx = pack(program, bpw, header, header_bits);
     let words: Vec<String> = idx.iter().map(|&i| wl[i].clone()).collect();
     let mut checked = program.to_vec();
     checked.extend_from_slice(&[bpw as u8, 1u8]);
     let seed = checksum_seed(&checked, 0);
-    let (text, _) = encode_words_into_language(&words, "english", "default", "body", seed, COUNTER_RANGE as usize)
+    let (text, _) = encode_words_into_language(&words, "english", "default", "body", seed, BEST_OF as usize)
         .expect("encode");
     (text, words)
 }

--- a/examples/bit_flip_legibility.rs
+++ b/examples/bit_flip_legibility.rs
@@ -16,7 +16,7 @@ use glossia::codec::{checksum_seed, hex_decode};
 use glossia::generator::data::load_payload_words_for_wordlist;
 use glossia::pipeline::encode_words_into_language;
 
-const COUNTER_RANGE: u64 = 4;
+const COUNTER_RANGE: u64 = 1;
 
 fn pack(program: &[u8], bits_per_word: usize, header: u32, header_bits: usize) -> Vec<usize> {
     let data_bits = program.len() * 8;
@@ -33,7 +33,8 @@ fn pack(program: &[u8], bits_per_word: usize, header: u32, header_bits: usize) -
         .collect()
 }
 
-/// Render a payload with checksum-seeded cover, sweeping the fluency counter.
+/// Render a payload with checksum-seeded cover. No counter sweep — the address
+/// determines its prose exactly.
 fn render(program: &[u8], header: u32, header_bits: usize, wl: &[String], bpw: usize) -> (String, Vec<String>) {
     let idx = pack(program, bpw, header, header_bits);
     let words: Vec<String> = idx.iter().map(|&i| wl[i].clone()).collect();

--- a/examples/bit_flip_legibility.rs
+++ b/examples/bit_flip_legibility.rs
@@ -1,0 +1,173 @@
+//! Does flipping one payload bit produce a recognizably different paragraph? (#76)
+//!
+//! This is the reader-facing validation criterion: not "how many bits of entropy
+//! does the cover carry" but "would a human notice the artifact changed". The
+//! figure that matters is the WORST case — the single most similar rendering
+//! across the whole sweep — because that is the one a reader could wave through.
+//!
+//! A single flipped bit lands inside exactly one 11-bit group, so exactly one of
+//! the 15 payload words changes and fourteen stay put. That alone is easy to miss.
+//! The checksum-seeded cover is what turns a one-word difference into a different
+//! paragraph.
+//!
+//! Run: cargo run --release --example bit_flip_legibility
+
+use glossia::codec::{checksum_seed, hex_decode};
+use glossia::generator::data::load_payload_words_for_wordlist;
+use glossia::pipeline::encode_words_into_language;
+
+const COUNTER_RANGE: u64 = 4;
+
+fn pack(program: &[u8], bits_per_word: usize, header: u32, header_bits: usize) -> Vec<usize> {
+    let data_bits = program.len() * 8;
+    let n_words = (data_bits + header_bits) / bits_per_word;
+    let bit = |i: usize| -> usize {
+        if i < data_bits {
+            ((program[i / 8] >> (7 - (i % 8))) & 1) as usize
+        } else {
+            ((header >> (header_bits - 1 - (i - data_bits))) & 1) as usize
+        }
+    };
+    (0..n_words)
+        .map(|w| (0..bits_per_word).fold(0, |acc, b| (acc << 1) | bit(w * bits_per_word + b)))
+        .collect()
+}
+
+/// Render a payload with checksum-seeded cover, sweeping the fluency counter.
+fn render(program: &[u8], header: u32, header_bits: usize, wl: &[String], bpw: usize) -> (String, Vec<String>) {
+    let idx = pack(program, bpw, header, header_bits);
+    let words: Vec<String> = idx.iter().map(|&i| wl[i].clone()).collect();
+    let mut checked = program.to_vec();
+    checked.extend_from_slice(&[bpw as u8, 1u8]);
+    let seed = checksum_seed(&checked, 0);
+    let (text, _) = encode_words_into_language(&words, "english", "default", "body", seed, COUNTER_RANGE as usize)
+        .expect("encode");
+    (text, words)
+}
+
+/// Fraction of token positions holding the same word.
+fn token_match(a: &str, b: &str) -> f64 {
+    let (x, y): (Vec<&str>, Vec<&str>) = (a.split_whitespace().collect(), b.split_whitespace().collect());
+    let n = x.len().max(y.len()).max(1);
+    x.iter().zip(y.iter()).filter(|(p, q)| p == q).count() as f64 / n as f64
+}
+
+fn main() {
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+    let bpw = wl.len().trailing_zeros() as usize;
+    let program = hex_decode("751e76e8199196d454941c45d1b3a323f1433bd6").unwrap();
+    let header_bits = 15 * bpw - program.len() * 8;
+    let header = ((bpw as u32) << (header_bits - 4)) | 1;
+
+    let (base_text, base_words) = render(&program, header, header_bits, &wl, bpw);
+    println!("BASELINE  (P2WPKH, bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4)\n");
+    println!("  {base_text}\n");
+    println!("  {} payload / {} total words\n", base_words.len(), base_text.split_whitespace().count());
+    println!("{}", "═".repeat(78));
+
+    // Every single-bit flip of the 160-bit program.
+    let mut results: Vec<(f64, usize, String, Vec<String>)> = Vec::new();
+    for b in 0..program.len() * 8 {
+        let mut p = program.clone();
+        p[b / 8] ^= 1 << (7 - (b % 8));
+        let (text, words) = render(&p, header, header_bits, &wl, bpw);
+        let diff_words = base_words.iter().zip(words.iter()).filter(|(a, c)| a != c).count();
+        results.push((token_match(&base_text, &text), diff_words, text, words));
+    }
+
+    let n = results.len();
+    let mean = results.iter().map(|r| r.0).sum::<f64>() / n as f64;
+    let payload_diffs: Vec<usize> = results.iter().map(|r| r.1).collect();
+    let max_payload_diff = *payload_diffs.iter().max().unwrap();
+    let min_payload_diff = *payload_diffs.iter().min().unwrap();
+
+    let mut sorted = results;
+    sorted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+
+    println!("\n{n} single-bit flips of the 160-bit program\n");
+    println!("  payload words differing : {min_payload_diff}–{max_payload_diff} of {} (a bit lands in one 11-bit group)", base_words.len());
+    println!("  mean token match        : {:.0}%", mean * 100.0);
+    println!("  WORST CASE (most similar): {:.0}%", sorted[0].0 * 100.0);
+    println!("  best case (most different): {:.0}%", sorted[n - 1].0 * 100.0);
+
+    let buckets = [(0.0, 0.2), (0.2, 0.4), (0.4, 0.6), (0.6, 0.8), (0.8, 1.01)];
+    println!("\n  distribution of token match:");
+    for (lo, hi) in buckets {
+        let c = sorted.iter().filter(|r| r.0 >= lo && r.0 < hi).count();
+        println!("    {:>3.0}–{:<3.0}%  {:<4} {}", lo * 100.0, hi * 100.0, c, "█".repeat(c * 40 / n.max(1)));
+    }
+
+    // Where does divergence START? A reader anchors on the opening, so a shared
+    // prefix matters more than an overall match rate.
+    let base_toks: Vec<&str> = base_text.split_whitespace().collect();
+    let prefixes: Vec<usize> = sorted
+        .iter()
+        .map(|(_, _, text, _)| {
+            let t: Vec<&str> = text.split_whitespace().collect();
+            base_toks.iter().zip(t.iter()).take_while(|(a, b)| a == b).count()
+        })
+        .collect();
+    let first_sentence_len = base_toks.iter().position(|w| w.ends_with('.')).map_or(0, |i| i + 1);
+    let share_first_sentence = prefixes.iter().filter(|&&p| p >= first_sentence_len).count();
+    let mut sorted_pref = prefixes.clone();
+    sorted_pref.sort_unstable();
+
+    println!("\n  divergence onset (shared leading tokens):");
+    println!("    first sentence is {first_sentence_len} tokens");
+    println!("    median shared prefix : {} tokens", sorted_pref[n / 2]);
+    println!("    longest shared prefix: {} tokens", sorted_pref[n - 1]);
+    println!(
+        "    flips reproducing the WHOLE first sentence: {share_first_sentence} of {n} ({:.0}%)",
+        share_first_sentence as f64 / n as f64 * 100.0
+    );
+    println!(
+        "    flips differing at token 1: {} of {n}",
+        prefixes.iter().filter(|&&p| p == 0).count()
+    );
+
+    println!("\n{}", "═".repeat(78));
+    println!("\nTHE THREE MOST SIMILAR RENDERINGS — the hardest cases to notice:\n");
+    for (m, d, text, _) in sorted.iter().take(3) {
+        println!("  [{:.0}% token match, {d} payload word(s) changed]", m * 100.0);
+        println!("  {text}\n");
+    }
+    println!("A TYPICAL CASE:\n");
+    let mid = &sorted[n / 2];
+    println!("  [{:.0}% token match, {} payload word(s) changed]", mid.0 * 100.0, mid.1);
+    println!("  {}\n", mid.2);
+
+    // Same sweep for the 32-byte size (P2TR / P2WSH), summary only.
+    println!("{}", "═".repeat(78));
+    let p2tr = hex_decode("da4710964f7852695de2da025290e24af6d8c281de5a0b902b7135fd9fd74d21").unwrap();
+    let hb32 = 24 * bpw - p2tr.len() * 8;
+    let hdr32 = ((bpw as u32) << (hb32 - 4)) | 1;
+    let (base32, words32) = render(&p2tr, hdr32, hb32, &wl, bpw);
+    let base32_toks: Vec<&str> = base32.split_whitespace().collect();
+    let fs32 = base32_toks.iter().position(|w| w.ends_with('.')).map_or(0, |i| i + 1);
+
+    let mut m32: Vec<f64> = Vec::new();
+    let mut pref32: Vec<usize> = Vec::new();
+    let mut worst32 = (0.0f64, String::new());
+    for b in 0..p2tr.len() * 8 {
+        let mut q = p2tr.clone();
+        q[b / 8] ^= 1 << (7 - (b % 8));
+        let (text, w) = render(&q, hdr32, hb32, &wl, bpw);
+        assert_eq!(words32.iter().zip(w.iter()).filter(|(a, c)| a != c).count(), 1);
+        let m = token_match(&base32, &text);
+        if m > worst32.0 { worst32 = (m, text.clone()); }
+        let t: Vec<&str> = text.split_whitespace().collect();
+        pref32.push(base32_toks.iter().zip(t.iter()).take_while(|(a, b)| a == b).count());
+        m32.push(m);
+    }
+    let n32 = m32.len();
+    pref32.sort_unstable();
+    println!("\n32-BYTE PROGRAM (P2TR), {n32} single-bit flips — {} payload / {} total words\n",
+             words32.len(), base32_toks.len());
+    println!("  {base32}\n");
+    println!("  mean token match         : {:.0}%", m32.iter().sum::<f64>() / n32 as f64 * 100.0);
+    println!("  WORST CASE (most similar): {:.0}%", worst32.0 * 100.0);
+    println!("  median shared prefix     : {} tokens (first sentence is {fs32})", pref32[n32 / 2]);
+    println!("  flips reproducing the whole first sentence: {} of {n32}",
+             pref32.iter().filter(|&&x| x >= fs32).count());
+    println!("\n  worst case:\n  {}", worst32.1);
+}

--- a/examples/counter_cost.rs
+++ b/examples/counter_cost.rs
@@ -1,0 +1,96 @@
+//! Is the fluency counter worth its verification cost? (#76)
+//!
+//! The counter lets the ENCODER shop for a more fluent rendering among N seeds.
+//! Verification does not generate anything — it reproduces a fixed artifact — so
+//! every counter value the encoder was allowed to use is a value the verifier
+//! must try, and a repair search must try per candidate.
+//!
+//! Fixing the counter at 0 makes encoding deterministic: one render to encode,
+//! one to verify, one per repair candidate. This measures what that costs in
+//! prose quality, which is the only thing the counter buys.
+//!
+//! Run: cargo run --release --example counter_cost
+
+use glossia::codec::{checksum_seed, hex_decode};
+use glossia::generator::data::load_payload_words_for_wordlist;
+use glossia::pipeline::encode_words_into_language;
+use std::time::Instant;
+
+const BPW: usize = 11;
+
+fn pack(program: &[u8], wl: &[String]) -> Vec<String> {
+    let hb = (program.len() * 8).div_ceil(BPW) * BPW - program.len() * 8;
+    let header = ((BPW as u32) << (hb - 4)) | 1;
+    let db = program.len() * 8;
+    let bit = |i: usize| -> usize {
+        if i < db { ((program[i / 8] >> (7 - (i % 8))) & 1) as usize }
+        else { ((header >> (hb - 1 - (i - db))) & 1) as usize }
+    };
+    (0..(db + hb) / BPW)
+        .map(|w| (0..BPW).fold(0, |a, b| (a << 1) | bit(w * BPW + b)))
+        .map(|i| wl[i].clone())
+        .collect()
+}
+
+fn seed_for(program: &[u8]) -> u64 {
+    let mut c = program.to_vec();
+    c.extend_from_slice(&[BPW as u8, 1u8]);
+    checksum_seed(&c, 0)
+}
+
+fn main() {
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+
+    // A spread of real programs, not one lucky case.
+    let programs: Vec<Vec<u8>> = [
+        "751e76e8199196d454941c45d1b3a323f1433bd6",
+        "62e907b15cbf27d5425399ebf6f0fb50ebb88f18",
+        "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb",
+        "da4710964f7852695de2da025290e24af6d8c281de5a0b902b7135fd9fd74d21",
+        "1863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+    ].iter().map(|h| hex_decode(h).unwrap()).collect();
+
+    println!("PROSE QUALITY: counter fixed at 0 vs swept over 4\n");
+    println!("  {:<10} {:>10} {:>10} {:>8}", "program", "fixed", "best-of-4", "saved");
+    let (mut sum_fixed, mut sum_swept) = (0usize, 0usize);
+    let mut identical = 0;
+    for p in &programs {
+        let words = pack(p, &wl);
+        let seed = seed_for(p);
+        let (a, _) = encode_words_into_language(&words, "english", "default", "body", seed, 1).unwrap();
+        let (b, _) = encode_words_into_language(&words, "english", "default", "body", seed, 4).unwrap();
+        let (na, nb) = (a.split_whitespace().count(), b.split_whitespace().count());
+        sum_fixed += na;
+        sum_swept += nb;
+        if a == b { identical += 1; }
+        println!("  {:<10} {:>10} {:>10} {:>8}",
+                 format!("{}B", p.len()), na, nb, na as i64 - nb as i64);
+    }
+    println!("\n  total words : {sum_fixed} fixed vs {sum_swept} swept ({:+} words over {} addresses)",
+             sum_fixed as i64 - sum_swept as i64, programs.len());
+    println!("  renderings the sweep did not improve at all: {identical} of {}", programs.len());
+
+    // ── cost side ───────────────────────────────────────────────────────
+    let words = pack(&programs[0], &wl);
+    let seed = seed_for(&programs[0]);
+
+    let t = Instant::now();
+    for _ in 0..10 { let _ = encode_words_into_language(&words, "english", "default", "body", seed, 1); }
+    let one = t.elapsed() / 10;
+
+    let t = Instant::now();
+    for _ in 0..10 { let _ = encode_words_into_language(&words, "english", "default", "body", seed, 4); }
+    let four = t.elapsed() / 10;
+
+    println!("\nVERIFICATION COST\n");
+    println!("  render, counter fixed : {one:?}");
+    println!("  render, swept over 4  : {four:?}   ({:.1}x)",
+             four.as_secs_f64() / one.as_secs_f64());
+    println!("\n  verify one artifact     : {one:?} vs {four:?}");
+    println!("  repair search, 14 cands : {:?} vs {:?}", one * 14, four * 14);
+
+    println!("\n  Verification reproduces a fixed artifact rather than generating a new");
+    println!("  one, so every counter the encoder MAY have used is a counter the verifier");
+    println!("  MUST try. Fixing it removes a loop from the verifier, a multiplier from");
+    println!("  the repair search, and a whole failure mode: two artifacts for one address.");
+}

--- a/examples/encode_prep_cost.rs
+++ b/examples/encode_prep_cost.rs
@@ -1,0 +1,36 @@
+//! Where does a single encode call spend its time? (#76)
+//! Run: cargo run --release --example encode_prep_cost
+use glossia::generator::data::{load_payload_words_for_wordlist, load_semantics, load_semantics_cached,
+                               load_cover_words_by_pos_for_wordlist, build_pos_mapping_for_wordlist};
+use glossia::grammar::{DialectConfig, Grammar};
+use glossia::pipeline::{build_zone_generator, encode_words_into_language};
+use std::collections::HashSet;
+use std::time::Instant;
+
+fn bench<T>(n: u32, label: &str, mut f: impl FnMut() -> T) {
+    let _ = f();
+    let t = Instant::now();
+    for _ in 0..n { let _ = f(); }
+    println!("  {:<46} {:>8.2} ms", label, t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+}
+
+fn main() {
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+    let words: Vec<String> = (0..15).map(|i| wl[i * 137].clone()).collect();
+    let set: HashSet<String> = wl.iter().map(|w| w.to_lowercase()).collect();
+
+    println!("PER-CALL COST (release, native)\n");
+    bench(50, "load_payload_words_for_wordlist (cached)", || load_payload_words_for_wordlist("english", "bip39").unwrap());
+    bench(50, "build_pos_mapping_for_wordlist", || build_pos_mapping_for_wordlist("english", "bip39").unwrap());
+    bench(50, "Grammar::from_language_dialect", || Grammar::from_language_dialect("english", "body").unwrap());
+    bench(50, "Grammar::from_language_dialect_cached", || Grammar::from_language_dialect_cached("english", "body").unwrap());
+    bench(20, "DialectConfig::from_language_dialect", || DialectConfig::from_language_dialect("english", "body").unwrap());
+    bench(50, "DialectConfig::..._cached", || DialectConfig::from_language_dialect_cached("english", "body").unwrap());
+    bench(50, "load_cover_words_by_pos_for_wordlist", || load_cover_words_by_pos_for_wordlist(&set, "english", "cover"));
+    bench(20, "load_semantics (uncached)", || load_semantics("english"));
+    bench(50, "load_semantics_cached", || load_semantics_cached("english"));
+    bench(50, "build_zone_generator", || build_zone_generator(15, "english", "body", &set, false, None, None, None, None).unwrap());
+    println!();
+    bench(20, "encode_words_into_language best_of=1", || encode_words_into_language(&words, "english", "default", "body", 42, 1).unwrap());
+    bench(20, "encode_words_into_language best_of=4", || encode_words_into_language(&words, "english", "default", "body", 42, 4).unwrap());
+}

--- a/examples/error_localization.rs
+++ b/examples/error_localization.rs
@@ -23,7 +23,7 @@ use glossia::pipeline::encode_words_into_language;
 use std::collections::HashSet;
 
 const BPW: usize = 11;
-const COUNTER_RANGE: u64 = 1;
+const BEST_OF: u64 = 4;
 
 fn header_bits(n: usize) -> usize { (n * 8).div_ceil(BPW) * BPW - n * 8 }
 
@@ -58,7 +58,7 @@ fn seed_of(words: &[String], wl: &[String]) -> u64 {
 
 fn render(words: &[String], wl: &[String]) -> String {
     encode_words_into_language(words, "english", "default", "body",
-                               seed_of(words, wl), COUNTER_RANGE as usize)
+                               seed_of(words, wl), BEST_OF as usize)
         .map(|(t, _)| t).unwrap_or_default()
 }
 

--- a/examples/error_localization.rs
+++ b/examples/error_localization.rs
@@ -1,0 +1,231 @@
+//! Can damage be located without knowing the original? (#76)
+//!
+//! The re-render is the reference: encode whatever the received text decodes to,
+//! and diff. Nothing about the true address is assumed.
+//!
+//! The two damage classes behave differently, and the difference is the whole
+//! story:
+//!
+//! * **Cover damage** leaves the payload intact, so the re-render is the correct
+//!   paragraph and a token diff points straight at the damaged words.
+//! * **Payload damage** changes the checksum, hence the seed, hence the entire
+//!   cover — so the diff says "everything differs" and localizes nothing. Only a
+//!   repair search can find it: propose plausible corrections, re-render each,
+//!   and keep the one that reproduces the received text.
+//!
+//! This measures how often that search succeeds and whether its answer is unique.
+//!
+//! Run: cargo run --release --example error_localization
+
+use glossia::codec::{checksum_seed, hex_decode, payload_tokens};
+use glossia::generator::data::load_payload_words_for_wordlist;
+use glossia::pipeline::encode_words_into_language;
+use std::collections::HashSet;
+
+const BPW: usize = 11;
+const COUNTER_RANGE: u64 = 4;
+
+fn header_bits(n: usize) -> usize { (n * 8).div_ceil(BPW) * BPW - n * 8 }
+
+fn pack(program: &[u8], wl: &[String]) -> Vec<String> {
+    let hb = header_bits(program.len());
+    let header = ((BPW as u32) << (hb - 4)) | 1;
+    let db = program.len() * 8;
+    let bit = |i: usize| -> usize {
+        if i < db { ((program[i / 8] >> (7 - (i % 8))) & 1) as usize }
+        else { ((header >> (hb - 1 - (i - db))) & 1) as usize }
+    };
+    (0..(db + hb) / BPW)
+        .map(|w| (0..BPW).fold(0, |a, b| (a << 1) | bit(w * BPW + b)))
+        .map(|i| wl[i].clone())
+        .collect()
+}
+
+fn seed_of(words: &[String], wl: &[String]) -> u64 {
+    // Seed from the payload the words encode — available to a decoder, since it
+    // is derived from the received text and not from the original.
+    let idx: Vec<usize> = words.iter()
+        .map(|w| wl.iter().position(|x| x == w).unwrap()).collect();
+    let mut bits = Vec::new();
+    for i in &idx { for b in (0..BPW).rev() { bits.push((i >> b) & 1); } }
+    let n = bits.len() / 8 * 8 / 8;
+    let mut bytes: Vec<u8> = (0..n).map(|i| (0..8).fold(0u8, |a, b| (a << 1) | bits[i * 8 + b] as u8)).collect();
+    bytes.truncate(if idx.len() == 15 { 20 } else { 32 });
+    let mut c = bytes.clone();
+    c.extend_from_slice(&[BPW as u8, 1u8]);
+    checksum_seed(&c, 0)
+}
+
+fn render(words: &[String], wl: &[String]) -> String {
+    encode_words_into_language(words, "english", "default", "body",
+                               seed_of(words, wl), COUNTER_RANGE as usize)
+        .map(|(t, _)| t).unwrap_or_default()
+}
+
+/// Token-level diff against the re-render. Returns indices that differ.
+fn diff(received: &str, rendered: &str) -> Vec<usize> {
+    let a: Vec<&str> = received.split_whitespace().collect();
+    let b: Vec<&str> = rendered.split_whitespace().collect();
+    (0..a.len().max(b.len()))
+        .filter(|&i| a.get(i) != b.get(i))
+        .collect()
+}
+
+/// Words one edit away from `w` that are in the wordlist — the plausible-typo set.
+fn edit1(w: &str, set: &HashSet<String>) -> Vec<String> {
+    let mut out = HashSet::new();
+    let cs: Vec<char> = w.chars().collect();
+    for i in 0..cs.len() {
+        for c in 'a'..='z' {
+            let mut v = cs.clone(); v[i] = c;
+            let s: String = v.into_iter().collect();
+            if s != w && set.contains(&s) { out.insert(s); }
+        }
+        let mut v = cs.clone(); v.remove(i);
+        let s: String = v.into_iter().collect();
+        if set.contains(&s) { out.insert(s); }
+    }
+    for i in 0..=cs.len() {
+        for c in 'a'..='z' {
+            let mut v = cs.clone(); v.insert(i, c);
+            let s: String = v.into_iter().collect();
+            if set.contains(&s) { out.insert(s); }
+        }
+    }
+    out.into_iter().collect()
+}
+
+/// Propose single-word repairs that explain the received text.
+///
+/// A correct repair does NOT reproduce the received text — it reproduces the
+/// ORIGINAL, which differs from what was received at exactly the damaged word.
+/// So the test is "differs in at most one token", not "matches". A wrong
+/// candidate changes the checksum and therefore the whole paragraph, so it
+/// mismatches almost everywhere.
+///
+/// Returns (position, replacement) for every candidate that explains the text.
+fn propose(received: &str, words: &[String], wl: &[String], set: &HashSet<String>)
+    -> (Vec<(usize, String)>, usize)
+{
+    let recv: Vec<&str> = received.split_whitespace().collect();
+    let mut hits = Vec::new();
+    let mut tried = 0;
+    for i in 0..words.len() {
+        for cand in edit1(&words[i], set) {
+            let mut w = words.to_vec();
+            w[i] = cand.clone();
+            tried += 1;
+            let got: Vec<String> = render(&w, wl).split_whitespace().map(String::from).collect();
+            let n = got.len().max(recv.len());
+            let mismatches = (0..n)
+                .filter(|&k| got.get(k).map(|s| s.as_str()) != recv.get(k).copied())
+                .count();
+            if mismatches <= 1 {
+                hits.push((i, cand));
+            }
+        }
+    }
+    (hits, tried)
+}
+
+/// Substitute a word into a token while preserving its surrounding punctuation
+/// and capitalization, so the only difference is the word itself. Replacing the
+/// whole token would drop a trailing period or an initial capital and make every
+/// comparison fail for the wrong reason.
+fn swap_in(token: &str, replacement: &str) -> String {
+    let a = token.find(|c: char| c.is_alphanumeric()).unwrap_or(0);
+    let b = token.rfind(|c: char| c.is_alphanumeric()).map_or(token.len(), |i| i + 1);
+    let core = &token[a..b];
+    let cased = if core.chars().next().is_some_and(|c| c.is_uppercase()) {
+        let mut it = replacement.chars();
+        it.next().map(|f| f.to_uppercase().collect::<String>() + it.as_str())
+            .unwrap_or_default()
+    } else {
+        replacement.to_string()
+    };
+    format!("{}{}{}", &token[..a], cased, &token[b..])
+}
+
+fn main() {
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+    let set: HashSet<String> = wl.iter().cloned().collect();
+    let program = hex_decode("751e76e8199196d454941c45d1b3a323f1433bd6").unwrap();
+    let words = pack(&program, &wl);
+    let truth = render(&words, &wl);
+
+    println!("BASELINE\n  {truth}\n");
+
+    // ── 1. cover damage: the diff should point straight at it ──────────
+    let toks: Vec<String> = truth.split_whitespace().map(String::from).collect();
+    let pay: HashSet<String> = words.iter().cloned().collect();
+    let cover_positions: Vec<usize> = toks.iter().enumerate()
+        .filter(|(_, t)| !pay.contains(&t.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase()))
+        .map(|(i, _)| i).collect();
+
+    let mut damaged = toks.clone();
+    let hit = [cover_positions[1], cover_positions[3]];
+    for &i in &hit {
+        let core = damaged[i].trim_matches(|c: char| !c.is_alphanumeric()).to_string();
+        damaged[i] = swap_in(&damaged[i], &format!("{core}x"));
+    }
+    let received = damaged.join(" ");
+
+    let harvested = payload_tokens(&received, |w| set.contains(w));
+    let rerender = render(&harvested, &wl);
+    let d = diff(&received, &rerender);
+    println!("── cover damage (2 words mangled) ──");
+    println!("  payload still decodes: {}", harvested == words);
+    println!("  damaged at positions : {hit:?}");
+    println!("  diff flags positions : {d:?}");
+    println!("  localized exactly    : {}\n", d == hit.to_vec());
+
+    // ── 2. payload damage: the diff cannot localize; search sometimes can ──
+    //
+    // Only typos that land on ANOTHER VALID payload word are dangerous. A typo
+    // that falls off the wordlist is a deletion and the word count catches it.
+    // BIP39 is designed for distinguishability, so those neighbours are scarce —
+    // enumerate every one of them and test the search on each.
+    let mut cases: Vec<(usize, String)> = Vec::new();
+    for (i, w) in words.iter().enumerate() {
+        for n in edit1(w, &set) { cases.push((i, n)); }
+    }
+    println!("── payload damage ──");
+    println!("  payload words                     : {}", words.len());
+    println!("  single-edit typos landing on ANOTHER payload word: {}", cases.len());
+    println!("  (a typo that leaves the wordlist is a deletion — the word count catches it)\n");
+
+    let mut diff_localized = 0;
+    let mut found = 0;
+    let mut unique = 0;
+    let mut total_tried = 0;
+    for (vi, bad_word) in &cases {
+        let mut bad = toks.clone();
+        let vpos = toks.iter().position(|t| {
+            t.trim_matches(|c: char| !c.is_alphanumeric()).eq_ignore_ascii_case(&words[*vi])
+        }).unwrap();
+        bad[vpos] = swap_in(&toks[vpos], bad_word);
+        let received = bad.join(" ");
+        let harvested = payload_tokens(&received, |w| set.contains(w));
+        if harvested.len() != words.len() { continue; }
+
+        let d = diff(&received, &render(&harvested, &wl));
+        if d.len() <= 3 { diff_localized += 1; }
+
+        let (hits, tried) = propose(&received, &harvested, &wl, &set);
+        total_tried += tried;
+        let correct = hits.iter().any(|(i, w)| i == vi && w == &words[*vi]);
+        if correct { found += 1; }
+        if hits.len() == 1 && correct { unique += 1; }
+    }
+    let n = cases.len().max(1);
+    println!("  diff alone localized it           : {diff_localized} of {n}");
+    println!("  repair search found the true word : {found} of {n}");
+    println!("  ...and it was the ONLY candidate  : {unique} of {n}");
+    println!("  mean candidates re-rendered       : {}", total_tried / n);
+
+    println!("\n  So: cover damage is located by diffing against the re-render, with no");
+    println!("  knowledge of the original. Payload damage is not — the checksum changes");
+    println!("  the whole paragraph — but the plausible-typo search recovers it, and the");
+    println!("  answer is unique because a wrong repair would have to reproduce the");
+    println!("  entire wording by accident.");
+}

--- a/examples/error_localization.rs
+++ b/examples/error_localization.rs
@@ -23,7 +23,7 @@ use glossia::pipeline::encode_words_into_language;
 use std::collections::HashSet;
 
 const BPW: usize = 11;
-const COUNTER_RANGE: u64 = 4;
+const COUNTER_RANGE: u64 = 1;
 
 fn header_bits(n: usize) -> usize { (n * 8).div_ceil(BPW) * BPW - n * 8 }
 

--- a/examples/prose_address_demo.rs
+++ b/examples/prose_address_demo.rs
@@ -1,5 +1,11 @@
 //! Prototype: Bitcoin locking scripts as self-verifying Glossia prose (glossia#76).
 //!
+//! SUPERSEDED — kept for the damage-discrimination measurement it records. This is
+//! the first layout (script-type byte, u16 wordlist length, the grammar's `bitpack`
+//! codec) and it still sweeps a fluency counter. The shipped format instead puts its
+//! header in the bit-packing slack, shows opcodes as Book of Bitcoin glyphs, and
+//! fixes the counter — see `user_journey.rs` and the demo page.
+//!
 //! Payload layout (proposed v1):
 //!     [0]     version      profile id: grammar + semantics + RNG + cover mode
 //!     [1]     script_type  1=P2PKH 2=P2SH 3=P2WPKH 4=P2WSH 5=P2TR

--- a/examples/prose_address_demo.rs
+++ b/examples/prose_address_demo.rs
@@ -1,0 +1,228 @@
+//! Prototype: Bitcoin locking scripts as self-verifying Glossia prose (glossia#76).
+//!
+//! Payload layout (proposed v1):
+//!     [0]     version      profile id: grammar + semantics + RNG + cover mode
+//!     [1]     script_type  1=P2PKH 2=P2SH 3=P2WPKH 4=P2WSH 5=P2TR
+//!     [2..4]  wordlist_len u16 BE, payload wordlist size (allows extension)
+//!     [4..]   program      hash160 / witness program (opcodes implied by type)
+//!
+//! The cover realization is seeded from a CRC-32 of the payload, so the choice of
+//! prose *is* the checksum. Verification re-encodes the decoded payload and
+//! compares: a correct payload reproduces the text, a wrong one renders differently.
+//!
+//! Run: cargo run --release --example prose_address_demo
+
+use glossia::codec::{decode_base_n, hex_decode, hex_encode};
+use glossia::generator::data::load_payload_words_for_wordlist;
+use glossia::merkle::WordlistTree;
+
+const COUNTER_RANGE: u64 = 16;
+/// Must match the grammar's declared codec (english/grammar.yaml: `codec: bitpack`).
+const CODEC: &str = "bitpack";
+
+/// CRC-32 (IEEE 802.3), computed bitwise — no dependency, and the polynomial is
+/// the spec, not an implementation detail.
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &b in data {
+        crc ^= b as u32;
+        for _ in 0..8 {
+            crc = if crc & 1 != 0 { (crc >> 1) ^ 0xEDB8_8320 } else { crc >> 1 };
+        }
+    }
+    !crc
+}
+
+/// splitmix64 finalizer — scatters consecutive counters across u64 so adjacent
+/// counter values map to unrelated prose (mirrors `mix64` in glossia-msg.js).
+fn mix64(x: u64) -> u64 {
+    let mut z = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+fn seed_for(payload: &[u8], counter: u64) -> u64 {
+    mix64((crc32(payload) as u64) << 32 | counter)
+}
+
+fn encode_at(hex: &str, seed: u64) -> Result<(String, Vec<String>), String> {
+    glossia::pipeline::encode_into_language(
+        hex, "english", "default", "body", None, seed, false, None, None, None, None,
+    )
+    .map(|(text, _cover, payload_words, _mode)| (text, payload_words))
+    .map_err(|e| format!("{e:?}"))
+}
+
+/// Encode, sweeping the fluency counter and keeping the densest rendering.
+/// Returns (prose, payload_words, winning_counter).
+fn encode_checksum_seeded(payload: &[u8]) -> Result<(String, Vec<String>, u64), String> {
+    let hex = hex_encode(payload);
+    let mut best: Option<(f64, String, Vec<String>, u64)> = None;
+    for c in 0..COUNTER_RANGE {
+        let (text, words) = encode_at(&hex, seed_for(payload, c))?;
+        let density = words.len() as f64 / text.split_whitespace().count().max(1) as f64;
+        if best.as_ref().map_or(true, |(d, ..)| density > *d) {
+            best = Some((density, text, words, c));
+        }
+    }
+    let (_, text, words, c) = best.unwrap();
+    Ok((text, words, c))
+}
+
+/// Harvest payload words from received text, exactly as the decoder does.
+fn payload_tokens(text: &str, tree: &WordlistTree) -> Vec<String> {
+    text.split_whitespace()
+        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
+        .filter(|w| !w.is_empty() && tree.contains(w))
+        .collect()
+}
+
+#[derive(Debug, PartialEq)]
+enum Verdict {
+    Verified { counter: u64 },
+    DecodedUnverified,
+    Failed(String),
+}
+
+/// Decode + verify by re-render. Fixed length means the byte count is known,
+/// so a dropped or spurious payload word shows up before any re-encode.
+#[allow(unused_variables)]
+fn decode_verified(text: &str, byte_count: usize, tree: &WordlistTree) -> (Option<Vec<u8>>, Verdict) {
+    let words = payload_tokens(text, tree);
+    // Fixed length => word count is a function of byte_count alone, so derive it
+    // from the codec. English's grammar.yaml declares `codec: bitpack`, which adds
+    // a padding word; the raw path (`encode_raw_base_n`) uses `bitpack_fixed` and
+    // is one word shorter. Whichever the format picks, it must match end to end.
+    let expected_words = glossia::codec::encode_base_n(&vec![0u8; byte_count], tree, CODEC)
+        .map(|w| w.len())
+        .unwrap_or(0);
+    if words.len() != expected_words {
+        return (
+            None,
+            Verdict::Failed(format!(
+                "word count {} != expected {expected_words}",
+                words.len()
+            )),
+        );
+    }
+    let bytes = match decode_base_n(&words, tree, CODEC) {
+        Ok(b) => b,
+        Err(e) => return (None, Verdict::Failed(format!("{e:?}"))),
+    };
+    // Re-render under every candidate counter; a match confirms the payload.
+    for c in 0..COUNTER_RANGE {
+        if let Ok((rendered, _)) = encode_at(&hex_encode(&bytes), seed_for(&bytes, c)) {
+            if rendered.split_whitespace().eq(text.split_whitespace()) {
+                return (Some(bytes), Verdict::Verified { counter: c });
+            }
+        }
+    }
+    (Some(bytes), Verdict::DecodedUnverified)
+}
+
+/// Fraction of token positions that agree between the received text and the
+/// closest re-render. This is the alignment oracle's signal: damaged *cover*
+/// leaves nearly every token in place, whereas a wrong *payload* changes the
+/// checksum, hence the seed, hence essentially the whole rendering.
+fn best_similarity(text: &str, tree: &WordlistTree) -> f64 {
+    let words = payload_tokens(text, tree);
+    let bytes = match decode_base_n(&words, tree, CODEC) {
+        Ok(b) => b,
+        Err(_) => return 0.0,
+    };
+    let recv: Vec<&str> = text.split_whitespace().collect();
+    let mut best = 0.0f64;
+    for c in 0..COUNTER_RANGE {
+        if let Ok((rendered, _)) = encode_at(&hex_encode(&bytes), seed_for(&bytes, c)) {
+            let got: Vec<&str> = rendered.split_whitespace().collect();
+            let n = recv.len().max(got.len()).max(1);
+            let agree = recv.iter().zip(got.iter()).filter(|(a, b)| a == b).count();
+            best = best.max(agree as f64 / n as f64);
+        }
+    }
+    best
+}
+
+const SCRIPT_TYPES: [&str; 6] = ["?", "P2PKH", "P2SH", "P2WPKH", "P2WSH", "P2TR"];
+
+fn main() {
+    let cases: Vec<(String, String)> = std::env::args()
+        .skip(1)
+        .collect::<Vec<_>>()
+        .chunks(2)
+        .filter(|c| c.len() == 2)
+        .map(|c| (c[0].clone(), c[1].clone()))
+        .collect();
+
+    let payload_words = load_payload_words_for_wordlist("english", "bip39").expect("wordlist");
+    let tree = WordlistTree::new(payload_words.clone());
+    println!("payload wordlist: english/bip39, {} words\n", payload_words.len());
+
+    for (addr, hex) in &cases {
+        let payload = hex_decode(hex).expect("hex");
+        let (prose, words, counter) = encode_checksum_seeded(&payload).expect("encode");
+
+        println!("{}", "─".repeat(74));
+        println!("{addr}");
+        println!(
+            "  {} · {} payload bytes · crc32 {:08x} · counter {counter}",
+            SCRIPT_TYPES[payload[1] as usize], payload.len(), crc32(&payload)
+        );
+        println!("\n{prose}\n");
+        println!(
+            "  {} payload words / {} total   seed {:#018x}",
+            words.len(),
+            prose.split_whitespace().count(),
+            seed_for(&payload, counter)
+        );
+
+        // Round-trip + verification
+        let (decoded, verdict) = decode_verified(&prose, payload.len(), &tree);
+        let ok = decoded.as_deref() == Some(payload.as_slice());
+        println!("  round-trip: {}   verdict: {verdict:?}", if ok { "exact" } else { "MISMATCH" });
+
+        // Negative test: swap one payload word for another valid wordlist word.
+        let victim = &words[words.len() / 2];
+        let replacement = if victim == &payload_words[0] { &payload_words[1] } else { &payload_words[0] };
+        let tampered = prose
+            .split_whitespace()
+            .map(|w| {
+                let bare = w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase();
+                if &bare == victim { replacement.clone() } else { w.to_string() }
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        let (_, tv) = decode_verified(&tampered, payload.len(), &tree);
+        println!(
+            "  payload word swapped ('{victim}' -> '{replacement}'): {tv:?}, {:.0}% token match",
+            best_similarity(&tampered, &tree) * 100.0
+        );
+
+        // Contrast: damage a COVER word instead. The payload is untouched, so the
+        // address still decodes correctly — only the checksum channel is dented.
+        // Mangle by suffixing, so the damaged token cannot land back on the payload
+        // wordlist (a replacement that IS a payload word would be an insertion, not
+        // cover damage — a different failure mode entirely).
+        let mut damaged_count = 0;
+        let cover_damaged = prose
+            .split_whitespace()
+            .map(|w| {
+                let bare = w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase();
+                if !tree.contains(&bare) && bare.len() >= 3 && damaged_count < 2 {
+                    damaged_count += 1;
+                    format!("{bare}x")
+                } else {
+                    w.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        let (cd, cv) = decode_verified(&cover_damaged, payload.len(), &tree);
+        println!(
+            "  {damaged_count} cover words damaged: {cv:?}, {:.0}% token match, payload still {}",
+            best_similarity(&cover_damaged, &tree) * 100.0,
+            if cd.as_deref() == Some(payload.as_slice()) { "exact" } else { "WRONG" }
+        );
+    }
+}

--- a/examples/prose_address_v2.py
+++ b/examples/prose_address_v2.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Prose address format v2 (glossia#76).
+
+Script opcodes are rendered verbatim as Unicode symbols; Glossia encodes only the
+entropy-carrying data (the hash160 or witness program). The format header rides in
+the bit-packing slack that the codec currently zero-fills, so it costs no words:
+
+    20-byte program : 160 data bits + 5 header bits = 165 = 15 words exactly
+    32-byte program : 256 data bits + 8 header bits = 264 = 24 words exactly
+
+Header (LSB-aligned in the tail): [log2_wordlist : 4][version : 1 or 4]
+log2 is enough because payload wordlists are powers of two (bip39 = 2^11,
+latin = 2^15), so 4 bits covers every list up to 2^15.
+
+The cover realization is seeded from CRC-32 of the encoded bits, so the choice of
+prose carries the checksum at zero length cost.
+
+Opcode symbols are drawn only from non-alphanumeric Unicode: the decoder's token
+trim (`trim_matches(|c| !c.is_alphanumeric())`) strips them, so they are invisible
+to decoding even when adjacent to a payload word.
+"""
+import subprocess, sys, os, yaml, zlib
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+CLI = os.path.join(ROOT, 'target/release/glossia')
+COUNTER_RANGE = 4
+VERSION = 1
+
+OPS = {'DUP': '⧉', 'HASH160': '⌗', 'EQUALVERIFY': '≟', 'CHECKSIG': '✓',
+       'EQUAL': '⩵', 'WIT0': '▽', 'WIT1': '△'}
+
+TEMPLATES = {                      # (leading symbols, trailing symbols)
+    'P2PKH':  ([OPS['DUP'], OPS['HASH160']], [OPS['EQUALVERIFY'], OPS['CHECKSIG']]),
+    'P2SH':   ([OPS['HASH160']],             [OPS['EQUAL']]),
+    'P2WPKH': ([OPS['WIT0']],                []),
+    'P2WSH':  ([OPS['WIT0']],                []),
+    'P2TR':   ([OPS['WIT1']],                []),
+}
+
+
+def load_wordlist():
+    class S(yaml.SafeLoader):
+        pass
+    S.add_constructor('tag:yaml.org,2002:bool', lambda l, n: l.construct_scalar(n))
+    d = yaml.load(open(os.path.join(ROOT, 'languages/english/payload_bip39.yaml')), Loader=S)
+    ws = d['words'] if isinstance(d, dict) and 'words' in d else list(d)
+    return [str(w) for w in ws]
+
+
+def mix64(x):
+    U64 = (1 << 64) - 1
+    z = (x + 0x9E3779B97F4A7C15) & U64
+    z = ((z ^ (z >> 30)) * 0xBF58476D1CE4E5B9) & U64
+    z = ((z ^ (z >> 27)) * 0x94D049BB133111EB) & U64
+    return (z ^ (z >> 31)) & U64
+
+
+def pack(program, bits_per_word, log2_wordlist, version):
+    """program bytes + header -> word indices, filling the slack exactly."""
+    data_bits = len(program) * 8
+    n_words = -(-data_bits // bits_per_word)
+    slack = n_words * bits_per_word - data_bits
+    assert slack >= 5, f'need >=5 slack bits, got {slack}'
+    header = (log2_wordlist << (slack - 4)) | (version & ((1 << (slack - 4)) - 1))
+    val = int.from_bytes(program, 'big') << slack | header
+    return [(val >> (bits_per_word * (n_words - 1 - i))) & ((1 << bits_per_word) - 1)
+            for i in range(n_words)], slack
+
+
+def unpack(indices, bits_per_word, n_program_bytes):
+    val = 0
+    for i in indices:
+        val = (val << bits_per_word) | i
+    total = len(indices) * bits_per_word
+    slack = total - n_program_bytes * 8
+    header = val & ((1 << slack) - 1)
+    program = (val >> slack).to_bytes(n_program_bytes, 'big')
+    return program, header >> (slack - 4), header & ((1 << (slack - 4)) - 1)
+
+
+def render(words, seed):
+    out = subprocess.run([CLI, '--seed', str(seed), '--width', '400'] + words,
+                         capture_output=True, text=True, timeout=300)
+    if out.returncode != 0:
+        raise RuntimeError(out.stderr[:300])
+    return ' '.join(out.stdout.split())
+
+
+def payload_tokens(text, wordset):
+    toks = []
+    for w in text.split():
+        bare = w.strip(''.join(c for c in w if not c.isalnum())).lower() if w else ''
+        bare = ''.join(ch for ch in bare)
+        # mirror Rust: trim non-alphanumeric from both ends, lowercase
+        s, e = 0, len(w)
+        while s < e and not w[s].isalnum():
+            s += 1
+        while e > s and not w[e - 1].isalnum():
+            e -= 1
+        bare = w[s:e].lower()
+        if bare and bare in wordset:
+            toks.append(bare)
+    return toks
+
+
+def main():
+    wordlist = load_wordlist()
+    wordset = set(wordlist)
+    bits_per_word = (len(wordlist) - 1).bit_length()   # 2048 -> 11
+    log2_wl = bits_per_word
+    idx = {w: i for i, w in enumerate(wordlist)}
+    print(f'payload wordlist: english/bip39, {len(wordlist)} words, '
+          f'{bits_per_word} bits/word (log2 = {log2_wl})\n')
+
+    for line in sys.stdin:
+        parts = line.rstrip('\n').split('\t')
+        if len(parts) < 4:
+            continue
+        label, addr, stype, program_hex = parts[0], parts[1], parts[2], parts[3]
+        program = bytes.fromhex(program_hex)
+        indices, slack = pack(program, bits_per_word, log2_wl, VERSION)
+        words = [wordlist[i] for i in indices]
+        checksum = zlib.crc32(bytes(program) + bytes([log2_wl, VERSION]))
+
+        best = None
+        for c in range(COUNTER_RANGE):
+            seed = mix64((checksum << 32 | c) & ((1 << 64) - 1))
+            prose = render(words, seed)
+            density = len(words) / max(1, len(prose.split()))
+            if best is None or density > best[0]:
+                best = (density, prose, c, seed)
+        _, prose, counter, seed = best
+
+        lead, trail = TEMPLATES[stype]
+        artifact = ' '.join(lead + [prose] + trail)
+
+        print('─' * 78)
+        print(f'{label}\n{addr}')
+        print(f'  {stype} · {len(program)}-byte program · {len(words)} payload words · '
+              f'{slack}-bit header (free) · crc32 {checksum:08x} · counter {counter}')
+        print(f'\n{artifact}\n')
+
+        # decode
+        toks = payload_tokens(artifact, wordset)
+        ok_count = len(toks) == len(words)
+        prog2, log2_2, ver2 = unpack([idx[t] for t in toks], bits_per_word, len(program)) \
+            if ok_count else (b'', -1, -1)
+        # verify by re-render
+        verdict = 'decoded, unverified'
+        if ok_count and prog2 == program:
+            for c in range(COUNTER_RANGE):
+                s2 = mix64((zlib.crc32(bytes(prog2) + bytes([log2_2, ver2])) << 32 | c)
+                           & ((1 << 64) - 1))
+                if render([wordlist[i] for i in [idx[t] for t in toks]], s2).split() == prose.split():
+                    verdict = f'VERIFIED (counter {c})'
+                    break
+        print(f'  round-trip: program {"exact" if prog2 == program else "MISMATCH"}, '
+              f'header log2={log2_2} version={ver2}   {verdict}')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/role_change_signal.rs
+++ b/examples/role_change_signal.rs
@@ -1,0 +1,92 @@
+//! Do payload words change grammatical ROLE when payload bits change? (#76)
+//!
+//! Role change is a coarser signal than a word-by-word diff: "insect was the
+//! subject, now it's an object" is something a reader can hold in mind. Because
+//! the cover is reseeded from the payload checksum, a changed payload reshuffles
+//! which slot each word lands in — even though the words themselves are 14/15
+//! identical after a single bit flip.
+
+use glossia::codec::{checksum_seed, hex_decode};
+use glossia::generator::core::{Placement, Role};
+use glossia::generator::data::load_payload_words_for_wordlist;
+use glossia::pipeline::encode_words_into_language_traced;
+use glossia::Pos;
+
+fn pack(program: &[u8], bpw: usize, header: u32, hb: usize) -> Vec<usize> {
+    let db = program.len() * 8;
+    let bit = |i: usize| -> usize {
+        if i < db { ((program[i / 8] >> (7 - (i % 8))) & 1) as usize }
+        else { ((header >> (hb - 1 - (i - db))) & 1) as usize }
+    };
+    (0..(db + hb) / bpw).map(|w| (0..bpw).fold(0, |a, b| (a << 1) | bit(w * bpw + b))).collect()
+}
+
+fn render(program: &[u8], header: u32, hb: usize, wl: &[String], bpw: usize) -> (String, Vec<Placement>) {
+    let words: Vec<String> = pack(program, bpw, header, hb).iter().map(|&i| wl[i].clone()).collect();
+    let mut checked = program.to_vec();
+    checked.extend_from_slice(&[bpw as u8, 1u8]);
+    let (t, _c, p) = encode_words_into_language_traced(
+        &words, "english", "default", "body", checksum_seed(&checked, 0), 4).expect("encode");
+    (t, p)
+}
+
+fn describe(p: &Placement) -> String {
+    let r = match p.role { Some(Role::Subject) => "subj", Some(Role::Object) => "obj", None => "—" };
+    format!("{}({:?},{})", p.word, p.pos, r)
+}
+
+fn main() {
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+    let bpw = wl.len().trailing_zeros() as usize;
+    let program = hex_decode("751e76e8199196d454941c45d1b3a323f1433bd6").unwrap();
+    let hb = 15 * bpw - program.len() * 8;
+    let header = ((bpw as u32) << (hb - 4)) | 1;
+
+    let (base_text, base_p) = render(&program, header, hb, &wl, bpw);
+    println!("BASELINE\n  {base_text}\n");
+    println!("  {}\n", base_p.iter().map(describe).collect::<Vec<_>>().join("  "));
+
+    let mut role_changed = vec![0usize; base_p.len()];
+    let mut pos_changed = vec![0usize; base_p.len()];
+    let mut sentence_moved = vec![0usize; base_p.len()];
+    let mut any_role = 0usize;
+    let mut examples: Vec<(usize, String, String)> = Vec::new();
+    let n = program.len() * 8;
+
+    for b in 0..n {
+        let mut q = program.clone();
+        q[b / 8] ^= 1 << (7 - (b % 8));
+        let (_t, p) = render(&q, header, hb, &wl, bpw);
+        let mut changed_here = 0;
+        for (i, (a, c)) in base_p.iter().zip(p.iter()).enumerate() {
+            if a.word == c.word {
+                if a.role != c.role { role_changed[i] += 1; changed_here += 1; }
+                if a.pos != c.pos { pos_changed[i] += 1; }
+                if a.sentence != c.sentence { sentence_moved[i] += 1; }
+            }
+        }
+        if changed_here > 0 { any_role += 1; }
+        if examples.len() < 2 && changed_here >= 3 {
+            examples.push((b, p.iter().map(describe).collect::<Vec<_>>().join("  "), _t));
+        }
+    }
+
+    println!("{}", "═".repeat(78));
+    println!("\n{n} single-bit flips — per-word change rates (unchanged words only)\n");
+    println!("  {:<12} {:>10} {:>10} {:>12}", "word", "role", "POS", "sentence");
+    for (i, p) in base_p.iter().enumerate() {
+        println!("  {:<12} {:>9.0}% {:>9.0}% {:>11.0}%", p.word,
+            role_changed[i] as f64 / n as f64 * 100.0,
+            pos_changed[i] as f64 / n as f64 * 100.0,
+            sentence_moved[i] as f64 / n as f64 * 100.0);
+    }
+    println!("\n  flips changing at least one word's role: {any_role} of {n} ({:.0}%)",
+             any_role as f64 / n as f64 * 100.0);
+
+    println!("\n{}", "═".repeat(78));
+    println!("\nEXAMPLES (3+ role changes):\n");
+    for (b, roles, text) in &examples {
+        println!("  bit {b}:\n  {text}\n  {roles}\n");
+    }
+    let _ = Pos::N;
+}

--- a/examples/role_change_signal.rs
+++ b/examples/role_change_signal.rs
@@ -26,7 +26,7 @@ fn render(program: &[u8], header: u32, hb: usize, wl: &[String], bpw: usize) -> 
     let mut checked = program.to_vec();
     checked.extend_from_slice(&[bpw as u8, 1u8]);
     let (t, _c, p) = encode_words_into_language_traced(
-        &words, "english", "default", "body", checksum_seed(&checked, 0), 1).expect("encode");
+        &words, "english", "default", "body", checksum_seed(&checked, 0), 4).expect("encode");
     (t, p)
 }
 

--- a/examples/role_change_signal.rs
+++ b/examples/role_change_signal.rs
@@ -26,7 +26,7 @@ fn render(program: &[u8], header: u32, hb: usize, wl: &[String], bpw: usize) -> 
     let mut checked = program.to_vec();
     checked.extend_from_slice(&[bpw as u8, 1u8]);
     let (t, _c, p) = encode_words_into_language_traced(
-        &words, "english", "default", "body", checksum_seed(&checked, 0), 4).expect("encode");
+        &words, "english", "default", "body", checksum_seed(&checked, 0), 1).expect("encode");
     (t, p)
 }
 

--- a/examples/similarity_table.rs
+++ b/examples/similarity_table.rs
@@ -1,0 +1,184 @@
+//! Would a precomputed word-similarity table speed up repair search? (#76)
+//!
+//! The search has two halves: proposing candidates, and re-rendering each one to
+//! see if it explains the received text. Precomputation removes the first. This
+//! measures whether that is the half that costs anything, and what a neighbour
+//! table over BIP39 actually looks like.
+//!
+//! Run: cargo run --release --example similarity_table
+
+use glossia::codec::{checksum_seed, hex_decode};
+use glossia::generator::data::load_payload_words_for_wordlist;
+use glossia::pipeline::encode_words_into_language;
+use std::collections::{HashMap, HashSet};
+use std::time::Instant;
+
+const BPW: usize = 11;
+
+/// Words within one edit of `w` that are themselves in the list.
+fn edit1(w: &str, set: &HashSet<String>) -> Vec<String> {
+    let mut out = HashSet::new();
+    let cs: Vec<char> = w.chars().collect();
+    for i in 0..cs.len() {
+        for c in 'a'..='z' {
+            let mut v = cs.clone();
+            v[i] = c;
+            let s: String = v.into_iter().collect();
+            if s != w && set.contains(&s) { out.insert(s); }
+        }
+        let mut v = cs.clone();
+        v.remove(i);
+        let s: String = v.into_iter().collect();
+        if set.contains(&s) { out.insert(s); }
+    }
+    for i in 0..=cs.len() {
+        for c in 'a'..='z' {
+            let mut v = cs.clone();
+            v.insert(i, c);
+            let s: String = v.into_iter().collect();
+            if set.contains(&s) { out.insert(s); }
+        }
+    }
+    out.into_iter().collect()
+}
+
+/// Full Levenshtein, for the edit-2 table.
+fn lev(a: &[char], b: &[char]) -> usize {
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for i in 1..=a.len() {
+        cur[0] = i;
+        for j in 1..=b.len() {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            cur[j] = (prev[j] + 1).min(cur[j - 1] + 1).min(prev[j - 1] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+fn main() {
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+    let set: HashSet<String> = wl.iter().cloned().collect();
+    let chars: Vec<Vec<char>> = wl.iter().map(|w| w.chars().collect()).collect();
+
+    // ── build the edit-1 table ──────────────────────────────────────────
+    let t0 = Instant::now();
+    let table: HashMap<&str, Vec<String>> =
+        wl.iter().map(|w| (w.as_str(), edit1(w, &set))).collect();
+    let build1 = t0.elapsed();
+
+    let with: Vec<&&str> = table.iter().filter(|(_, v)| !v.is_empty()).map(|(k, _)| k).collect();
+    let total1: usize = table.values().map(|v| v.len()).sum();
+    let max1 = table.iter().max_by_key(|(_, v)| v.len()).unwrap();
+
+    println!("EDIT-1 NEIGHBOUR TABLE over english/bip39 ({} words)\n", wl.len());
+    println!("  build time            : {:?}", build1);
+    println!("  words with a neighbour: {} of {} ({:.0}%)",
+             with.len(), wl.len(), with.len() as f64 / wl.len() as f64 * 100.0);
+    println!("  directed pairs        : {total1}");
+    println!("  mean neighbours/word  : {:.2}", total1 as f64 / wl.len() as f64);
+    println!("  most neighbours       : {:?} -> {:?}", max1.0, max1.1);
+    println!("  table size (as pairs) : ~{} KB", total1 * 10 / 1024);
+
+    // ── the edit-2 table, i.e. a looser similarity ──────────────────────
+    let t1 = Instant::now();
+    let mut total2 = 0usize;
+    let mut with2 = 0usize;
+    for i in 0..wl.len() {
+        let mut n = 0;
+        for j in 0..wl.len() {
+            if i != j && (chars[i].len() as i32 - chars[j].len() as i32).abs() <= 2
+                && lev(&chars[i], &chars[j]) <= 2 { n += 1; }
+        }
+        total2 += n;
+        if n > 0 { with2 += 1; }
+    }
+    let build2 = t1.elapsed();
+    println!("\nEDIT-2 TABLE (looser, catches two-character slips)\n");
+    println!("  build time            : {:?}  (all-pairs: 2048² Levenshtein)", build2);
+    println!("  words with a neighbour: {} of {} ({:.0}%)",
+             with2, wl.len(), with2 as f64 / wl.len() as f64 * 100.0);
+    println!("  directed pairs        : {total2}");
+    println!("  mean neighbours/word  : {:.2}", total2 as f64 / wl.len() as f64);
+
+    // ── where the search time actually goes ─────────────────────────────
+    let program = hex_decode("751e76e8199196d454941c45d1b3a323f1433bd6").unwrap();
+    let hb = (program.len() * 8).div_ceil(BPW) * BPW - program.len() * 8;
+    let header = ((BPW as u32) << (hb - 4)) | 1;
+    let db = program.len() * 8;
+    let bit = |i: usize| -> usize {
+        if i < db { ((program[i / 8] >> (7 - (i % 8))) & 1) as usize }
+        else { ((header >> (hb - 1 - (i - db))) & 1) as usize }
+    };
+    let words: Vec<String> = (0..(db + hb) / BPW)
+        .map(|w| (0..BPW).fold(0, |a, b| (a << 1) | bit(w * BPW + b)))
+        .map(|i| wl[i].clone()).collect();
+
+    let mut c = program.clone();
+    c.extend_from_slice(&[BPW as u8, 1u8]);
+    let seed = checksum_seed(&c, 0);
+
+    // candidate generation, on the fly vs looked up
+    let t2 = Instant::now();
+    let mut n_gen = 0;
+    for w in &words { n_gen += edit1(w, &set).len(); }
+    let gen_time = t2.elapsed();
+
+    let t3 = Instant::now();
+    let mut n_lookup = 0;
+    for w in &words { n_lookup += table[w.as_str()].len(); }
+    let lookup_time = t3.elapsed();
+
+    // one re-render
+    let t4 = Instant::now();
+    let _ = encode_words_into_language(&words, "english", "default", "body", seed, 4);
+    let render_time = t4.elapsed();
+
+    println!("\nWHERE THE SEARCH TIME GOES (15-word address, {n_gen} candidates)\n");
+    println!("  generating candidates on the fly : {gen_time:?}");
+    println!("  looking them up in the table     : {lookup_time:?}");
+    println!("  ONE re-render                    : {render_time:?}");
+    println!("  {n_gen} re-renders (the actual search): {:?}", render_time * n_gen as u32);
+    println!("\n  candidate generation is {:.4}% of the search",
+             gen_time.as_secs_f64() / (render_time.as_secs_f64() * n_gen as f64) * 100.0);
+    assert_eq!(n_gen, n_lookup, "table and on-the-fly must agree");
+
+    // ── so what DOES the table buy? coverage, not speed ─────────────────
+    //
+    // 63% of words have no edit-1 neighbour, so a single-character slip on them
+    // leaves the wordlist and becomes a deletion the word count already catches.
+    // The dangerous silent case is a slip that lands on another valid word. An
+    // edit-2 table covers two-character slips too — 16x the candidates, which is
+    // free to LOOK UP and expensive to RENDER. Measure what that extra coverage
+    // is worth.
+    let render_one = render_time.as_secs_f64();
+    println!("\nWHAT THE TABLE ACTUALLY BUYS\n");
+    println!("  edit-1: {:.2} candidates/word -> {:.0} per 15-word address -> {:.1}s to search",
+             total1 as f64 / wl.len() as f64,
+             total1 as f64 / wl.len() as f64 * 15.0,
+             total1 as f64 / wl.len() as f64 * 15.0 * render_one);
+    println!("  edit-2: {:.2} candidates/word -> {:.0} per 15-word address -> {:.1}s to search",
+             total2 as f64 / wl.len() as f64,
+             total2 as f64 / wl.len() as f64 * 15.0,
+             total2 as f64 / wl.len() as f64 * 15.0 * render_one);
+    println!("\n  Looking up 16x more candidates costs 4us either way. RENDERING them is");
+    println!("  the difference between a second and half a minute — so the table is worth");
+    println!("  building for candidate QUALITY and ORDER (try likely repairs first, stop");
+    println!("  at the first explanation), not for lookup speed.");
+
+    // Early exit is the lever the table enables: rank candidates and stop early.
+    println!("\n  With ranked candidates and early exit, expected renders is about half");
+    println!("  the candidate count, so edit-2 lands near {:.0}s rather than {:.0}s.",
+             total2 as f64 / wl.len() as f64 * 15.0 * render_one / 2.0,
+             total2 as f64 / wl.len() as f64 * 15.0 * render_one);
+
+    // The single biggest cost lever is unrelated to the table.
+    let t5 = Instant::now();
+    let _ = encode_words_into_language(&words, "english", "default", "body", seed, 1);
+    let one_candidate = t5.elapsed();
+    println!("\n  Bigger lever, unrelated to the table: a render with best_of=1 takes {:?}",
+             one_candidate);
+    println!("  versus {:?} at best_of=4 — the verifier repeats the encoder's counter", render_time);
+    println!("  sweep, so the format's counter range sets the search cost directly.");
+}

--- a/examples/txid_prose.rs
+++ b/examples/txid_prose.rs
@@ -1,0 +1,179 @@
+//! A txid as prose, using the Book of Bitcoin notation (#76).
+//!
+//! A txid is 32 bytes, so its geometry is exactly the P2TR/P2WSH case already
+//! settled: 256 data bits + 8 header bits = 264 = 24 words at 11 bits per word.
+//! The header is free.
+//!
+//! What is NOT settled is the type mark. An address says what it is with opcode
+//! glyphs, because a locking script really is opcodes. A txid is not script, so
+//! it borrows from the other half of the notation — the citation scheme, where
+//! `§` already means "the transaction". That keeps the rule intact: Glossia
+//! encodes the entropy, notation says what the entropy is.
+//!
+//! Two things this checks rather than asserts:
+//!   1. every candidate mark against all 24 shipped payload wordlists, so a mark
+//!      cannot silently swallow an adjacent payload word;
+//!   2. a real txid, round-tripped, in display byte order.
+//!
+//! Run: cargo run --release --example txid_prose
+
+use glossia::codec::{checksum_seed, hex_decode, hex_encode, payload_tokens_with_markup, Markup};
+use glossia::generator::data::{load_payload_words_for_wordlist, markup_collisions};
+use glossia::pipeline::encode_words_into_language;
+use std::collections::HashSet;
+
+const BPW: usize = 11;
+const BEST_OF: usize = 4;
+const VERSION: u32 = 1;
+
+/// Candidate marks, and what each would mean.
+const CANDIDATES: [(char, &str); 12] = [
+    ('\u{00A7}', "§  transaction — the citation scheme's section mark"),
+    ('\u{25A0}', "■  block — the chapter mark (a block hash, not a txid)"),
+    ('\u{03B2}', "β  difficulty window — the book mark"),
+    ('\u{22D4}', "⋔  merkle proof — already taken, taptree siblings"),
+    ('\u{2080}', "₀  subscript zero — the house index convention (⧉₂, °₄, βₙ)"),
+    ('\u{2081}', "₁  subscript one"),
+    ('\u{2089}', "₉  subscript nine"),
+    ('.',        ".  outpoint separator, the book's §17.2 form"),
+    ('#',        "#  a plain ASCII alternative, for comparison"),
+    ('\u{00B7}', "·  middle dot"),
+    ('\u{2236}', "∶  ratio — a colon that is not the ASCII colon"),
+    (':',        ":  the txid:vout separator every tool prints"),
+];
+
+fn pack(bytes: &[u8], wl: &[String]) -> Vec<String> {
+    let db = bytes.len() * 8;
+    let hb = db.div_ceil(BPW) * BPW - db;      // 8 for 32 bytes
+    let header = ((BPW as u32) << (hb - 4)) | VERSION;
+    let bit = |i: usize| -> usize {
+        if i < db { ((bytes[i / 8] >> (7 - (i % 8))) & 1) as usize }
+        else { ((header >> (hb - 1 - (i - db))) & 1) as usize }
+    };
+    (0..(db + hb) / BPW)
+        .map(|w| (0..BPW).fold(0, |a, b| (a << 1) | bit(w * BPW + b)))
+        .map(|i| wl[i].clone())
+        .collect()
+}
+
+fn unpack(words: &[String], n: usize, wl: &[String]) -> Option<Vec<u8>> {
+    let mut bits = Vec::new();
+    for w in words {
+        let i = wl.iter().position(|x| x.eq_ignore_ascii_case(w))?;
+        for b in (0..BPW).rev() { bits.push((i >> b) & 1); }
+    }
+    Some((0..n).map(|i| (0..8).fold(0u8, |a, b| (a << 1) | bits[i * 8 + b] as u8)).collect())
+}
+
+fn seed(bytes: &[u8]) -> u64 {
+    let mut c = bytes.to_vec();
+    c.extend_from_slice(&[BPW as u8, VERSION as u8]);
+    checksum_seed(&c, 0)
+}
+
+fn render(bytes: &[u8], wl: &[String]) -> (String, Vec<String>) {
+    let words = pack(bytes, wl);
+    let (t, _) = encode_words_into_language(&words, "english", "default", "body", seed(bytes), BEST_OF)
+        .expect("encode");
+    (t, words)
+}
+
+fn main() {
+    // ── 1. which marks are safe? ────────────────────────────────────
+    //
+    // The condition is NOT "non-alphanumeric" — that rule is what lets ⓪ and ①
+    // through — it is "not a character any payload word uses". Checked against
+    // every shipped wordlist, not just bip39.
+    println!("MARK SAFETY — checked against all shipped payload wordlists\n");
+    let hits = markup_collisions(CANDIDATES.iter().map(|(c, _)| *c));
+    for (c, desc) in CANDIDATES {
+        let bad: Vec<String> = hits.iter()
+            .filter(|(_, chars)| chars.contains(&c))
+            .map(|(list, _)| list.clone())
+            .collect();
+        println!("  {:<8} {:<62} {}", format!("U+{:04X}", c as u32), desc,
+                 if bad.is_empty() { "safe".to_string() }
+                 else { format!("COLLIDES: {}", bad.join(", ")) });
+    }
+
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+    let set: HashSet<String> = wl.iter().map(|w| w.to_lowercase()).collect();
+
+    // ── 2. a real txid ──────────────────────────────────────────────
+    //
+    // The pizza transaction, in DISPLAY byte order — the order a person copies
+    // from an explorer, and therefore the order the prose has to mean. Wire
+    // order is the reverse; encoding that instead would round-trip perfectly and
+    // still name the wrong transaction to every tool the reader owns.
+    let txid = "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d";
+    let bytes = hex_decode(txid).unwrap();
+    let mark = '\u{00A7}';
+    let markup = Markup::new([mark], &wl).expect("§ validates against bip39");
+
+    let (prose, words) = render(&bytes, &wl);
+    let artifact = format!("{mark} {prose}");
+
+    println!("\n{}", "═".repeat(78));
+    println!("\nTXID  {txid}\n");
+    println!("  {artifact}\n");
+    println!("  {} payload words / {} words total ({} bytes -> {} data bits + {} header)",
+             words.len(), prose.split_whitespace().count(), bytes.len(), bytes.len() * 8,
+             24 * BPW - bytes.len() * 8);
+
+    // ── 3. it decodes ───────────────────────────────────────────────
+    let harvested = payload_tokens_with_markup(&artifact, &markup, |w| set.contains(w));
+    let got = unpack(&harvested, bytes.len(), &wl).expect("unpack");
+    println!("\n  harvested {} words, decodes to {}", harvested.len(), hex_encode(&got));
+    println!("  round trip: {}", if got == bytes { "exact" } else { "FAILED" });
+
+    // ── 4. and it self-verifies ─────────────────────────────────────
+    //
+    // Worth more here than for an address. base58check and bech32 already carry
+    // a checksum; a txid carries NONE — 64 hex characters with no redundancy at
+    // all, where a typo is indistinguishable from a transaction that has not
+    // propagated yet. The cover words supply what the format never had.
+    let (rerender, _) = render(&got, &wl);
+    println!("  re-render matches: {}", rerender == prose);
+
+    let mut flipped = bytes.clone();
+    flipped[17] ^= 0x08;
+    let (other, ow) = render(&flipped, &wl);
+    let same_words = words.iter().zip(ow.iter()).filter(|(a, b)| a == b).count();
+    let toks: Vec<&str> = prose.split_whitespace().collect();
+    let otoks: Vec<&str> = other.split_whitespace().collect();
+    let same_toks = toks.iter().zip(otoks.iter()).filter(|(a, b)| a == b).count();
+    println!("\n  one bit flipped:");
+    println!("    {other}");
+    println!("\n    payload words shared with the original: {same_words} of {}", words.len());
+    println!("    token positions shared                 : {same_toks} of {}", toks.len().max(otoks.len()));
+
+    // ── 5. an outpoint ──────────────────────────────────────────────
+    //
+    // The book prints an outpoint as §17.2 — section dot verse. That form cannot
+    // be lifted verbatim: `.` and `:` are payload characters in cs/ascii7 (and
+    // `.` in every image colormap list), so declaring either as markup would
+    // strip a character out of real payload words. The subscript digits are
+    // clean across all 24 lists, and they are already the house index
+    // convention — ⧉₂, °₄, βₙ, ηₙ. So the index rides the mark: §₀.
+    let vout_mark = ['\u{00A7}', '\u{2080}'];
+    let outpoint = format!("\u{00A7}\u{2080} {prose}");
+    let om = Markup::new(vout_mark, &wl).expect("§₀ validates");
+    let oh = payload_tokens_with_markup(&outpoint, &om, |w| set.contains(w));
+    println!("\n{}", "═".repeat(78));
+    println!("\nOUTPOINT — output 0 of that transaction\n");
+    println!("  \u{00A7}\u{2080} {prose}\n");
+    println!("  harvested {} words, still decodes to the same txid: {}",
+             oh.len(), unpack(&oh, bytes.len(), &wl).as_deref() == Some(&bytes[..]));
+    println!("\n  The index carries no entropy and a wrong one is caught by the");
+    println!("  transaction it names, so it stays a numeral. Only the 32 bytes");
+    println!("  become words.");
+
+    println!("\n{}", "═".repeat(78));
+    println!("\nWHEN NOT TO DO THIS\n");
+    println!("  For a CONFIRMED transaction the book already has a shorter handle:");
+    println!("  the citation. III \u{03B2}2 \u{25A0}5 \u{00A7}7 is four tokens against twenty-four");
+    println!("  words, and it is speakable in a breath. The trade is self-containment:");
+    println!("  a citation needs the chain to resolve, the prose does not. So prose for");
+    println!("  a txid in flight or quoted outside the book, citation once it is mined");
+    println!("  and the reader is inside the book.");
+}

--- a/examples/user_journey.rs
+++ b/examples/user_journey.rs
@@ -177,7 +177,31 @@ fn main() {
     println!("\n  A fixed-length address has a fixed word count, so a dropped address word");
     println!("  is caught before anything is decoded at all.");
 
-    hr("6. TWO ADDRESSES THAT DIFFER BY ONE BIT");
+    hr("6. A CONNECTIVE WORD TURNS INTO AN ADDRESS WORD");
+    // 'son' is connective prose; 'sun' is an address word. One character apart.
+    let inserted = artifact.replacen(" son ", " sun ", 1);
+    println!("\n  'son' misread as 'sun':\n");
+    println!("  {inserted}\n");
+    let (_g, verdict, _) = c.read(&inserted, program.len());
+    println!("  {verdict}");
+    println!("\n  This is the mirror of scenario 5. Nothing was lost — a word was GAINED,");
+    println!("  because a connective word landed in the address vocabulary. The fixed");
+    println!("  word count catches it the same way.");
+
+    hr("7. TWO ERRORS THAT HIDE EACH OTHER");
+    // A dropped address word and a gained one cancel out in the count.
+    let compound = artifact.replacen(" son ", " sun ", 1).replacen("ring", "map", 1);
+    println!("\n  'son' -> 'sun' (gained) and 'ring' -> 'map' (lost), together:\n");
+    println!("  {compound}\n");
+    let (g, verdict, sim) = c.read(&compound, program.len());
+    println!("  {verdict}  (wording match {:.0}%)", sim * 100.0);
+    println!("  decodes to: {}", hex_encode(g.as_deref().unwrap_or(&[])));
+    println!("  is that the right address? {}", g.as_deref() == Some(&program[..]));
+    println!("\n  The word count is back to normal, so counting alone would pass this.");
+    println!("  Only the wording check catches it — which is the reason the address");
+    println!("  determines its own prose rather than being wrapped in arbitrary text.");
+
+    hr("8. TWO ADDRESSES THAT DIFFER BY ONE BIT");
     let mut near = program.clone();
     near[19] ^= 1;
     let (other, _p2) = c.render(&near, '\u{25BD}');
@@ -188,7 +212,7 @@ fn main() {
     println!("  are two different paragraphs — which is why the wording is derived from");
     println!("  the address rather than chosen freely.");
 
-    hr("7. READING IT ALOUD");
+    hr("9. READING IT ALOUD");
     println!("\n  If you dictate this, the listener needs the address words in order:\n");
     println!("  {}\n", places.iter().map(|p| p.word.as_str()).collect::<Vec<_>>().join(" · "));
     println!("  The grammar is what makes that speakable — and the roles are a second");

--- a/examples/user_journey.rs
+++ b/examples/user_journey.rs
@@ -1,0 +1,204 @@
+//! What a person actually experiences handling a prose-encoded Bitcoin address (#76).
+//!
+//! Each scenario is a real encode/decode round trip, not a mock-up: the prose,
+//! the verdict, and the recovered address are all computed.
+//!
+//! Run: cargo run --release --example user_journey
+
+use glossia::codec::{checksum_seed, crc32, hex_encode, payload_tokens_with_markup, Markup};
+use glossia::generator::core::{Placement, Role};
+use glossia::generator::data::load_payload_words_for_wordlist;
+use glossia::pipeline::encode_words_into_language_traced;
+use std::collections::HashSet;
+
+const COUNTER_RANGE: u64 = 4;
+const SIGILS: [char; 3] = ['\u{25BD}', '\u{25B3}', '\u{2317}'];
+
+struct Codec {
+    wl: Vec<String>,
+    set: HashSet<String>,
+    bpw: usize,
+    markup: Markup,
+}
+
+impl Codec {
+    fn new() -> Self {
+        let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+        let set = wl.iter().map(|w| w.to_lowercase()).collect();
+        let bpw = wl.len().trailing_zeros() as usize;
+        let markup = Markup::new(SIGILS, &wl).expect("sigils validate");
+        Self { wl, set, bpw, markup }
+    }
+
+    fn header_bits(&self, program_len: usize) -> usize {
+        let words = (program_len * 8 + self.bpw - 1) / self.bpw;
+        let mut hb = words * self.bpw - program_len * 8;
+        if hb < 5 { hb += self.bpw; }
+        hb
+    }
+
+    fn pack(&self, program: &[u8]) -> Vec<String> {
+        let hb = self.header_bits(program.len());
+        let header = ((self.bpw as u32) << (hb - 4)) | 1;
+        let db = program.len() * 8;
+        let bit = |i: usize| -> usize {
+            if i < db { ((program[i / 8] >> (7 - (i % 8))) & 1) as usize }
+            else { ((header >> (hb - 1 - (i - db))) & 1) as usize }
+        };
+        (0..(db + hb) / self.bpw)
+            .map(|w| (0..self.bpw).fold(0, |a, b| (a << 1) | bit(w * self.bpw + b)))
+            .map(|i| self.wl[i].clone())
+            .collect()
+    }
+
+    fn unpack(&self, words: &[String], n_bytes: usize) -> Option<Vec<u8>> {
+        let hb = self.header_bits(n_bytes);
+        if words.len() != (n_bytes * 8 + hb) / self.bpw { return None; }
+        let mut bits = Vec::new();
+        for w in words {
+            let i = self.wl.iter().position(|x| x.to_lowercase() == w.to_lowercase())?;
+            for b in (0..self.bpw).rev() { bits.push((i >> b) & 1); }
+        }
+        Some((0..n_bytes).map(|i| (0..8).fold(0u8, |a, b| (a << 1) | bits[i * 8 + b] as u8)).collect())
+    }
+
+    fn seed(&self, program: &[u8]) -> u64 {
+        let mut c = program.to_vec();
+        c.extend_from_slice(&[self.bpw as u8, 1u8]);
+        checksum_seed(&c, 0)
+    }
+
+    fn render(&self, program: &[u8], sigil: char) -> (String, Vec<Placement>) {
+        let words = self.pack(program);
+        let (t, _c, p) = encode_words_into_language_traced(
+            &words, "english", "default", "body", self.seed(program), COUNTER_RANGE as usize,
+        ).expect("encode");
+        (format!("{sigil} {t}"), p)
+    }
+
+    /// Decode + verify. Returns (recovered program, verdict, similarity).
+    fn read(&self, artifact: &str, n_bytes: usize) -> (Option<Vec<u8>>, &'static str, f64) {
+        let words = payload_tokens_with_markup(artifact, &self.markup, |w| self.set.contains(w));
+        let expected = (n_bytes * 8 + self.header_bits(n_bytes)) / self.bpw;
+        if words.len() != expected {
+            return (None, "UNREADABLE — wrong number of address words", 0.0);
+        }
+        let Some(program) = self.unpack(&words, n_bytes) else {
+            return (None, "UNREADABLE — word not in the address vocabulary", 0.0);
+        };
+        // Re-render and compare: this is the checksum.
+        let mut best = 0.0f64;
+        let recv: Vec<&str> = artifact.split_whitespace().skip(1).collect();
+        for c in 0..COUNTER_RANGE {
+            let w = self.pack(&program);
+            let mut cc = program.clone();
+            cc.extend_from_slice(&[self.bpw as u8, 1u8]);
+            let s = checksum_seed(&cc, 0).wrapping_add(c);
+            if let Ok((t, _, _)) = encode_words_into_language_traced(
+                &w, "english", "default", "body", s, 1) {
+                let got: Vec<&str> = t.split_whitespace().collect();
+                if got == recv { return (Some(program), "VERIFIED", 1.0); }
+                let n = recv.len().max(got.len()).max(1);
+                best = best.max(recv.iter().zip(got.iter()).filter(|(a, b)| a == b).count() as f64 / n as f64);
+            }
+        }
+        if best > 0.75 {
+            (Some(program), "READABLE, NOT VERIFIED — wording differs slightly; address itself looks intact", best)
+        } else {
+            (Some(program), "MISMATCH — this is not the address it was written as", best)
+        }
+    }
+}
+
+fn roles(p: &[Placement]) -> String {
+    p.iter().filter_map(|x| match x.role {
+        Some(Role::Subject) => Some(format!("{} (subject)", x.word)),
+        Some(Role::Object) => Some(format!("{} (object)", x.word)),
+        None => None,
+    }).collect::<Vec<_>>().join(", ")
+}
+
+fn hr(title: &str) {
+    println!("\n{}\n{title}\n{}", "─".repeat(76), "─".repeat(76));
+}
+
+fn main() {
+    let c = Codec::new();
+    // P2WPKH, bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4
+    let program = glossia::codec::hex_decode("751e76e8199196d454941c45d1b3a323f1433bd6").unwrap();
+    let (artifact, places) = c.render(&program, '\u{25BD}');
+
+    hr("1. SOMEONE SENDS YOU AN ADDRESS");
+    println!("\n  {artifact}\n");
+    println!("  This is a pay-to-witness-public-key-hash address. The ▽ is the opcode;");
+    println!("  the sentences carry the 20-byte program. {} of the words are address", places.len());
+    println!("  data, the rest is connective prose.\n");
+    println!("  hash160  {}", hex_encode(&program));
+    println!("  checksum {:08x}", crc32(&program));
+
+    hr("2. YOU PASTE IT IN AND IT CHECKS OUT");
+    let (got, verdict, _) = c.read(&artifact, program.len());
+    println!("\n  {verdict}");
+    println!("  recovered: {}", hex_encode(got.as_deref().unwrap_or(&[])));
+    println!("  matches the original: {}", got.as_deref() == Some(&program[..]));
+    println!("\n  Verification re-renders the address from the bytes you decoded and");
+    println!("  compares the prose. Only the true bytes reproduce this exact wording.");
+
+    hr("3. YOU RETYPE IT AND FUMBLE A CONNECTIVE WORD");
+    let sloppy = artifact.replacen(" may ", " might ", 1).replacen(" per ", " for ", 1);
+    println!("\n  {sloppy}\n");
+    let (got, verdict, sim) = c.read(&sloppy, program.len());
+    println!("  {verdict}");
+    println!("  address recovered correctly: {}", got.as_deref() == Some(&program[..]));
+    println!("  wording match: {:.0}%", sim * 100.0);
+    println!("\n  The address words were untouched, so the money still goes to the right");
+    println!("  place — but the wording no longer matches, so it cannot self-verify.");
+    println!("  A wallet should say so rather than claim success.");
+
+    hr("4. YOU MISTYPE AN ADDRESS WORD INTO ANOTHER REAL WORD");
+    let victim = &places[places.len() / 2].word;
+    let typo = artifact.replacen(victim.as_str(), "kitten", 1);
+    println!("\n  '{victim}' misread as 'kitten':\n");
+    println!("  {typo}\n");
+    let (_g, verdict, sim) = c.read(&typo, program.len());
+    println!("  {verdict}  (wording match {:.0}%)", sim * 100.0);
+    println!("\n  This is the dangerous case: 'kitten' is a valid address word, so the");
+    println!("  text still decodes — to a DIFFERENT address. The wording is what catches");
+    println!("  it. Funds sent here would be unrecoverable, so the check matters.");
+
+    hr("5. A WORD GETS LOST IN COPY-PASTE");
+    let mut toks: Vec<&str> = artifact.split_whitespace().collect();
+    let drop_at = places[2].token_index + 1;
+    let dropped = toks.remove(drop_at);
+    println!("\n  '{dropped}' lost:\n");
+    println!("  {}\n", toks.join(" "));
+    let (_g, verdict, _) = c.read(&toks.join(" "), program.len());
+    println!("  {verdict}");
+    println!("\n  A fixed-length address has a fixed word count, so a dropped address word");
+    println!("  is caught before anything is decoded at all.");
+
+    hr("6. TWO ADDRESSES THAT DIFFER BY ONE BIT");
+    let mut near = program.clone();
+    near[19] ^= 1;
+    let (other, _p2) = c.render(&near, '\u{25BD}');
+    println!("\n  yours:  {artifact}\n");
+    println!("  theirs: {other}\n");
+    println!("  The two hash160s differ in a single bit, and share 14 of 15 address");
+    println!("  words. You are not meant to spot that. You are meant to see that these");
+    println!("  are two different paragraphs — which is why the wording is derived from");
+    println!("  the address rather than chosen freely.");
+
+    hr("7. READING IT ALOUD");
+    println!("\n  If you dictate this, the listener needs the address words in order:\n");
+    println!("  {}\n", places.iter().map(|p| p.word.as_str()).collect::<Vec<_>>().join(" · "));
+    println!("  The grammar is what makes that speakable — and the roles are a second");
+    println!("  handle on it:\n");
+    println!("  {}", roles(&places));
+    println!("\n  Sentence by sentence:");
+    let mut cur = usize::MAX;
+    for p in &places {
+        if p.sentence != cur { cur = p.sentence; print!("\n    sentence {}: ", cur + 1); }
+        print!("{} ", p.word);
+    }
+    println!("\n");
+}

--- a/examples/user_journey.rs
+++ b/examples/user_journey.rs
@@ -11,7 +11,10 @@ use glossia::generator::data::load_payload_words_for_wordlist;
 use glossia::pipeline::encode_words_into_language_traced;
 use std::collections::HashSet;
 
-const COUNTER_RANGE: u64 = 4;
+/// No counter sweep: verification reproduces a fixed artifact rather than
+/// generating a new one, so the encoder's fluency search would become a cost the
+/// verifier and every repair candidate must repeat.
+const COUNTER_RANGE: u64 = 1;
 /// Opcode glyphs from the Book of Bitcoin notation (btc-prose.js OPCODE_SYMBOLS).
 /// U+24EA and U+2460 are Unicode category No — *alphanumeric* — so they survive
 /// the decoder's token trim. They are safe only because they are declared here.

--- a/examples/user_journey.rs
+++ b/examples/user_journey.rs
@@ -12,7 +12,18 @@ use glossia::pipeline::encode_words_into_language_traced;
 use std::collections::HashSet;
 
 const COUNTER_RANGE: u64 = 4;
-const SIGILS: [char; 3] = ['\u{25BD}', '\u{25B3}', '\u{2317}'];
+/// Opcode glyphs from the Book of Bitcoin notation (btc-prose.js OPCODE_SYMBOLS).
+/// U+24EA and U+2460 are Unicode category No — *alphanumeric* — so they survive
+/// the decoder's token trim. They are safe only because they are declared here.
+const SIGILS: [char; 7] = [
+    '\u{29C9}', // ⧉ OP_DUP
+    '\u{2316}', // ⌖ OP_HASH160
+    '\u{2261}', // ≡ OP_EQUALVERIFY
+    '\u{2207}', // ∇ OP_CHECKSIG
+    '=',         // OP_EQUAL
+    '\u{24EA}', // ⓪ OP_0
+    '\u{2460}', // ① OP_1
+];
 
 struct Codec {
     wl: Vec<String>,
@@ -126,13 +137,13 @@ fn main() {
     let c = Codec::new();
     // P2WPKH, bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4
     let program = glossia::codec::hex_decode("751e76e8199196d454941c45d1b3a323f1433bd6").unwrap();
-    let (artifact, places) = c.render(&program, '\u{25BD}');
+    let (artifact, places) = c.render(&program, '\u{24EA}');  // OP_0
 
     hr("1. SOMEONE SENDS YOU AN ADDRESS");
     println!("\n  {artifact}\n");
-    println!("  This is a pay-to-witness-public-key-hash address. The ▽ is the opcode;");
-    println!("  the sentences carry the 20-byte program. {} of the words are address", places.len());
-    println!("  data, the rest is connective prose.\n");
+    println!("  This is a pay-to-witness-public-key-hash address. \u{24EA} is OP_0, the");
+    println!("  witness version; the sentences carry the 20-byte program. {} of the", places.len());
+    println!("  words are address data, the rest is connective prose.\n");
     println!("  hash160  {}", hex_encode(&program));
     println!("  checksum {:08x}", crc32(&program));
 
@@ -204,7 +215,7 @@ fn main() {
     hr("8. TWO ADDRESSES THAT DIFFER BY ONE BIT");
     let mut near = program.clone();
     near[19] ^= 1;
-    let (other, _p2) = c.render(&near, '\u{25BD}');
+    let (other, _p2) = c.render(&near, '\u{24EA}');
     println!("\n  yours:  {artifact}\n");
     println!("  theirs: {other}\n");
     println!("  The two hash160s differ in a single bit, and share 14 of 15 address");

--- a/examples/user_journey.rs
+++ b/examples/user_journey.rs
@@ -11,10 +11,11 @@ use glossia::generator::data::load_payload_words_for_wordlist;
 use glossia::pipeline::encode_words_into_language_traced;
 use std::collections::HashSet;
 
-/// No counter sweep: verification reproduces a fixed artifact rather than
-/// generating a new one, so the encoder's fluency search would become a cost the
-/// verifier and every repair candidate must repeat.
-const COUNTER_RANGE: u64 = 1;
+/// Fluency budget, locked at 4 — a fixed parameter, not a search. Encoder and
+/// verifier both render best-of-4 from the checksum seed, so one address has one
+/// prose. Chosen where the marginal return falls off: density rises 0.53 -> 0.59
+/// from N=1 to N=4 at 20 bytes, and past N=8 each doubling buys under one word.
+const BEST_OF: u64 = 4;
 /// Opcode glyphs from the Book of Bitcoin notation (btc-prose.js OPCODE_SYMBOLS).
 /// U+24EA and U+2460 are Unicode category No — *alphanumeric* — so they survive
 /// the decoder's token trim. They are safe only because they are declared here.
@@ -85,7 +86,7 @@ impl Codec {
     fn render(&self, program: &[u8], sigil: char) -> (String, Vec<Placement>) {
         let words = self.pack(program);
         let (t, _c, p) = encode_words_into_language_traced(
-            &words, "english", "default", "body", self.seed(program), COUNTER_RANGE as usize,
+            &words, "english", "default", "body", self.seed(program), BEST_OF as usize,
         ).expect("encode");
         (format!("{sigil} {t}"), p)
     }
@@ -103,7 +104,7 @@ impl Codec {
         // Re-render and compare: this is the checksum.
         let mut best = 0.0f64;
         let recv: Vec<&str> = artifact.split_whitespace().skip(1).collect();
-        for c in 0..COUNTER_RANGE {
+        for c in 0..BEST_OF {
             let w = self.pack(&program);
             let mut cc = program.clone();
             cc.extend_from_slice(&[self.bpw as u8, 1u8]);

--- a/glossia-cli/src/main.rs
+++ b/glossia-cli/src/main.rs
@@ -6,7 +6,7 @@
 // rand = "0.8"
 
 use rand::{seq::SliceRandom, Rng, SeedableRng};
-use rand::rngs::StdRng;
+use glossia::CoverRng;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use glossia::types::Pos;
@@ -1625,7 +1625,7 @@ fn main() {
         // Generate a random seed from thread_rng for non-deterministic behavior
         rand::thread_rng().gen::<u64>()
     };
-    let mut rng = StdRng::seed_from_u64(seed_value);
+    let mut rng = CoverRng::seed_from_u64(seed_value);
     
     if verbose {
         if seed.is_some() {
@@ -1936,7 +1936,7 @@ fn main() {
                 &delimiter,
             )
         } else {
-            let mut variation_rng = StdRng::seed_from_u64(variation_seed);
+            let mut variation_rng = CoverRng::seed_from_u64(variation_seed);
             generate_text_with_original_payload(
                 &mut variation_rng,
                 &lex,
@@ -2345,7 +2345,7 @@ mod tests {
     fn test_plan_sentence_max_j() {
         // Load cache
         let cache = SequenceCache::load(GenerationMode::Body, "english", 20, false).expect("Failed to load cache");
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         
         // Create payload with N, V, N
         let payload = vec![
@@ -2379,7 +2379,7 @@ mod tests {
     #[test]
     fn test_ordered_payload_extraction() {
         // Smoke test: generate text and verify payload words appear in order
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let words = vec!["abandon".to_string(), "ability".to_string(), "able".to_string()];
         
         let payload: Vec<PayloadTok> = words
@@ -2574,7 +2574,7 @@ mod tests {
         };
 
         // Generate sentences with random BIP39 words (using fixed seed for reproducibility)
-        let mut rng = StdRng::seed_from_u64(TEST_SEED);
+        let mut rng = CoverRng::seed_from_u64(TEST_SEED);
         let words = select_random_words(&mut rng, 10, "english").unwrap();
         
         let payload: Vec<PayloadTok> = words
@@ -2645,7 +2645,7 @@ mod tests {
 
         // Test with different payload sizes (using same seed for reproducibility)
         for word_count in [5, 8, 12] {
-            let mut rng = StdRng::seed_from_u64(TEST_SEED);
+            let mut rng = CoverRng::seed_from_u64(TEST_SEED);
             let words = select_random_words(&mut rng, word_count, "english").unwrap();
             
             let payload: Vec<PayloadTok> = words
@@ -2689,7 +2689,7 @@ mod tests {
     #[test]
     fn test_sentence_structure() {
         // Test that generated sentences have reasonable structure (using fixed seed for reproducibility)
-        let mut rng = StdRng::seed_from_u64(TEST_SEED);
+        let mut rng = CoverRng::seed_from_u64(TEST_SEED);
         let words = select_random_words(&mut rng, 5, "english").unwrap();
         
         let payload: Vec<PayloadTok> = words
@@ -2727,7 +2727,7 @@ mod tests {
     #[test]
     fn test_compute_k_candidates_compact_mode() {
         let cache = SequenceCache::load(GenerationMode::Body, "english", 20, false).expect("Failed to load cache");
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         
         // Compact mode should return k_min..=k_max in order
         let candidates = compute_k_candidates(
@@ -2759,7 +2759,7 @@ mod tests {
     #[test]
     fn test_compute_k_candidates_natural_mode() {
         let cache = SequenceCache::load(GenerationMode::Body, "english", 20, false).expect("Failed to load cache");
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         
         // Natural mode should ignore k_min and sample from all available k values
         let candidates = compute_k_candidates(
@@ -2793,7 +2793,7 @@ mod tests {
     #[test]
     fn test_compute_k_candidates_natural_mode_prefix() {
         let cache = SequenceCache::load(GenerationMode::Subject, "english", 20, false).expect("Failed to load cache");
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         
         // Natural mode with require_prefix should start at k=2 (k_min ignored)
         let candidates = compute_k_candidates(
@@ -2827,7 +2827,7 @@ mod tests {
     #[test]
     fn test_compute_k_candidates_natural_mode_weight_ordering() {
         let cache = SequenceCache::load(GenerationMode::Body, "english", 20, false).expect("Failed to load cache");
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         
         // Test that after the sampled k, remaining k's are in descending weight order
         let candidates = compute_k_candidates(
@@ -2892,7 +2892,7 @@ mod tests {
         let mut forced: HashMap<usize, usize> = HashMap::new();
         forced.insert(1, 0); // Force "apple" into N slot
 
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let mut payload_i = 0usize;
         let out = fill_slots(
             &mut rng, &lex, &slots, &refinements, &payload, &mut payload_i,
@@ -2919,7 +2919,7 @@ mod tests {
         let mut forced: HashMap<usize, usize> = HashMap::new();
         forced.insert(1, 0); // Force "basket" into N slot
 
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let mut payload_i = 0usize;
         let out = fill_slots(
             &mut rng, &lex, &slots, &refinements, &payload, &mut payload_i,
@@ -2951,7 +2951,7 @@ mod tests {
         let refinements = vec![Some("def".to_string()), None, None];
 
         let def_words: HashSet<&str> = ["the", "its", "our"].iter().copied().collect();
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let mut payload_i = 0usize;
         let out = fill_slots(
             &mut rng, &lex, &slots, &refinements, &payload, &mut payload_i,
@@ -2988,7 +2988,7 @@ mod tests {
         let slots = vec![Pos::N, Pos::Cop, Pos::Adj, Pos::Dot];
         let refinements = vec![None, Some("sg".to_string()), None, None];
 
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let mut payload_i = 0usize;
         let out = fill_slots(
             &mut rng, &lex, &slots, &refinements, &payload, &mut payload_i,
@@ -3022,7 +3022,7 @@ mod tests {
         let slots = vec![Pos::N, Pos::Cop, Pos::Adj, Pos::Dot];
         let refinements = vec![None, Some("pl".to_string()), None, None];
 
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let mut payload_i = 0usize;
         let out = fill_slots(
             &mut rng, &lex, &slots, &refinements, &payload, &mut payload_i,
@@ -3046,7 +3046,7 @@ mod tests {
         let slots = vec![Pos::Adj, Pos::N, Pos::V, Pos::N, Pos::Dot];
         let refinements = vec![None, None, None, None, None];
 
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let mut payload_i = 0usize;
         let out = fill_slots(
             &mut rng, &lex, &slots, &refinements, &payload, &mut payload_i,
@@ -3073,7 +3073,7 @@ mod tests {
         ].iter().copied().collect();
 
         for seed in [42u64, 123, 999, 7, 2024] {
-            let mut rng = StdRng::seed_from_u64(seed);
+            let mut rng = CoverRng::seed_from_u64(seed);
             let words = select_random_words(&mut rng, 6, "latin").unwrap();
 
             let payload: Vec<PayloadTok> = words.iter().map(|word| {
@@ -3138,7 +3138,7 @@ mod tests {
     #[test]
     fn test_english_round_trip() {
         // Encode 4+ BIP39 words, extract from output, verify they match in order
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let words = vec![
             "abandon".to_string(),
             "ability".to_string(),
@@ -3192,13 +3192,13 @@ mod tests {
 
         let lex = setup_test_lexicon(payload_set, wordlist_set);
 
-        let mut rng1 = StdRng::seed_from_u64(42);
+        let mut rng1 = CoverRng::seed_from_u64(42);
         let (text1, _) = generate_text(
             &mut rng1, &lex, &payload, false, GenerationMode::Body, "english",
             3, 20, SentenceLengthMode::Compact, " ",
         );
 
-        let mut rng2 = StdRng::seed_from_u64(42);
+        let mut rng2 = CoverRng::seed_from_u64(42);
         let (text2, _) = generate_text(
             &mut rng2, &lex, &payload, false, GenerationMode::Body, "english",
             3, 20, SentenceLengthMode::Compact, " ",
@@ -3211,7 +3211,7 @@ mod tests {
 
     #[test]
     fn test_single_payload_word_appears_in_output() {
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let payload = vec![PayloadTok::new("abandon", &[Pos::N, Pos::V])];
         let payload_set: HashSet<String> = payload.iter().map(|t| t.word.to_lowercase()).collect();
         let wordlist_words = load_payload_words("english").unwrap();
@@ -3235,7 +3235,7 @@ mod tests {
     #[test]
     fn test_many_payload_words_round_trip() {
         // Test with 12 random BIP39 words
-        let mut rng = StdRng::seed_from_u64(99);
+        let mut rng = CoverRng::seed_from_u64(99);
         let words = select_random_words(&mut rng, 12, "english").unwrap();
 
         let payload: Vec<PayloadTok> = words.iter().map(|word| {
@@ -3270,7 +3270,7 @@ mod tests {
     #[test]
     fn test_output_ends_with_period_body_mode() {
         // Body mode text should end with a period for English
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let words = vec!["abandon".to_string(), "ability".to_string()];
         let payload: Vec<PayloadTok> = words.iter().map(|word| {
             let tags = tag_word(word);
@@ -3350,7 +3350,7 @@ mod tests {
 
     #[test]
     fn test_meta_round_trip_4_words() {
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let words = vec![
             "base64".to_string(),
             "latin".to_string(),
@@ -3398,7 +3398,7 @@ mod tests {
 
     #[test]
     fn test_meta_round_trip_8_words() {
-        let mut rng = StdRng::seed_from_u64(100);
+        let mut rng = CoverRng::seed_from_u64(100);
         let words = select_random_words(&mut rng, 8, "meta").unwrap();
 
         let pos_mapping = build_pos_mapping_for_wordlist("meta", "default")
@@ -3456,13 +3456,13 @@ mod tests {
 
         let lex = setup_meta_lexicon(payload_set, wordlist_set);
 
-        let mut rng1 = StdRng::seed_from_u64(42);
+        let mut rng1 = CoverRng::seed_from_u64(42);
         let (text1, _) = generate_text(
             &mut rng1, &lex, &payload, false, GenerationMode::Body, "meta",
             3, 12, SentenceLengthMode::Compact, " ",
         );
 
-        let mut rng2 = StdRng::seed_from_u64(42);
+        let mut rng2 = CoverRng::seed_from_u64(42);
         let (text2, _) = generate_text(
             &mut rng2, &lex, &payload, false, GenerationMode::Body, "meta",
             3, 12, SentenceLengthMode::Compact, " ",
@@ -3473,7 +3473,7 @@ mod tests {
 
     #[test]
     fn test_meta_output_ends_with_period() {
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let words = vec!["pgp".to_string(), "nostr".to_string()];
         let pos_mapping = build_pos_mapping_for_wordlist("meta", "default")
             .expect("Meta POS mapping");
@@ -3505,7 +3505,7 @@ mod tests {
     #[test]
     fn test_first_word_is_capitalized() {
         // First word of output should be capitalized
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
         let words = vec!["abandon".to_string(), "ability".to_string()];
         let payload: Vec<PayloadTok> = words.iter().map(|word| {
             let tags = tag_word(word);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -146,6 +146,82 @@ pub fn alnum_token_count(text: &str) -> usize {
         .count()
 }
 
+/// A declared set of markup characters — opcode sigils, delimiters, any decoration
+/// a format places around prose — that decoding must strip rather than read.
+///
+/// [`normalize_token`] can only strip what is non-alphanumeric, which is a guess:
+/// `β` is Unicode category `Ll`, indistinguishable from a payload letter, so
+/// `βabsorb` normalizes to itself and the payload word vanishes. Declaring the
+/// markup removes the guess — a known symbol is stripped whether or not Unicode
+/// considers it a letter.
+///
+/// The safety condition is not "non-alphanumeric" but "not a character any payload
+/// word uses", which [`Markup::new`] checks against the wordlist. Both shipped
+/// payload lists are plain `a`–`z`, so symbols, Greek letters and numerals are all
+/// admissible; declaring `e` is not.
+#[derive(Debug, Clone, Default)]
+pub struct Markup {
+    chars: std::collections::HashSet<char>,
+}
+
+impl Markup {
+    /// Declare a markup set, validated against the payload wordlist.
+    ///
+    /// Returns `Err` with the offending characters if any of them appears inside a
+    /// payload word, since stripping such a character would corrupt decoding.
+    pub fn new<I, S>(chars: I, payload_words: &[S]) -> Result<Self, Vec<char>>
+    where
+        I: IntoIterator<Item = char>,
+        S: AsRef<str>,
+    {
+        let chars: std::collections::HashSet<char> = chars.into_iter().collect();
+        let alphabet: std::collections::HashSet<char> = payload_words
+            .iter()
+            .flat_map(|w| w.as_ref().to_lowercase().chars().collect::<Vec<_>>())
+            .collect();
+        let mut bad: Vec<char> = chars
+            .iter()
+            .copied()
+            .filter(|c| {
+                alphabet.contains(c) || c.to_lowercase().any(|lc| alphabet.contains(&lc))
+            })
+            .collect();
+        if !bad.is_empty() {
+            bad.sort_unstable();
+            return Err(bad);
+        }
+        Ok(Self { chars })
+    }
+
+    /// A markup set with no validation available (no wordlist to check against).
+    pub fn unchecked<I: IntoIterator<Item = char>>(chars: I) -> Self {
+        Self { chars: chars.into_iter().collect() }
+    }
+
+    pub fn contains(&self, c: char) -> bool {
+        self.chars.contains(&c)
+    }
+
+    /// Normalize a token, stripping declared markup as well as non-alphanumerics.
+    pub fn normalize_token(&self, word: &str) -> String {
+        word.trim_matches(|c: char| !c.is_alphanumeric() || self.chars.contains(&c))
+            .to_lowercase()
+    }
+}
+
+/// Like [`payload_tokens`], but strips a declared [`Markup`] set from token edges
+/// first, so format decoration cannot hide an adjacent payload word.
+pub fn payload_tokens_with_markup<F: Fn(&str) -> bool>(
+    text: &str,
+    markup: &Markup,
+    is_payload: F,
+) -> Vec<String> {
+    text.split_whitespace()
+        .map(|w| markup.normalize_token(w))
+        .filter(|w| !w.is_empty() && is_payload(w))
+        .collect()
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // Payload integrity
 // ═══════════════════════════════════════════════════════════════════════
@@ -730,6 +806,48 @@ mod tests {
                 "adjacent {sym} should hide the payload word"
             );
         }
+    }
+
+    #[test]
+    fn declared_markup_rescues_an_adjacent_alphanumeric_symbol() {
+        // The case normalize_token cannot handle: beta is Unicode Ll, so trimming
+        // by category leaves it attached and the payload word is lost. Declaring
+        // it as markup strips it.
+        let wl = ["absorb".to_string(), "victory".to_string()];
+        let markup = Markup::new(['\u{03B2}', '\u{2460}', '\u{25BD}'], &wl).unwrap();
+        let is_payload = |w: &str| w == "absorb";
+
+        assert!(payload_tokens("\u{03B2}absorb", is_payload).is_empty(), "undeclared: lost");
+        assert_eq!(
+            payload_tokens_with_markup("\u{03B2}absorb", &markup, is_payload),
+            vec!["absorb"],
+            "declared: recovered"
+        );
+        assert_eq!(
+            payload_tokens_with_markup("\u{2460}absorb \u{25BD} victory", &markup, is_payload),
+            vec!["absorb"]
+        );
+    }
+
+    #[test]
+    fn markup_rejects_characters_payload_words_use() {
+        let wl = ["absorb".to_string(), "victory".to_string()];
+        // 'e' does not occur, 'a' and 'b' do.
+        assert!(Markup::new(['e'], &wl).is_ok());
+        assert_eq!(Markup::new(['a', 'b', '\u{25BD}'], &wl).unwrap_err(), vec!['a', 'b']);
+        // Case-folded: declaring 'A' would still strip 'a'.
+        assert_eq!(Markup::new(['A'], &wl).unwrap_err(), vec!['A']);
+    }
+
+    #[test]
+    fn markup_leaves_undeclared_text_alone() {
+        let wl = ["absorb".to_string()];
+        let markup = Markup::new(['\u{25BD}'], &wl).unwrap();
+        assert_eq!(markup.normalize_token("Absorb."), "absorb");
+        assert_eq!(markup.normalize_token("\u{25BD}absorb"), "absorb");
+        // A markup char inside a word is not an edge, so the token stays corrupt
+        // and is dropped rather than silently mis-parsed.
+        assert_eq!(markup.normalize_token("ab\u{25BD}sorb"), "ab\u{25BD}sorb");
     }
 
     #[test]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -108,6 +108,83 @@ pub fn hex_encode(bytes: &[u8]) -> String {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
+// Decode-side tokenization
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Normalize a received token the way decoding does: strip non-alphanumeric
+/// characters from both ends, then lowercase.
+///
+/// This is Unicode-aware, because `char::is_alphanumeric` follows Unicode
+/// properties. Symbols drawn from *alphanumeric* categories — circled digits
+/// (`①`), Greek letters (`β`), Roman numerals (`Ⅻ`), superscripts — are therefore
+/// NOT stripped. Whitespace-separated they are harmless (nothing matches them in
+/// a payload wordlist), but placed directly against a word with no separating
+/// space they stop the trim before it reaches the word, so `①absorb` normalizes
+/// to `①absorb` and the payload word is silently lost. Decorative markup around
+/// prose must come from non-alphanumeric symbols.
+pub fn normalize_token(word: &str) -> String {
+    word.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase()
+}
+
+/// Harvest payload words from received text: split on whitespace, normalize each
+/// token, and keep the ones `is_payload` accepts.
+///
+/// This is the canonical decode-side tokenizer — the inverse of embedding payload
+/// words in prose. Cover words are dropped simply by failing the predicate, which
+/// is why payload and cover wordlists must stay disjoint.
+pub fn payload_tokens<F: Fn(&str) -> bool>(text: &str, is_payload: F) -> Vec<String> {
+    text.split_whitespace()
+        .map(|w| normalize_token(w))
+        .filter(|w| !w.is_empty() && is_payload(w))
+        .collect()
+}
+
+/// Count whitespace-separated tokens with any alphanumeric content.
+pub fn alnum_token_count(text: &str) -> usize {
+    text.split_whitespace()
+        .filter(|w| !normalize_token(w).is_empty())
+        .count()
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Payload integrity
+// ═══════════════════════════════════════════════════════════════════════
+
+/// CRC-32 (IEEE 802.3, reflected, polynomial 0xEDB88320).
+///
+/// Computed bitwise so the polynomial is visible as the specification rather
+/// than baked into a lookup table. Used to derive a cover seed from a payload,
+/// so that which prose was chosen carries the payload's checksum (see #76).
+/// This detects transcription damage; it is not a cryptographic digest and
+/// resists no adversary.
+pub fn crc32(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &b in data {
+        crc ^= b as u32;
+        for _ in 0..8 {
+            crc = if crc & 1 != 0 { (crc >> 1) ^ 0xEDB8_8320 } else { crc >> 1 };
+        }
+    }
+    !crc
+}
+
+/// splitmix64 finalizer: scatter a small counter across the whole u64 range so
+/// consecutive counter values map to unrelated cover realizations. Mirrors
+/// `mix64` in `web/glossia-msg.js`.
+pub fn mix64(x: u64) -> u64 {
+    let mut z = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Derive a cover seed from a payload checksum and a fluency counter, so the
+/// choice of cover realization carries the checksum at no length cost.
+pub fn checksum_seed(payload: &[u8], counter: u64) -> u64 {
+    mix64(((crc32(payload) as u64) << 32) | (counter & 0xFFFF_FFFF))
+}
+
+// ═══════════════════════════════════════════════════════════════════════
 // Base64 utilities
 // ═══════════════════════════════════════════════════════════════════════
 
@@ -597,6 +674,80 @@ pub fn encode_str_base_n(s: &str, wordlist: &WordlistTree, codec: &str) -> Resul
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn crc32_known_vector() {
+        // The canonical CRC-32/ISO-HDLC check value for "123456789".
+        assert_eq!(crc32(b"123456789"), 0xCBF4_3926);
+        assert_eq!(crc32(b""), 0);
+    }
+
+    #[test]
+    fn crc32_detects_single_bit_flip() {
+        let a = [0x75u8, 0x1e, 0x76, 0xe8];
+        let mut b = a;
+        b[2] ^= 0x01;
+        assert_ne!(crc32(&a), crc32(&b));
+    }
+
+    #[test]
+    fn checksum_seed_varies_with_payload_and_counter() {
+        let p = b"locking script";
+        assert_ne!(checksum_seed(p, 0), checksum_seed(p, 1));
+        assert_ne!(checksum_seed(p, 0), checksum_seed(b"locking scripts", 0));
+        // Deterministic.
+        assert_eq!(checksum_seed(p, 7), checksum_seed(p, 7));
+    }
+
+    #[test]
+    fn normalize_token_strips_and_lowercases() {
+        assert_eq!(normalize_token("Absorb."), "absorb");
+        assert_eq!(normalize_token("\"quote,\""), "quote");
+        assert_eq!(normalize_token("---"), "");
+    }
+
+    #[test]
+    fn normalize_token_strips_non_alphanumeric_symbols_even_when_adjacent() {
+        // Opcode sigils must come from non-alphanumeric Unicode categories.
+        for sym in ["\u{29C9}", "\u{2317}", "\u{225F}", "\u{2713}", "\u{25BD}", "\u{25B3}"] {
+            assert_eq!(normalize_token(&format!("{sym}absorb")), "absorb", "sym {sym}");
+            assert_eq!(normalize_token(sym), "", "sym {sym} alone");
+        }
+    }
+
+    #[test]
+    fn alphanumeric_symbols_swallow_an_adjacent_payload_word() {
+        // Circled digits, Greek letters and Roman numerals are alphanumeric under
+        // Unicode, so the trim stops at them. Separated by a space they are
+        // harmless; touching a word they hide it. This is why the address format
+        // restricts opcode symbols to non-alphanumeric characters.
+        let is_payload = |w: &str| w == "absorb";
+        for sym in ["\u{2460}", "\u{03B2}", "\u{216B}"] {
+            assert_eq!(payload_tokens(&format!("{sym} absorb"), is_payload), vec!["absorb"]);
+            assert!(
+                payload_tokens(&format!("{sym}absorb"), is_payload).is_empty(),
+                "adjacent {sym} should hide the payload word"
+            );
+        }
+    }
+
+    #[test]
+    fn payload_tokens_drops_cover_and_keeps_order() {
+        let payload: std::collections::HashSet<&str> =
+            ["insect", "victory", "ring"].into_iter().collect();
+        assert_eq!(
+            payload_tokens("Insect may see victory to ring.", |w| payload.contains(w)),
+            vec!["insect", "victory", "ring"]
+        );
+    }
+
+    #[test]
+    fn alnum_token_count_ignores_pure_punctuation() {
+        assert_eq!(alnum_token_count("a b c"), 3);
+        assert_eq!(alnum_token_count("\u{25BD} a b"), 2);
+    }
+
     use super::*;
 
     /// Build a toy wordlist of arbitrary size for testing base-N.

--- a/src/generator/core.rs
+++ b/src/generator/core.rs
@@ -1,5 +1,5 @@
 use rand::{seq::SliceRandom, Rng, SeedableRng};
-use rand::rngs::StdRng;
+use crate::CoverRng;
 use std::collections::{HashMap, HashSet};
 use crate::types::Pos;
 use crate::grammar::{Grammar, SequenceWithProbability};
@@ -926,7 +926,7 @@ pub fn generate_text_best_of_indexed(
     const DENSITY_TOL: f64 = 0.02;
 
     let gen_one = |seed: u64| {
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = CoverRng::seed_from_u64(seed);
         generate_text_with_original_payload(
             &mut rng, lex, payload, original_payload_set, verbose, mode, language,
             grammar_dialect, k_min, k_max, length_mode, delimiter,

--- a/src/generator/core.rs
+++ b/src/generator/core.rs
@@ -1475,10 +1475,14 @@ pub fn generate_text_traced<R: Rng>(
     } else {
         // Body mode: Keep generating sentences until all payload tokens are embedded
         
-        // In merkle mode (when original_payload_set is provided), use segmentation approach
-        // Segment the sequence into chunks ending with 1-2 payload words
+        // Segmented generation: split the payload into chunks ending in 1-2 payload
+        // words and emit a sentence per chunk, rejecting any sentence that embeds
+        // none of them. This is the STANDARD path -- the pipeline always supplies
+        // `original_payload_set` -- not a merkle-only branch. Merkleizing merely
+        // makes the set narrower than `payload`, so validation checks the original
+        // words rather than the interleaved merkle ones.
         if original_payload_set.is_some() {
-            let (t, ps, pl) = generate_text_merkle_segmented(
+            let (t, ps, pl) = generate_text_segmented(
                 rng,
                 lex,
                 payload,
@@ -1886,7 +1890,13 @@ pub fn generate_text_traced<R: Rng>(
 }
 
 /// Generate text using merkle segmentation: segment sequence into chunks ending with 1-2 payload words
-fn generate_text_merkle_segmented<R: Rng>(
+/// Generate prose by segmenting the payload and validating each sentence.
+///
+/// Every sentence must embed at least one word from `original_payload_set`, or it
+/// is discarded and regenerated. Used for all pipeline encodes; when merkleizing,
+/// `payload` also carries merkle words and `original_payload_set` is the narrower
+/// set that validation applies to.
+fn generate_text_segmented<R: Rng>(
     rng: &mut R,
     lex: &Lexicon,
     payload: &[PayloadTok],

--- a/src/generator/core.rs
+++ b/src/generator/core.rs
@@ -893,6 +893,36 @@ pub fn generate_text_best_of(
     length_mode: SentenceLengthMode,
     delimiter: &str,
 ) -> (String, HashSet<String>) {
+    let (text, set, _) = generate_text_best_of_indexed(
+        base_seed, n_candidates, lex, payload, original_payload_set, verbose, mode,
+        language, grammar_dialect, k_min, k_max, length_mode, delimiter,
+    );
+    (text, set)
+}
+
+/// Like [`generate_text_best_of`], but also returns which candidate won — the
+/// offset `k` such that the winning seed was `base_seed + k`.
+///
+/// A verifier that re-derives the base seed (e.g. from a payload checksum) can
+/// only reproduce the rendering if it knows, or can search for, this offset.
+/// Returning it lets an encoder report the counter instead of leaving callers to
+/// rediscover it.
+#[allow(clippy::too_many_arguments)]
+pub fn generate_text_best_of_indexed(
+    base_seed: u64,
+    n_candidates: usize,
+    lex: &Lexicon,
+    payload: &[PayloadTok],
+    original_payload_set: Option<&HashSet<String>>,
+    verbose: bool,
+    mode: GenerationMode,
+    language: &str,
+    grammar_dialect: Option<&str>,
+    k_min: usize,
+    k_max: usize,
+    length_mode: SentenceLengthMode,
+    delimiter: &str,
+) -> (String, HashSet<String>, u64) {
     const DENSITY_TOL: f64 = 0.02;
 
     let gen_one = |seed: u64| {
@@ -906,20 +936,21 @@ pub fn generate_text_best_of(
     let n = n_candidates.max(1);
     let model = lex.semantics();
     if n == 1 || model.is_none() {
-        return gen_one(base_seed);
+        let (text, set) = gen_one(base_seed);
+        return (text, set, 0);
     }
     let model = model.unwrap();
 
     // Generate and score each candidate sequentially. (Candidates are
     // independent and could be parallelized, but the sequence-cache memo makes
     // candidates after the first cheap, so this stays simple for now.)
-    let mut candidates: Vec<(f64, f64, (String, HashSet<String>))> = Vec::with_capacity(n);
+    let mut candidates: Vec<(f64, f64, u64, (String, HashSet<String>))> = Vec::with_capacity(n);
     for k in 0..n {
         let out = gen_one(base_seed.wrapping_add(k as u64));
         let total = out.0.split_whitespace().count().max(1);
         let density = payload.len() as f64 / total as f64;
         let coherence = model.coherence_score(&out.0);
-        candidates.push((density, coherence, out));
+        candidates.push((density, coherence, k as u64, out));
     }
 
     let max_density = candidates.iter().map(|c| c.0).fold(f64::MIN, f64::max);
@@ -928,7 +959,7 @@ pub fn generate_text_best_of(
         .filter(|c| c.0 >= max_density - DENSITY_TOL)
         .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
         .expect("at least one candidate generated");
-    best.2
+    (best.3 .0, best.3 .1, best.2)
 }
 
 /// Generate sentences until all payload tokens are embedded.

--- a/src/generator/core.rs
+++ b/src/generator/core.rs
@@ -551,13 +551,121 @@ pub fn fill_slots<R: Rng>(
     payload: &[PayloadTok],
     payload_i: &mut usize,
     prev_words: &[&str],
-    _expected_first_pos: Option<Pos>,
+    expected_first_pos: Option<Pos>,
     forced_placements: Option<&HashMap<usize, usize>>,
     payload_only_mode: bool,
     prime_constraint_enabled: bool,
     dot_is_punctuation: bool,
     agreement: Option<&crate::generator::agreement::Agreement>,
 ) -> Vec<String> {
+    fill_slots_traced(
+        rng, lex, slots, refinements, payload, payload_i, prev_words, expected_first_pos,
+        forced_placements, payload_only_mode, prime_constraint_enabled, dot_is_punctuation,
+        agreement,
+    )
+    .0
+}
+
+/// The grammatical role a payload word plays relative to a neighbouring verb.
+///
+/// Inferred from the flat POS sequence with the same rule the semantic layer uses
+/// (`semantics.rs`): the nearest noun to a verb's left is its subject, the nearest
+/// to its right its object, bounded by the sentence. This is an approximation of
+/// syntax, not a parse — the grammar is flat, so there is no tree to consult.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Role {
+    Subject,
+    Object,
+}
+
+/// Where a payload word ended up in the generated prose.
+///
+/// Encoding never changes *which* payload words appear or their order, but it does
+/// choose which grammatical slot each one fills — the same word can land as a
+/// subject in one rendering and an object in another. Callers that want to explain
+/// or verify a rendering need that, and it was previously discarded.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Placement {
+    pub word: String,
+    /// Index into the payload word sequence.
+    pub payload_index: usize,
+    /// The POS slot the generator placed it in.
+    pub pos: Pos,
+    /// Index into the whitespace-split output text.
+    pub token_index: usize,
+    /// Zero-based sentence number.
+    pub sentence: usize,
+    /// Subject/object relative to the governing verb, when one is adjacent.
+    pub role: Option<Role>,
+}
+
+/// Assign subject/object roles over one sentence's trace.
+///
+/// For each verb, the nearest noun to its left becomes the subject and the nearest
+/// to its right the object. Nouns are considered whether they hold payload or
+/// cover words, since a cover noun still occupies the argument position.
+fn infer_roles(trace: &[Option<(Pos, Option<usize>)>]) -> Vec<Option<Role>> {
+    let mut roles = vec![None; trace.len()];
+    let pos_at = |i: usize| trace[i].map(|(p, _)| p);
+    for v in 0..trace.len() {
+        if pos_at(v) != Some(Pos::V) {
+            continue;
+        }
+        // subject: nearest noun left, not crossing another verb
+        for i in (0..v).rev() {
+            match pos_at(i) {
+                Some(Pos::V) => break,
+                Some(Pos::N) | Some(Pos::Pron) => {
+                    if roles[i].is_none() {
+                        roles[i] = Some(Role::Subject);
+                    }
+                    break;
+                }
+                _ => {}
+            }
+        }
+        // object: nearest noun right, not crossing another verb
+        for i in (v + 1)..trace.len() {
+            match pos_at(i) {
+                Some(Pos::V) => break,
+                Some(Pos::N) | Some(Pos::Pron) => {
+                    if roles[i].is_none() {
+                        roles[i] = Some(Role::Object);
+                    }
+                    break;
+                }
+                _ => {}
+            }
+        }
+    }
+    roles
+}
+
+/// Like [`fill_slots`], but also reports what each emitted token is.
+///
+/// The trace is index-aligned with the returned words: entry `i` describes token
+/// `i`. `Some((pos, Some(payload_index)))` is a payload word placed in a `pos`
+/// slot, `Some((pos, None))` a cover word, and `None` a token that fills no slot
+/// (a bare sentence-final period). Alignment is maintained at every push site
+/// rather than reconstructed afterwards, so it holds even in the degenerate case
+/// where a sentence opens with punctuation.
+#[allow(clippy::too_many_arguments)]
+pub fn fill_slots_traced<R: Rng>(
+    rng: &mut R,
+    lex: &Lexicon,
+    slots: &[Pos],
+    refinements: &[Option<String>],
+    payload: &[PayloadTok],
+    payload_i: &mut usize,
+    prev_words: &[&str],
+    _expected_first_pos: Option<Pos>,
+    forced_placements: Option<&HashMap<usize, usize>>,
+    payload_only_mode: bool,
+    prime_constraint_enabled: bool,
+    dot_is_punctuation: bool,
+    agreement: Option<&crate::generator::agreement::Agreement>,
+) -> (Vec<String>, Vec<Option<(Pos, Option<usize>)>>) {
+    let mut trace: Vec<Option<(Pos, Option<usize>)>> = Vec::new();
     let mut out: Vec<String> = Vec::new();
     // Slot / refinement of each emitted token in `out` (Dot slots that only
     // append punctuation are not represented). Used by the agreement post-pass.
@@ -577,6 +685,7 @@ pub fn fill_slots<R: Rng>(
                 last.push('.');
             } else {
                 out.push(".".to_string());
+                trace.push(None);
             }
             gov_verb = None; // clause boundary
             continue;
@@ -622,6 +731,7 @@ pub fn fill_slots<R: Rng>(
                 payload[idx].word, ref_tag, i
             );
             out.push(payload[idx].word.clone());
+            trace.push(Some((slot, Some(idx))));
             emitted_slots.push(slot);
             emitted_refs.push(ref_tag.map(|s| s.to_string()));
             used_payload_indices.insert(idx);
@@ -750,6 +860,7 @@ pub fn fill_slots<R: Rng>(
 
         update_gov_verb(&mut gov_verb, slot, &cover_word);
         out.push(cover_word);
+        trace.push(Some((slot, None)));
         emitted_slots.push(slot);
         emitted_refs.push(ref_tag.map(|s| s.to_string()));
     }
@@ -767,7 +878,8 @@ pub fn fill_slots<R: Rng>(
         ag.apply(&emitted_slots, &emitted_refs, &mut out);
     }
 
-    out
+    debug_assert_eq!(trace.len(), out.len(), "trace must stay aligned with emitted tokens");
+    (out, trace)
 }
 
 /// Compute k candidates based on the length mode.
@@ -995,11 +1107,48 @@ pub fn generate_text_with_original_payload<R: Rng>(
     length_mode: SentenceLengthMode,
     delimiter: &str,
 ) -> (String, HashSet<String>) {
+    let (text, set, _) = generate_text_traced(
+        rng, lex, payload, original_payload_set, verbose, mode, language, grammar_dialect,
+        k_min, k_max, length_mode, delimiter,
+    );
+    (text, set)
+}
+
+/// Like [`generate_text_with_original_payload`], but also reports where each
+/// payload word landed — its POS slot, sentence, token position and inferred
+/// subject/object role.
+///
+/// Placement is a property of the *rendering*, not the payload: the same word in
+/// the same position can be a subject in one cover realization and an object in
+/// another. Reseeding the cover (as checksum-seeded encoding does) therefore
+/// reshuffles roles, which makes role change a coarse, memorable signal that a
+/// payload differs — easier for a reader to check than a word-by-word diff.
+#[allow(clippy::too_many_arguments)]
+pub fn generate_text_traced<R: Rng>(
+    rng: &mut R,
+    lex: &Lexicon,
+    payload: &[PayloadTok],
+    original_payload_set: Option<&HashSet<String>>,
+    verbose: bool,
+    mode: GenerationMode,
+    language: &str,
+    grammar_dialect: Option<&str>,
+    k_min: usize,
+    k_max: usize,
+    length_mode: SentenceLengthMode,
+    delimiter: &str,
+) -> (String, HashSet<String>, Vec<Placement>) {
     // Build payload set for highlighting (returned to caller)
     // Note: In merkle mode, this includes Merkle words too, but we check against original_payload_set
     // for sentence validation.
     let payload_set: HashSet<String> = payload.iter().map(|t| t.word.to_lowercase()).collect();
-    
+
+    // Where each payload word lands. Accumulated per sentence with a running token
+    // offset so `token_index` refers to the final joined text.
+    let mut placements: Vec<Placement> = Vec::new();
+    let mut token_offset: usize = 0;
+    let mut sentence_no: usize = 0;
+
     // Use original_payload_set for validation if provided, otherwise use payload_set
     let validation_payload_set: HashSet<String> = original_payload_set
         .map(|s| s.clone())
@@ -1010,7 +1159,8 @@ pub fn generate_text_with_original_payload<R: Rng>(
     if matches!(mode, GenerationMode::PayloadOnly) {
         let words: Vec<String> = payload.iter().map(|tok| tok.word.clone()).collect();
         let text = words.join(delimiter);
-        return (text, payload_set);
+        // Payload-only mode fills no grammatical slots, so there is nothing to report.
+        return (text, payload_set, Vec::new());
     }
 
     let mut words: Vec<String> = Vec::new();
@@ -1228,7 +1378,7 @@ pub fn generate_text_with_original_payload<R: Rng>(
             // Convert prev_words_strings to slice for fill_slots
             let prev_words_refs: Vec<&str> = prev_words_strings.iter().map(|s| s.as_str()).collect();
             let payload_only_mode = matches!(mode, GenerationMode::PayloadOnly);
-            let mut sentence_words = fill_slots(
+            let (mut sentence_words, sentence_trace) = fill_slots_traced(
                 rng,
                 lex,
                 &slots,
@@ -1243,6 +1393,25 @@ pub fn generate_text_with_original_payload<R: Rng>(
                 grammar.dot_is_punctuation(),
                 agreement_ref,
             );
+            // Record where each payload word landed in this sentence.
+            {
+                let roles = infer_roles(&sentence_trace);
+                for (j, entry) in sentence_trace.iter().enumerate() {
+                    if let Some((pos, Some(pidx))) = entry {
+                        placements.push(Placement {
+                            word: payload[*pidx].word.clone(),
+                            payload_index: *pidx,
+                            pos: *pos,
+                            token_index: token_offset + j,
+                            sentence: sentence_no,
+                            role: roles[j],
+                        });
+                    }
+                }
+                token_offset += sentence_trace.len();
+                sentence_no += 1;
+            }
+
 
             // Update current_payload_i to reflect what was actually used
             current_payload_i = temp_payload_i.max(max_forced_idx + 1);
@@ -1309,7 +1478,7 @@ pub fn generate_text_with_original_payload<R: Rng>(
         // In merkle mode (when original_payload_set is provided), use segmentation approach
         // Segment the sequence into chunks ending with 1-2 payload words
         if original_payload_set.is_some() {
-            return generate_text_merkle_segmented(
+            let (t, ps, pl) = generate_text_merkle_segmented(
                 rng,
                 lex,
                 payload,
@@ -1323,6 +1492,7 @@ pub fn generate_text_with_original_payload<R: Rng>(
                 &cache,
                 agreement_ref,
             );
+            return (t, ps, pl);
         }
 
         let mut sentence_count = 0;
@@ -1540,7 +1710,7 @@ pub fn generate_text_with_original_payload<R: Rng>(
         let mut temp_payload_i = (max_forced_idx + 1).max(payload_i_before);
 
         let payload_only_mode = matches!(mode, GenerationMode::PayloadOnly);
-        let mut sentence_words = fill_slots(
+        let (mut sentence_words, sentence_trace) = fill_slots_traced(
             rng,
             lex,
             &slots,
@@ -1555,6 +1725,25 @@ pub fn generate_text_with_original_payload<R: Rng>(
             grammar.dot_is_punctuation(),
             agreement_ref,
         );
+        // Record where each payload word landed in this sentence.
+        {
+            let roles = infer_roles(&sentence_trace);
+            for (j, entry) in sentence_trace.iter().enumerate() {
+                if let Some((pos, Some(pidx))) = entry {
+                    placements.push(Placement {
+                        word: payload[*pidx].word.clone(),
+                        payload_index: *pidx,
+                        pos: *pos,
+                        token_index: token_offset + j,
+                        sentence: sentence_no,
+                        role: roles[j],
+                    });
+                }
+            }
+            token_offset += sentence_trace.len();
+            sentence_no += 1;
+        }
+
 
         // Update payload_i to reflect what was actually used
         payload_i = temp_payload_i.max(max_forced_idx + 1);
@@ -1693,7 +1882,7 @@ pub fn generate_text_with_original_payload<R: Rng>(
 
     // Return unhighlighted text (caller can apply highlighting if needed)
     let text = join_words_with_payload_grammar(&words, &payload_set, &grammar);
-    (text, payload_set)
+    (text, payload_set, placements)
 }
 
 /// Generate text using merkle segmentation: segment sequence into chunks ending with 1-2 payload words
@@ -1710,12 +1899,15 @@ fn generate_text_merkle_segmented<R: Rng>(
     prime_constraint_enabled: bool,
     cache: &SequenceCache,
     agreement: Option<&crate::generator::agreement::Agreement>,
-) -> (String, HashSet<String>) {
+) -> (String, HashSet<String>, Vec<Placement>) {
     use super::utils::normalize_token_for_bip39;
 
     let grammar = get_grammar(GenerationMode::Body, language);
     let payload_set: HashSet<String> = payload.iter().map(|t| t.word.to_lowercase()).collect();
     let mut words: Vec<String> = Vec::new();
+    let mut placements: Vec<Placement> = Vec::new();
+    let mut token_offset: usize = 0;
+    let mut sentence_no: usize = 0;
     let mut segment_start = 0;
     let mut sentence_count = 0;
     // Dynamic limit: at worst 1 payload word per sentence, plus buffer for rejected sentences
@@ -1898,7 +2090,7 @@ fn generate_text_merkle_segmented<R: Rng>(
         
         // Fill slots
         let mut temp_payload_i = payload_i;
-        let mut sentence_words = fill_slots(
+        let (mut sentence_words, sentence_trace) = fill_slots_traced(
             rng,
             lex,
             &slots,
@@ -1942,6 +2134,26 @@ fn generate_text_merkle_segmented<R: Rng>(
                 *first = capitalize(first);
             }
             
+            // Record placements for this sentence. Only accepted sentences count —
+            // rejected ones are regenerated and never reach the output.
+            {
+                let roles = infer_roles(&sentence_trace);
+                for (j, entry) in sentence_trace.iter().enumerate() {
+                    if let Some((pos, Some(pidx))) = entry {
+                        placements.push(Placement {
+                            word: payload[*pidx].word.clone(),
+                            payload_index: *pidx,
+                            pos: *pos,
+                            token_index: token_offset + j,
+                            sentence: sentence_no,
+                            role: roles[j],
+                        });
+                    }
+                }
+                token_offset += sentence_trace.len();
+                sentence_no += 1;
+            }
+
             // Add sentence
             if !words.is_empty() {
                 // Add space between sentences
@@ -1971,7 +2183,7 @@ fn generate_text_merkle_segmented<R: Rng>(
     }
 
     let text = join_words_with_payload_grammar(&words, &payload_set, &grammar);
-    (text, payload_set)
+    (text, payload_set, placements)
 }
 
 #[cfg(test)]

--- a/src/generator/data.rs
+++ b/src/generator/data.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -464,6 +464,68 @@ pub fn load_payload_words(language: &str) -> Result<Vec<String>, String> {
 /// Load payload words for a specific wordlist profile.
 pub fn load_payload_words_for_wordlist(language: &str, wordlist: &str) -> Result<Vec<String>, String> {
     Ok(load_or_build_payload_cache(language, wordlist)?.words.clone())
+}
+
+/// The set of characters that appear in a payload wordlist.
+///
+/// A format that decorates prose with sigils must not choose a character any
+/// payload word uses, or decoding would strip payload content. Reading the
+/// alphabet from the wordlist itself makes that condition checkable rather than
+/// guessed — see [`crate::codec::Markup`].
+pub fn payload_alphabet(language: &str, wordlist: &str) -> Result<BTreeSet<char>, String> {
+    Ok(load_payload_words_for_wordlist(language, wordlist)?
+        .iter()
+        .flat_map(|w| w.chars())
+        .collect())
+}
+
+/// Alphabets for every embedded payload wordlist, keyed `"language/wordlist"`.
+///
+/// Wordlists are append-only, so a list that is safe for a given sigil today can
+/// acquire a colliding character tomorrow. Validating against every shipped
+/// wordlist — not just the one a format currently uses — turns that into a test
+/// failure instead of a silently mis-decoded artifact.
+///
+/// Wordlists that fail to load are skipped rather than propagated, so a single
+/// malformed profile cannot mask collisions in the rest.
+pub fn all_payload_alphabets() -> BTreeMap<String, BTreeSet<char>> {
+    let mut out = BTreeMap::new();
+    for language in get_available_languages() {
+        for wordlist in get_available_wordlists(language) {
+            if let Ok(alphabet) = payload_alphabet(language, &wordlist) {
+                if !alphabet.is_empty() {
+                    out.insert(format!("{language}/{wordlist}"), alphabet);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Every `"language/wordlist"` whose payload alphabet contains one of `chars`.
+///
+/// Returns the offending characters per wordlist, so a format can report exactly
+/// which sigil clashes with which list.
+pub fn markup_collisions<I: IntoIterator<Item = char>>(
+    chars: I,
+) -> BTreeMap<String, Vec<char>> {
+    let chars: Vec<char> = chars.into_iter().collect();
+    let mut out = BTreeMap::new();
+    for (name, alphabet) in all_payload_alphabets() {
+        let hits: Vec<char> = chars
+            .iter()
+            .copied()
+            .filter(|c| {
+                alphabet.contains(c)
+                    || c.to_lowercase().any(|lc| alphabet.contains(&lc))
+                    || c.to_uppercase().any(|uc| alphabet.contains(&uc))
+            })
+            .collect();
+        if !hits.is_empty() {
+            out.insert(name, hits);
+        }
+    }
+    out
 }
 
 /// Inject a scale-derived payload wordlist into the in-memory cache.

--- a/src/generator/data.rs
+++ b/src/generator/data.rs
@@ -76,6 +76,39 @@ pub fn load_semantics(language: &str) -> Option<crate::generator::semantics::Sem
     if std::env::var("GLOSSIA_DISABLE_SEMANTICS").is_ok() {
         return None;
     }
+    load_semantics_uncached(language)
+}
+
+static SEMANTICS_CACHE: OnceLock<Mutex<HashMap<String, Option<Arc<crate::generator::semantics::SemanticModel>>>>> =
+    OnceLock::new();
+
+/// `load_semantics`, memoized and pre-wrapped in the `Arc` the Lexicon wants.
+///
+/// English's semantics.yaml is ~100 KB and was reparsed on every encode — the
+/// single largest fixed cost in the pipeline. The result depends only on the
+/// language, so parse it once.
+///
+/// The env-var escape hatch is deliberately checked *outside* the cache, so
+/// toggling `GLOSSIA_DISABLE_SEMANTICS` still takes effect within a process.
+pub fn load_semantics_cached(
+    language: &str,
+) -> Option<Arc<crate::generator::semantics::SemanticModel>> {
+    #[cfg(not(target_arch = "wasm32"))]
+    if std::env::var("GLOSSIA_DISABLE_SEMANTICS").is_ok() {
+        return None;
+    }
+    let cache = SEMANTICS_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Some(hit) = cache.lock().unwrap().get(language) {
+        return hit.clone();
+    }
+    let model = load_semantics_uncached(language).map(Arc::new);
+    cache.lock().unwrap().insert(language.to_string(), model.clone());
+    model
+}
+
+/// The parse itself, without the env-var check (which `load_semantics_cached`
+/// applies first) — so a cached entry never bakes in the escape hatch's state.
+fn load_semantics_uncached(language: &str) -> Option<crate::generator::semantics::SemanticModel> {
     let content = get_embedded_yaml(&format!("{}/semantics.yaml", language))?;
     match crate::generator::semantics::SemanticModel::from_yaml(content) {
         Ok(model) if !model.is_empty() => Some(model),
@@ -605,9 +638,57 @@ pub fn load_cover_words_by_pos(wordlist_set: &HashSet<String>, language: &str) -
     load_cover_words_by_pos_for_wordlist(wordlist_set, language, default_wordlist(language))
 }
 
+/// The parsed cover vocabulary for a language/wordlist, before any payload filter.
+///
+/// Parsing cover.yaml is the expensive half and depends only on (language,
+/// wordlist); removing payload words from the result is the cheap half and is
+/// the only part that varies per call. Splitting them lets the parse be
+/// memoized, which matters because every encode used to redo it.
+struct CoverIndex {
+    by_pos: HashMap<Pos, Vec<String>>,
+    refined: HashMap<(Pos, String), Vec<String>>,
+}
+
+static COVER_INDEX_CACHE: OnceLock<Mutex<HashMap<String, Arc<CoverIndex>>>> = OnceLock::new();
+
+fn cover_index(language: &str, wordlist: &str) -> Arc<CoverIndex> {
+    let key = format!("{language}/{wordlist}");
+    let cache = COVER_INDEX_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Some(hit) = cache.lock().unwrap().get(&key) {
+        return hit.clone();
+    }
+    let (by_pos, refined) = parse_cover_words(&HashSet::new(), language, wordlist);
+    let idx = Arc::new(CoverIndex { by_pos, refined });
+    cache.lock().unwrap().insert(key, idx.clone());
+    idx
+}
+
 /// Load cover words for a specific wordlist profile.
 /// Returns (by_pos, refined_cover) where refined_cover maps (POS, refinement_tag) -> words.
 pub fn load_cover_words_by_pos_for_wordlist(wordlist_set: &HashSet<String>, language: &str, wordlist: &str) -> (HashMap<Pos, Vec<String>>, HashMap<(Pos, String), Vec<String>>) {
+    let idx = cover_index(language, wordlist);
+    if wordlist_set.is_empty() {
+        return (idx.by_pos.clone(), idx.refined.clone());
+    }
+    // Dropping a word from every bucket is equivalent to never having added it,
+    // which is what the unfiltered parse would have done — including leaving a
+    // POS out entirely rather than mapping it to an empty list, since a present
+    // but empty bucket is not the same thing to the Lexicon.
+    let keep = |words: &Vec<String>| -> Vec<String> {
+        words.iter().filter(|w| !wordlist_set.contains(&w.to_lowercase())).cloned().collect()
+    };
+    let by_pos = idx.by_pos.iter()
+        .map(|(pos, words)| (*pos, keep(words)))
+        .filter(|(_, words)| !words.is_empty())
+        .collect();
+    let refined = idx.refined.iter()
+        .map(|(k, words)| (k.clone(), keep(words)))
+        .filter(|(_, words)| !words.is_empty())
+        .collect();
+    (by_pos, refined)
+}
+
+fn parse_cover_words(wordlist_set: &HashSet<String>, language: &str, wordlist: &str) -> (HashMap<Pos, Vec<String>>, HashMap<(Pos, String), Vec<String>>) {
     let (_, cover_filename) = wordlist_filenames(language, wordlist);
     // Load language-specific POS tag mappings
     let pos_mappings = load_pos_mappings(language);

--- a/src/generator/types.rs
+++ b/src/generator/types.rs
@@ -369,7 +369,7 @@ impl Lexicon {
 mod tests {
     use super::*;
     use rand::SeedableRng;
-    use rand::rngs::StdRng;
+    use crate::CoverRng;
 
     /// Build a minimal Lexicon for testing with refined cover words.
     fn test_lexicon_with_refinements() -> Lexicon {
@@ -405,7 +405,7 @@ mod tests {
     #[test]
     fn test_pick_cover_refined_with_matching_tag() {
         let lex = test_lexicon_with_refinements();
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
 
         // Pick from Det[def] -- should return one of "the", "its", "our"
         let def_words: HashSet<&str> = ["the", "its", "our"].iter().copied().collect();
@@ -422,7 +422,7 @@ mod tests {
     #[test]
     fn test_pick_cover_refined_cop_sg() {
         let lex = test_lexicon_with_refinements();
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
 
         // Cop[sg] should produce "is"
         for _ in 0..10 {
@@ -434,7 +434,7 @@ mod tests {
     #[test]
     fn test_pick_cover_refined_cop_pl() {
         let lex = test_lexicon_with_refinements();
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
 
         // Cop[pl] should produce "are"
         for _ in 0..10 {
@@ -446,7 +446,7 @@ mod tests {
     #[test]
     fn test_pick_cover_refined_fallback_no_refinement() {
         let lex = test_lexicon_with_refinements();
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
 
         // No refinement tag -> falls back to unrefined pick_cover
         let word = lex.pick_cover_refined(&mut rng, Pos::Det, None, &[]);
@@ -457,7 +457,7 @@ mod tests {
     #[test]
     fn test_pick_cover_refined_fallback_unknown_tag() {
         let lex = test_lexicon_with_refinements();
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
 
         // Unknown refinement tag -> no matching bucket -> falls back to pick_cover
         let word = lex.pick_cover_refined(&mut rng, Pos::Det, Some("nonexistent"), &[]);
@@ -467,7 +467,7 @@ mod tests {
     #[test]
     fn test_pick_cover_refined_recent_exclusion() {
         let lex = test_lexicon_with_refinements();
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
 
         // Exclude "the" and "its" from recent -- should return "our"
         let word = lex.pick_cover_refined(&mut rng, Pos::Det, Some("def"), &["the", "its"]);
@@ -477,7 +477,7 @@ mod tests {
     #[test]
     fn test_pick_cover_refined_exhaustion_fallback() {
         let lex = test_lexicon_with_refinements();
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
 
         // Cop[sg] only has "is". Mark "is" as recent.
         // The refined selection first tries with recent filter (empty), then drops the recent
@@ -491,7 +491,7 @@ mod tests {
     #[test]
     fn test_pick_cover_refined_all_exhausted_final_fallback() {
         let lex = test_lexicon_with_refinements();
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
 
         // Mark ALL Cop words as recent
         let word = lex.pick_cover_refined(&mut rng, Pos::Cop, Some("sg"), &["is", "are"]);
@@ -512,7 +512,7 @@ mod tests {
         let wordlist_set: HashSet<String> = HashSet::new();
         let lex = Lexicon::new(payload_set, wordlist_set)
             .with_words(Pos::N, &["user"]);
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
 
         let word = lex.pick_cover(&mut rng, Pos::Adv, &[]);
         assert_eq!(word, "", "Should return empty string when no words for POS");
@@ -521,7 +521,7 @@ mod tests {
     #[test]
     fn test_pick_cover_refined_indef_det() {
         let lex = test_lexicon_with_refinements();
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = CoverRng::seed_from_u64(42);
 
         // Det[indef] should return "a" or "an"
         let indef_words: HashSet<&str> = ["a", "an"].iter().copied().collect();

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,5 +1,6 @@
 use rand::Rng;
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex, OnceLock};
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
 use crate::types::{Pos, Sym};
@@ -129,6 +130,27 @@ impl DialectConfig {
     /// is derived at runtime from the base chromatic payload filtered by the scale pattern.
     /// The derived words are injected into the in-memory cache so that subsequent
     /// `load_payload_words_for_wordlist()` calls find them transparently.
+    /// `from_language_dialect`, memoized. Same reasoning as the grammar cache it
+    /// sits on top of: the config is a pure function of (language, dialect), and
+    /// building one reparses the grammar plus its wordlist and scale references.
+    ///
+    /// A scale-defining dialect is deliberately NOT cached: constructing it
+    /// injects derived payload words into the wordlist cache as a side effect,
+    /// and skipping the construction would skip the injection.
+    pub fn from_language_dialect_cached(language: &str, dialect: &str) -> Result<Arc<DialectConfig>, String> {
+        static CACHE: OnceLock<Mutex<HashMap<String, Arc<DialectConfig>>>> = OnceLock::new();
+        let key = format!("{language}/{dialect}");
+        let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        if let Some(hit) = cache.lock().unwrap().get(&key) {
+            return Ok(hit.clone());
+        }
+        let built = Arc::new(Self::from_language_dialect(language, dialect).map_err(|e| e.to_string())?);
+        if built.scale.is_none() {
+            cache.lock().unwrap().insert(key, built.clone());
+        }
+        Ok(built)
+    }
+
     pub fn from_language_dialect(language: &str, dialect: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let grammar = Grammar::from_language_dialect(language, dialect)?;
         let (mut payload_wl, payload_language, cover_wl) = Self::parse_wordlist_refs(language, dialect);
@@ -748,6 +770,28 @@ impl Grammar {
             }
         }
         (" ".to_string(), true, None, None, "bitpack".to_string(), None)
+    }
+
+    /// `from_language_dialect`, memoized.
+    ///
+    /// Parsing grammar.yaml and rebuilding the CFG rules depends only on
+    /// (language, dialect) and produces the same grammar every time, yet the
+    /// encode path did it twice per call. Callers that only read from the
+    /// grammar should prefer this; the owned constructor stays for callers that
+    /// mutate one. Errors are returned as strings because the underlying
+    /// `Box<dyn Error>` is neither `Send` nor cacheable.
+    pub fn from_language_dialect_cached(language: &str, dialect: &str) -> Result<Arc<Grammar>, String> {
+        static CACHE: OnceLock<Mutex<HashMap<String, Result<Arc<Grammar>, String>>>> = OnceLock::new();
+        let key = format!("{language}/{dialect}");
+        let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        if let Some(hit) = cache.lock().unwrap().get(&key) {
+            return hit.clone();
+        }
+        let built = Grammar::from_language_dialect(language, dialect)
+            .map(Arc::new)
+            .map_err(|e| e.to_string());
+        cache.lock().unwrap().insert(key, built.clone());
+        built
     }
 
     /// Load grammar from language and dialect (YAML-only)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,23 @@ pub mod image_codec;
 pub mod wasm;
 
 // Re-export key types
+/// The RNG that realizes cover words and sentence shape.
+///
+/// Pinned to ChaCha12 explicitly rather than inherited from `rand::rngs::StdRng`.
+/// `StdRng` is documented as not reproducible across `rand` major versions -- its
+/// algorithm may change -- which makes it unsafe for anything whose *output* is
+/// part of a format. Verification by re-render (#76) is exactly that: a dependency
+/// bump could otherwise change every rendering while the version field still
+/// claimed compatibility.
+///
+/// `StdRng` in rand 0.8 *is* ChaCha12, and `seed_from_u64` is a `SeedableRng`
+/// provided method, so this pin is byte-identical to the previous behaviour --
+/// verified over raw stream, `gen::<f64>()` and `choose()` draws. ChaCha20 is a
+/// different stream and would invalidate every existing encoding; do not
+/// "upgrade" to it. The RNG never selects payload words, only cover, so its
+/// strength is not a security property.
+pub type CoverRng = rand_chacha::ChaCha12Rng;
+
 pub use types::Pos;
 pub use grammar::{Grammar, SequenceWithProbability, DialectConfig};
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1430,6 +1430,93 @@ fn prepare_payload(
 /// dialect config, and cover wordlist, then constructing the Lexicon), so it is
 /// factored out of [`generate_prose_for_zone`] and reused across best-of-N
 /// candidates rather than rebuilt per sample.
+/// Like [`encode_words_into_language`], but also reports where each payload word
+/// landed: its POS slot, sentence, token position and inferred subject/object role.
+///
+/// Which slot a word fills is a property of the rendering, not the payload — the
+/// same word can be a subject in one cover realization and an object in another.
+pub fn encode_words_into_language_traced(
+    words: &[String],
+    language: &str,
+    wordlist: &str,
+    dialect: &str,
+    seed: u64,
+    best_of: usize,
+) -> Result<(String, u64, Vec<crate::generator::core::Placement>), PipelineError> {
+    let (toks, payload_word_set, gen) = prepare_words_encode(words, language, wordlist, dialect)?;
+    let (text, counter) = {
+        let (t, _s, c) = crate::generator::core::generate_text_best_of_indexed(
+            seed, best_of.max(1), &gen.lex, &toks, Some(&payload_word_set), false,
+            gen.mode, language, Some(dialect), gen.k_min, gen.k_max, gen.length_mode, " ",
+        );
+        (t, c)
+    };
+    let mut rng = <crate::CoverRng as rand::SeedableRng>::seed_from_u64(seed.wrapping_add(counter));
+    let (_t2, _s2, placements) = crate::generator::core::generate_text_traced(
+        &mut rng, &gen.lex, &toks, Some(&payload_word_set), false, gen.mode, language,
+        Some(dialect), gen.k_min, gen.k_max, gen.length_mode, " ",
+    );
+    debug_assert_eq!(_t2, text, "traced re-render must match the selected candidate");
+    Ok((text, counter, placements))
+}
+
+/// Shared setup for the word-driven encode entry points.
+fn prepare_words_encode(
+    words: &[String],
+    language: &str,
+    wordlist: &str,
+    dialect: &str,
+) -> Result<(Vec<PayloadTok>, HashSet<String>, ZoneGenerator), PipelineError> {
+    let wordlist = resolve_wordlist_name(language, wordlist);
+    let payload_words = crate::generator::data::load_payload_words_for_wordlist(language, &wordlist)
+        .map_err(PipelineError::EncodeError)?;
+    let payload_word_set: HashSet<String> =
+        payload_words.iter().map(|w| w.to_lowercase()).collect();
+
+    let grammar = Grammar::from_language_dialect(language, dialect)
+        .map_err(|e| PipelineError::EncodeError(format!("Grammar error: {}", e)))?;
+    let is_cs_grammar = !grammar.dot_is_punctuation();
+    let pos_mapping = if is_cs_grammar {
+        HashMap::new()
+    } else {
+        build_pos_mapping_for_wordlist(language, &wordlist).map_err(PipelineError::EncodeError)?
+    };
+    // Reject words the payload wordlist does not contain. A word with no allowed
+    // POS cannot be placed in any slot, and the generator would simply omit it —
+    // yielding prose that decodes to a different payload than the caller supplied.
+    // Failing loudly here is the difference between a caught mistake and a wrong
+    // address.
+    let unknown: Vec<String> = words
+        .iter()
+        .filter(|w| !payload_word_set.contains(&w.to_lowercase()))
+        .cloned()
+        .collect();
+    if !unknown.is_empty() {
+        return Err(PipelineError::EncodeError(format!(
+            "not payload words in {}/{}: {}",
+            language,
+            wordlist,
+            unknown.join(", ")
+        )));
+    }
+
+    let toks: Vec<PayloadTok> = words
+        .iter()
+        .map(|word| {
+            let allowed = if is_cs_grammar {
+                vec![Pos::N]
+            } else {
+                pos_mapping.get(&word.to_lowercase()).cloned().unwrap_or_default()
+            };
+            PayloadTok::new(word.clone(), &allowed)
+        })
+        .collect();
+    let gen = build_zone_generator(
+        toks.len(), language, dialect, &payload_word_set, false, None, None, None, None,
+    )?;
+    Ok((toks, payload_word_set, gen))
+}
+
 /// Wrap already-chosen payload words in cover prose.
 ///
 /// This is the second stage of encoding on its own, for callers that produced the
@@ -1448,50 +1535,10 @@ pub fn encode_words_into_language(
     seed: u64,
     best_of: usize,
 ) -> Result<(String, u64), PipelineError> {
-    let wordlist = resolve_wordlist_name(language, wordlist);
-    let payload_words = crate::generator::data::load_payload_words_for_wordlist(language, &wordlist)
-        .map_err(PipelineError::EncodeError)?;
-    let payload_word_set: HashSet<String> =
-        payload_words.iter().map(|w| w.to_lowercase()).collect();
-
-    let grammar = Grammar::from_language_dialect(language, dialect)
-        .map_err(|e| PipelineError::EncodeError(format!("Grammar error: {}", e)))?;
-    let is_cs_grammar = !grammar.dot_is_punctuation();
-    let pos_mapping = if is_cs_grammar {
-        HashMap::new()
-    } else {
-        build_pos_mapping_for_wordlist(language, &wordlist).map_err(PipelineError::EncodeError)?
-    };
-
-    let payload_toks: Vec<PayloadTok> = words
-        .iter()
-        .map(|word| {
-            let allowed = if is_cs_grammar {
-                vec![Pos::N]
-            } else {
-                pos_mapping.get(&word.to_lowercase()).cloned().unwrap_or_default()
-            };
-            PayloadTok::new(word.clone(), &allowed)
-        })
-        .collect();
-
-    let gen = build_zone_generator(
-        payload_toks.len(), language, dialect, &payload_word_set, false, None, None, None, None,
-    )?;
+    let (toks, payload_word_set, gen) = prepare_words_encode(words, language, wordlist, dialect)?;
     let (text, _set, counter) = crate::generator::core::generate_text_best_of_indexed(
-        seed,
-        best_of.max(1),
-        &gen.lex,
-        &payload_toks,
-        Some(&payload_word_set),
-        false,
-        gen.mode,
-        language,
-        Some(dialect),
-        gen.k_min,
-        gen.k_max,
-        gen.length_mode,
-        " ",
+        seed, best_of.max(1), &gen.lex, &toks, Some(&payload_word_set), false,
+        gen.mode, language, Some(dialect), gen.k_min, gen.k_max, gen.length_mode, " ",
     );
     Ok((text, counter))
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -25,7 +25,7 @@ use std::fmt;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use rand::SeedableRng;
-use rand::rngs::StdRng;
+use crate::CoverRng;
 
 use crate::codec::{self, DataMode};
 use crate::generator::data::{
@@ -1626,7 +1626,7 @@ fn generate_prose_for_zone(
         cover_override, length_mode, k_min_override, k_max_override,
     )?;
 
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = CoverRng::seed_from_u64(seed);
     let (text, payload_set) = generate_text_with_original_payload(
         &mut rng,
         &gen.lex,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1061,11 +1061,7 @@ impl Pipeline {
             .map_err(|e| PipelineError::DecodeError(e))?;
         let payload_tree = WordlistTree::new(payload_words);
 
-        let words: Vec<String> = input
-            .split_whitespace()
-            .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
-            .filter(|w| !w.is_empty() && payload_tree.contains(w))
-            .collect();
+        let words: Vec<String> = codec::payload_tokens(input, |w| payload_tree.contains(w));
 
         if words.is_empty() {
             return Err(PipelineError::DecodeError(
@@ -1434,19 +1430,95 @@ fn prepare_payload(
 /// dialect config, and cover wordlist, then constructing the Lexicon), so it is
 /// factored out of [`generate_prose_for_zone`] and reused across best-of-N
 /// candidates rather than rebuilt per sample.
-struct ZoneGenerator {
-    lex: Lexicon,
-    mode: GenerationMode,
-    k_min: usize,
-    k_max: usize,
-    length_mode: SentenceLengthMode,
+/// Wrap already-chosen payload words in cover prose.
+///
+/// This is the second stage of encoding on its own, for callers that produced the
+/// payload words themselves rather than letting the grammar's codec do it — a
+/// fixed-length format that packs its own bits, for instance. The words are
+/// embedded in the order given and never altered, so decoding is unchanged.
+///
+/// With `best_of > 1` the densest / most coherent of `best_of` consecutive seeds
+/// is returned; the second element is the winning offset `k`, so the exact
+/// rendering can be reproduced from `seed + k`.
+pub fn encode_words_into_language(
+    words: &[String],
+    language: &str,
+    wordlist: &str,
+    dialect: &str,
+    seed: u64,
+    best_of: usize,
+) -> Result<(String, u64), PipelineError> {
+    let wordlist = resolve_wordlist_name(language, wordlist);
+    let payload_words = crate::generator::data::load_payload_words_for_wordlist(language, &wordlist)
+        .map_err(PipelineError::EncodeError)?;
+    let payload_word_set: HashSet<String> =
+        payload_words.iter().map(|w| w.to_lowercase()).collect();
+
+    let grammar = Grammar::from_language_dialect(language, dialect)
+        .map_err(|e| PipelineError::EncodeError(format!("Grammar error: {}", e)))?;
+    let is_cs_grammar = !grammar.dot_is_punctuation();
+    let pos_mapping = if is_cs_grammar {
+        HashMap::new()
+    } else {
+        build_pos_mapping_for_wordlist(language, &wordlist).map_err(PipelineError::EncodeError)?
+    };
+
+    let payload_toks: Vec<PayloadTok> = words
+        .iter()
+        .map(|word| {
+            let allowed = if is_cs_grammar {
+                vec![Pos::N]
+            } else {
+                pos_mapping.get(&word.to_lowercase()).cloned().unwrap_or_default()
+            };
+            PayloadTok::new(word.clone(), &allowed)
+        })
+        .collect();
+
+    let gen = build_zone_generator(
+        payload_toks.len(), language, dialect, &payload_word_set, false, None, None, None, None,
+    )?;
+    let (text, _set, counter) = crate::generator::core::generate_text_best_of_indexed(
+        seed,
+        best_of.max(1),
+        &gen.lex,
+        &payload_toks,
+        Some(&payload_word_set),
+        false,
+        gen.mode,
+        language,
+        Some(dialect),
+        gen.k_min,
+        gen.k_max,
+        gen.length_mode,
+        " ",
+    );
+    Ok((text, counter))
+}
+
+/// The deterministic half of encoding: everything needed to wrap payload words in
+/// cover prose, with no payload and no RNG involved.
+///
+/// Encoding is two composable stages — map bytes to payload words
+/// ([`crate::codec::encode_base_n`]), then insert cover words around them
+/// ([`crate::generator::core::generate_text_with_original_payload`]). This struct
+/// is the seam: build it once for a language/dialect, then drive it with whatever
+/// payload words you like. Callers that pack their own bits (a fixed-length
+/// address format, say) need that seam, because the byte-oriented entry points
+/// apply the grammar's own codec.
+pub struct ZoneGenerator {
+    pub lex: Lexicon,
+    pub mode: GenerationMode,
+    pub k_min: usize,
+    pub k_max: usize,
+    pub length_mode: SentenceLengthMode,
 }
 
 /// Shared first phase of zone generation: load the grammar/dialect config, build
 /// the cover Lexicon (attaching a semantic model when the language ships one), and
 /// derive the sentence-length parameters. Deterministic — it does not touch the
 /// RNG — so single-shot and best-of-N generation share identical setup.
-fn build_zone_generator(
+pub fn build_zone_generator(
     zone_len: usize,
     language: &str,
     dialect: &str,
@@ -2106,10 +2178,7 @@ fn decode_extracted_words(
 /// payload words, the input carries no cover words (see
 /// [`decode_extracted_words`]).
 fn alnum_token_count(text: &str) -> usize {
-    text.split_whitespace()
-        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
-        .filter(|w| !w.is_empty())
-        .count()
+    codec::alnum_token_count(text)
 }
 
 /// Internal decode with separate grammar language and payload language.
@@ -2186,10 +2255,7 @@ fn decode_from_language_with_payload_lang(
             .collect()
     } else {
         // Standard: whitespace-delimited, filter against payload wordlist.
-        text.split_whitespace()
-            .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
-            .filter(|w| payload_tree.contains(w))
-            .collect()
+        codec::payload_tokens(text, |w| payload_tree.contains(w))
     };
 
     if extracted.is_empty() {
@@ -2287,10 +2353,7 @@ fn decode_from_language_rich_with_payload_lang(
             })
             .collect()
     } else {
-        text.split_whitespace()
-            .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
-            .filter(|w| payload_tree.contains(w))
-            .collect()
+        codec::payload_tokens(text, |w| payload_tree.contains(w))
     };
 
     if extracted.is_empty() {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1121,7 +1121,7 @@ impl Pipeline {
 
         // Resolve payload_language: if the dialect declares a different language
         // for payload files, pass it so decode loads the correct wordlist.
-        let payload_lang = DialectConfig::from_language_dialect(language, dialect)
+        let payload_lang = DialectConfig::from_language_dialect_cached(language, dialect)
             .map(|c| c.payload_language().to_string())
             .unwrap_or_else(|_| language.to_string());
 
@@ -1237,7 +1237,7 @@ impl Pipeline {
         }
 
         // Resolve payload_language for cross-language payload (e.g., sig_bip39).
-        let payload_lang = DialectConfig::from_language_dialect(language, dialect)
+        let payload_lang = DialectConfig::from_language_dialect_cached(language, dialect)
             .map(|c| c.payload_language().to_string())
             .unwrap_or_else(|_| language.to_string());
 
@@ -1313,7 +1313,7 @@ fn apply_wordlist_modifier(
 fn resolve_dialect_wordlist(ep: Endpoint) -> Endpoint {
     match ep {
         Endpoint::Language { ref language, ref wordlist, ref dialect } if wordlist == "default" => {
-            if let Ok(config) = DialectConfig::from_language_dialect(language, dialect) {
+            if let Ok(config) = DialectConfig::from_language_dialect_cached(language, dialect) {
                 let declared = config.payload_wordlist();
                 if declared != "default" {
                     return Endpoint::Language {
@@ -1359,7 +1359,7 @@ fn prepare_payload(
     // Resolve payload_language: if the dialect declares a different language for
     // payload files (e.g., sig_bip39 uses English BIP39 words inside CS grammar),
     // load from that language's directory instead.
-    let payload_lang = DialectConfig::from_language_dialect(language, dialect)
+    let payload_lang = DialectConfig::from_language_dialect_cached(language, dialect)
         .map(|c| c.payload_language().to_string())
         .unwrap_or_else(|_| language.to_string());
 
@@ -1473,7 +1473,7 @@ fn prepare_words_encode(
     let payload_word_set: HashSet<String> =
         payload_words.iter().map(|w| w.to_lowercase()).collect();
 
-    let grammar = Grammar::from_language_dialect(language, dialect)
+    let grammar = Grammar::from_language_dialect_cached(language, dialect)
         .map_err(|e| PipelineError::EncodeError(format!("Grammar error: {}", e)))?;
     let is_cs_grammar = !grammar.dot_is_punctuation();
     let pos_mapping = if is_cs_grammar {
@@ -1576,10 +1576,13 @@ pub fn build_zone_generator(
     k_min_override: Option<usize>,
     k_max_override: Option<usize>,
 ) -> Result<ZoneGenerator, PipelineError> {
-    // 1. Load grammar and dialect config.
-    let dialect_config = crate::grammar::DialectConfig::from_language_dialect(language, dialect)
+    // 1. Load grammar and dialect config. Both are pure functions of
+    // (language, dialect) and both parse YAML, so both are memoized — this is
+    // called once per encode, and best-of-N plus a verifier's repair search make
+    // that a lot of encodes.
+    let dialect_config = crate::grammar::DialectConfig::from_language_dialect_cached(language, dialect)
         .map_err(|e| PipelineError::EncodeError(format!("Dialect config error: {}", e)))?;
-    let grammar = Grammar::from_language_dialect(language, dialect)
+    let grammar = Grammar::from_language_dialect_cached(language, dialect)
         .map_err(|e| PipelineError::EncodeError(format!("Grammar error: {}", e)))?;
 
     // 2. Build Lexicon (cover words).
@@ -1616,8 +1619,8 @@ pub fn build_zone_generator(
     // Optional semantic model: softly biases sentence planning toward coherent
     // verb-argument pairings. Absent for languages without a semantics.yaml, in
     // which case planning is unchanged. Never affects payload order or decoding.
-    if let Some(model) = crate::generator::data::load_semantics(language) {
-        lex = lex.with_semantics(std::sync::Arc::new(model));
+    if let Some(model) = crate::generator::data::load_semantics_cached(language) {
+        lex = lex.with_semantics(model);
     }
 
     // 3. Grammar-derived sentence parameters.
@@ -1998,7 +2001,7 @@ pub fn encode_into_language_best_of(
     // Best-of ranks candidates by semantic coherence, so with no model (or a
     // single candidate) there is nothing to select over — this is exactly a plain
     // single encode.
-    if n == 1 || crate::generator::data::load_semantics(language).is_none() {
+    if n == 1 || crate::generator::data::load_semantics_cached(language).is_none() {
         return encode_into_language(
             input, language, wordlist, dialect, forced_data_mode, base_seed, verbose,
             cover_override, length_mode, k_min_override, k_max_override,
@@ -2083,7 +2086,7 @@ fn encode_into_language_best_of_via_pipeline(
     // in exchange for higher coherence. Small: density stays primary.
     const DENSITY_TOL: f64 = 0.02;
 
-    let model = crate::generator::data::load_semantics(language)
+    let model = crate::generator::data::load_semantics_cached(language)
         .expect("caller ensures a semantic model exists for best-of selection");
 
     let mut candidates: Vec<(f64, f64, (String, HashSet<String>, Vec<String>, DataMode))> =

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::prelude::*;
 use rand::SeedableRng;
-use rand::rngs::StdRng;
+use crate::CoverRng;
 use std::collections::HashSet;
 
 use crate::generator::data::{
@@ -164,7 +164,7 @@ fn encode_inner(
             Some(grammar_dialect), k_min, k_max, SentenceLengthMode::Natural, " ",
         )
     } else {
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = CoverRng::seed_from_u64(seed);
         generate_text_with_original_payload(
             &mut rng, &lex, &payload_toks, None, false, mode, language,
             Some(grammar_dialect), k_min, k_max, SentenceLengthMode::Natural, " ",
@@ -297,7 +297,7 @@ fn random_words_inner(
         return Err("Wordlist is empty".to_string());
     }
 
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = CoverRng::seed_from_u64(seed);
     let mut selected = Vec::with_capacity(count);
     for _ in 0..count {
         use rand::seq::SliceRandom;
@@ -785,7 +785,7 @@ fn encode_characters_inner(
     };
 
     // 7. Generate text
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = CoverRng::seed_from_u64(seed);
     let mode = if grammar_dialect.starts_with("subject") {
         GenerationMode::Subject
     } else {
@@ -1196,7 +1196,7 @@ fn encode_random_words_inner(
     }
 
     // 2. Generate random words
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = CoverRng::seed_from_u64(seed);
     let mut selected_words = Vec::with_capacity(count);
     for _ in 0..count {
         use rand::seq::SliceRandom;
@@ -1249,7 +1249,7 @@ fn encode_random_words_inner(
     };
 
     // 7. Generate text with the same RNG (re-seeded for text generation)
-    let mut text_rng = StdRng::seed_from_u64(seed.wrapping_add(1)); // Offset seed for text gen
+    let mut text_rng = CoverRng::seed_from_u64(seed.wrapping_add(1)); // Offset seed for text gen
     let mode = if grammar_dialect.starts_with("subject") {
         GenerationMode::Subject
     } else {
@@ -1419,7 +1419,7 @@ fn encode_raw_base_n_inner(
             Some(dialect), k_min, k_max, SentenceLengthMode::Natural, " ",
         )
     } else {
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = CoverRng::seed_from_u64(seed);
         generate_text_with_original_payload(
             &mut rng, &lex, &payload_toks, None, false, mode, language,
             Some(dialect), k_min, k_max, SentenceLengthMode::Natural, " ",

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -93,7 +93,7 @@ fn encode_inner(
     };
 
     // 1. Load grammar
-    let grammar = crate::grammar::Grammar::from_language_dialect(language, grammar_dialect)
+    let grammar = crate::grammar::Grammar::from_language_dialect_cached(language, grammar_dialect)
         .map_err(|e| format!("Grammar error: {}", e))?;
 
     // 2. Load payload wordlist and build WordlistTree
@@ -132,8 +132,8 @@ fn encode_inner(
     // Attach the semantic model so planning (and best-of-N) can bias toward
     // coherent verb-argument pairings. Absent for non-English; never affects
     // decoding.
-    if let Some(model) = crate::generator::data::load_semantics(language) {
-        lex = lex.with_semantics(std::sync::Arc::new(model));
+    if let Some(model) = crate::generator::data::load_semantics_cached(language) {
+        lex = lex.with_semantics(model);
     }
 
     // Derive k_min/k_max from the grammar's structure and payload size.
@@ -214,7 +214,7 @@ fn decode_inner(text: &str, language: &str, wordlist: &str) -> Result<String, St
     let payload_tree = WordlistTree::new(payload_words.clone());
 
     // 2. Load grammar to check payload separator
-    let grammar = crate::grammar::Grammar::from_language_dialect(language, "body")
+    let grammar = crate::grammar::Grammar::from_language_dialect_cached(language, "body")
         .map_err(|e| format!("Grammar error: {}", e))?;
     let payload_separator = grammar.payload_separator();
 
@@ -406,7 +406,7 @@ pub fn get_all_dialects() -> String {
 
         for dialect_name in dialects {
             // Try to load the dialect config to get wordlist info
-            match DialectConfig::from_language_dialect(lang, &dialect_name) {
+            match DialectConfig::from_language_dialect_cached(lang, &dialect_name) {
                 Ok(config) => {
                     let payload_wl = config.payload_wordlist();
                     let cover_wl = config.cover_wordlist();
@@ -772,7 +772,7 @@ fn encode_characters_inner(
     lex = lex.with_refined_cover(refined_cover);
 
     // 6. Load grammar and compute dynamic k_min/k_max
-    let grammar = crate::grammar::Grammar::from_language_dialect(language, grammar_dialect)
+    let grammar = crate::grammar::Grammar::from_language_dialect_cached(language, grammar_dialect)
         .map_err(|e| format!("Grammar error: {}", e))?;
 
     let min_k = grammar.min_sentence_length().unwrap_or(5);
@@ -1231,12 +1231,12 @@ fn encode_random_words_inner(
     // Attach the semantic model so planning (and best-of-N) can bias toward
     // coherent verb-argument pairings. Absent for non-English; never affects
     // decoding.
-    if let Some(model) = crate::generator::data::load_semantics(language) {
-        lex = lex.with_semantics(std::sync::Arc::new(model));
+    if let Some(model) = crate::generator::data::load_semantics_cached(language) {
+        lex = lex.with_semantics(model);
     }
 
     // 6. Load grammar and compute dynamic k_min/k_max
-    let grammar = crate::grammar::Grammar::from_language_dialect(language, grammar_dialect)
+    let grammar = crate::grammar::Grammar::from_language_dialect_cached(language, grammar_dialect)
         .map_err(|e| format!("Grammar error: {}", e))?;
 
     let min_k = grammar.min_sentence_length().unwrap_or(5);
@@ -1326,7 +1326,7 @@ pub fn get_cover_words(language: &str, wordlist: &str) -> String {
         Ok(w) => w.iter().map(|x| x.to_lowercase()).collect(),
         Err(e) => return serde_json::json!({ "error": e }).to_string(),
     };
-    let cover_wl = match crate::grammar::DialectConfig::from_language_dialect(language, "body") {
+    let cover_wl = match crate::grammar::DialectConfig::from_language_dialect_cached(language, "body") {
         Ok(cfg) => cfg.cover_wordlist().to_string(),
         Err(_) => "cover".to_string(),
     };
@@ -1509,11 +1509,11 @@ fn encode_raw_base_n_inner(
     // Attach the semantic model so planning (and best-of-N) can bias toward
     // coherent verb-argument pairings. Absent for non-English; never affects
     // decoding.
-    if let Some(model) = crate::generator::data::load_semantics(language) {
-        lex = lex.with_semantics(std::sync::Arc::new(model));
+    if let Some(model) = crate::generator::data::load_semantics_cached(language) {
+        lex = lex.with_semantics(model);
     }
 
-    let grammar = crate::grammar::Grammar::from_language_dialect(language, dialect)
+    let grammar = crate::grammar::Grammar::from_language_dialect_cached(language, dialect)
         .map_err(|e| format!("Grammar error: {}", e))?;
 
     let min_k = grammar.min_sentence_length().unwrap_or(5);

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -246,10 +246,7 @@ fn decode_inner(text: &str, language: &str, wordlist: &str) -> Result<String, St
             .collect()
     } else {
         // Standard whitespace-delimited extraction
-        text.split_whitespace()
-            .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
-            .filter(|w| payload_tree.contains(w))
-            .collect()
+        codec::payload_tokens(text, |w| payload_tree.contains(w))
     };
 
     if extracted.is_empty() {
@@ -1481,11 +1478,7 @@ fn decode_raw_base_n_inner(text: &str, language: &str, wordlist: &str, expected_
     let payload_set: HashSet<String> = payload_words.iter().map(|w| w.to_lowercase()).collect();
 
     // 3. Extract payload words (filter out cover/prose words)
-    let extracted: Vec<String> = text
-        .split_whitespace()
-        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase())
-        .filter(|w| payload_set.contains(w))
-        .collect();
+    let extracted: Vec<String> = codec::payload_tokens(text, |w| payload_set.contains(w));
 
     if extracted.is_empty() {
         return Ok(serde_json::json!({

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 use rand::SeedableRng;
 use crate::CoverRng;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
 use crate::generator::data::{
     get_available_languages, get_available_wordlists,
@@ -1310,6 +1310,36 @@ pub fn get_payload_words(language: &str, wordlist: &str) -> String {
         }),
         Err(e) => serde_json::json!({ "error": e }).to_string(),
     }
+}
+
+/// The cover vocabulary for a language/dialect, as a flat JSON array.
+///
+/// The complement of `get_payload_words`, and what a verifier needs to tell a
+/// misspelling from a word that was never payload. Locating a damaged payload
+/// word means searching tokens that are not in the payload wordlist — but the
+/// connective prose is not in it either, so without this list every cover word
+/// is a candidate site and the search does an order of magnitude more work than
+/// the question requires.
+#[wasm_bindgen]
+pub fn get_cover_words(language: &str, wordlist: &str) -> String {
+    let payload: HashSet<String> = match load_payload_words_for_wordlist(language, wordlist) {
+        Ok(w) => w.iter().map(|x| x.to_lowercase()).collect(),
+        Err(e) => return serde_json::json!({ "error": e }).to_string(),
+    };
+    let cover_wl = match crate::grammar::DialectConfig::from_language_dialect(language, "body") {
+        Ok(cfg) => cfg.cover_wordlist().to_string(),
+        Err(_) => "cover".to_string(),
+    };
+    let (by_pos, refined) = load_cover_words_by_pos_for_wordlist(&payload, language, &cover_wl);
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    for words in by_pos.into_values() {
+        out.extend(words.into_iter().map(|w| w.to_lowercase()));
+    }
+    for words in refined.into_values() {
+        out.extend(words.into_iter().map(|w| w.to_lowercase()));
+    }
+    serde_json::to_string(&out.into_iter().collect::<Vec<_>>())
+        .unwrap_or_else(|e| serde_json::json!({ "error": e.to_string() }).to_string())
 }
 
 /// Wrap caller-supplied payload words in cover prose, reporting where each landed.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1297,6 +1297,93 @@ fn encode_random_words_inner(
 
 /// Encode raw bytes (hex or base64 input) into base-N payload words.
 ///
+/// The payload wordlist itself, as a JSON array in index order.
+///
+/// Needed by callers that pack their own bits: the index of a word IS its value,
+/// so a format doing its own bit-packing needs the mapping. Returns `{ error }` on
+/// an unknown language/wordlist.
+#[wasm_bindgen]
+pub fn get_payload_words(language: &str, wordlist: &str) -> String {
+    match load_payload_words_for_wordlist(language, wordlist) {
+        Ok(words) => serde_json::to_string(&words).unwrap_or_else(|e| {
+            serde_json::json!({ "error": e.to_string() }).to_string()
+        }),
+        Err(e) => serde_json::json!({ "error": e }).to_string(),
+    }
+}
+
+/// Wrap caller-supplied payload words in cover prose, reporting where each landed.
+///
+/// For formats that pack their own bits — a fixed-length address that carries a
+/// header in the bit-packing slack, say — where the byte-oriented entries cannot
+/// express the packing. `words_json` is a JSON array of payload words, embedded in
+/// the order given.
+///
+/// Returns JSON `{ encoded_text, counter, placements: [{ word, payload_index, pos,
+/// token_index, sentence, role }] }`, or `{ error }` if any word is not in the
+/// payload wordlist (which would otherwise be silently dropped).
+#[wasm_bindgen]
+pub fn encode_words(
+    words_json: &str,
+    language: &str,
+    wordlist: &str,
+    dialect: &str,
+    seed: u64,
+    best_of: usize,
+) -> String {
+    let words: Vec<String> = match serde_json::from_str(words_json) {
+        Ok(w) => w,
+        Err(e) => return serde_json::json!({ "error": format!("bad words JSON: {e}") }).to_string(),
+    };
+    match crate::pipeline::encode_words_into_language_traced(
+        &words, language, wordlist, dialect, seed, best_of.max(1),
+    ) {
+        Err(e) => serde_json::json!({ "error": format!("{e:?}") }).to_string(),
+        Ok((text, counter, placements)) => {
+            let ps: Vec<serde_json::Value> = placements
+                .iter()
+                .map(|p| {
+                    serde_json::json!({
+                        "word": p.word,
+                        "payload_index": p.payload_index,
+                        "pos": p.pos.to_string(),
+                        "token_index": p.token_index,
+                        "sentence": p.sentence,
+                        "role": match p.role {
+                            Some(crate::generator::core::Role::Subject) => "subject",
+                            Some(crate::generator::core::Role::Object) => "object",
+                            None => "",
+                        },
+                    })
+                })
+                .collect();
+            serde_json::json!({
+                "encoded_text": text,
+                "counter": counter,
+                "placements": ps,
+            })
+            .to_string()
+        }
+    }
+}
+
+/// Derive a cover seed from a payload checksum, so the choice of prose carries the
+/// checksum. `hex` is the exact byte string the checksum covers.
+///
+/// Exposed so browsers and the Rust core agree bit-for-bit rather than
+/// reimplementing CRC-32 and splitmix64 in JavaScript.
+#[wasm_bindgen]
+pub fn checksum_seed_for(hex: &str, counter: u64) -> u64 {
+    let bytes = codec::hex_decode(hex).unwrap_or_default();
+    codec::checksum_seed(&bytes, counter)
+}
+
+/// CRC-32 of a hex byte string, for display alongside an artifact.
+#[wasm_bindgen]
+pub fn payload_crc32(hex: &str) -> u32 {
+    codec::crc32(&codec::hex_decode(hex).unwrap_or_default())
+}
+
 /// If `dialect` is empty, returns space-joined bare payload words.
 /// If `dialect` is provided (e.g., "body"), wraps the payload words in prose.
 ///

--- a/tests/cover_words_export.rs
+++ b/tests/cover_words_export.rs
@@ -1,0 +1,69 @@
+//! The WASM `get_cover_words` export is the complement of `get_payload_words`,
+//! and a verifier uses it to tell "this token is connective prose" from "this
+//! token is a mangled address word". The export itself is wasm32-only, but the
+//! property it depends on is not: the two vocabularies have to be disjoint and
+//! the cover list has to be populated. An empty list silently degrades the
+//! locate-a-misspelling search back to trying every token; an overlapping one
+//! makes it skip a real payload word.
+
+use glossia::generator::data::{load_cover_words_by_pos_for_wordlist, load_payload_words_for_wordlist};
+use std::collections::{BTreeSet, HashSet};
+
+/// Exactly what the export flattens: every cover word for a language/wordlist.
+fn cover(language: &str, wordlist: &str) -> BTreeSet<String> {
+    let payload: HashSet<String> = load_payload_words_for_wordlist(language, wordlist)
+        .unwrap()
+        .iter()
+        .map(|w| w.to_lowercase())
+        .collect();
+    let (by_pos, refined) = load_cover_words_by_pos_for_wordlist(&payload, language, "cover");
+    let mut out = BTreeSet::new();
+    for words in by_pos.into_values() {
+        out.extend(words.into_iter().map(|w| w.to_lowercase()));
+    }
+    for words in refined.into_values() {
+        out.extend(words.into_iter().map(|w| w.to_lowercase()));
+    }
+    out
+}
+
+#[test]
+fn cover_vocabulary_is_populated() {
+    let c = cover("english", "bip39");
+    assert!(c.len() > 50, "english cover vocabulary is only {} words", c.len());
+}
+
+#[test]
+fn cover_and_payload_are_disjoint() {
+    let payload: HashSet<String> = load_payload_words_for_wordlist("english", "bip39")
+        .unwrap()
+        .iter()
+        .map(|w| w.to_lowercase())
+        .collect();
+    let overlap: Vec<String> = cover("english", "bip39")
+        .into_iter()
+        .filter(|w| payload.contains(w))
+        .collect();
+    assert!(overlap.is_empty(), "cover words also in the payload wordlist: {overlap:?}");
+}
+
+#[test]
+fn the_prose_of_a_real_encode_is_covered_by_the_two_vocabularies() {
+    // The point of the export: every word of a rendering is either payload or
+    // cover, so a token in neither set is a transcription error and nothing
+    // else. If this ever fails, the search would treat honest prose as damage.
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+    let words: Vec<String> = (0..15).map(|i| wl[i * 137].clone()).collect();
+    let (text, _) =
+        glossia::pipeline::encode_words_into_language(&words, "english", "default", "body", 7, 4)
+            .expect("encode");
+
+    let payload: HashSet<String> = wl.iter().map(|w| w.to_lowercase()).collect();
+    let cover_set = cover("english", "bip39");
+    let unknown: Vec<String> = text
+        .split_whitespace()
+        .map(glossia::codec::normalize_token)
+        .filter(|t| !t.is_empty() && !payload.contains(t) && !cover_set.contains(t))
+        .collect();
+    assert!(unknown.is_empty(), "rendered words in neither vocabulary: {unknown:?}");
+}

--- a/tests/markup_collisions.rs
+++ b/tests/markup_collisions.rs
@@ -1,0 +1,75 @@
+//! Guard the prose-address sigil set against every shipped payload wordlist (#76).
+//!
+//! A format that decorates prose with symbols must not use a character any payload
+//! word uses. Wordlists are append-only, so a sigil that is safe today can be
+//! invalidated by a later addition — checking against every embedded wordlist turns
+//! that into a test failure rather than a mis-decoded address.
+
+use glossia::codec::{payload_tokens_with_markup, Markup};
+use glossia::generator::data::{
+    all_payload_alphabets, load_payload_words_for_wordlist, markup_collisions, payload_alphabet,
+};
+
+/// The opcode sigils used by the prose address format.
+const SIGILS: [char; 8] = [
+    '\u{29C9}', // ⧉  OP_DUP
+    '\u{2317}', // ⌗  OP_HASH160
+    '\u{225F}', // ≟  OP_EQUALVERIFY
+    '\u{2713}', // ✓  OP_CHECKSIG
+    '\u{2A75}', // ⩵  OP_EQUAL
+    '\u{25BD}', // ▽  witness v0
+    '\u{25B3}', // △  witness v1
+    '\u{03B2}', // β  difficulty mark (letter-like: safe only because declared)
+];
+
+#[test]
+fn address_sigils_collide_with_no_shipped_payload_wordlist() {
+    let collisions = markup_collisions(SIGILS);
+    assert!(
+        collisions.is_empty(),
+        "prose-address sigils collide with payload wordlists: {collisions:?}"
+    );
+}
+
+#[test]
+fn ascii_punctuation_is_not_safe_as_markup() {
+    // cs/ascii7 uses all 95 printable ASCII characters and cs/base64 includes '=',
+    // so "non-alphanumeric" is not a sufficient safety condition — the reason
+    // Markup validates against the wordlist instead of against Unicode category.
+    for c in ['=', '-', '.', '_', '/', '+'] {
+        assert!(
+            !markup_collisions([c]).is_empty(),
+            "{c:?} should be reported as colliding with some payload wordlist"
+        );
+    }
+}
+
+#[test]
+fn every_shipped_wordlist_reports_an_alphabet() {
+    let alphabets = all_payload_alphabets();
+    assert!(alphabets.len() >= 10, "expected many wordlists, got {}", alphabets.len());
+    for (name, alphabet) in &alphabets {
+        assert!(!alphabet.is_empty(), "{name} has an empty alphabet");
+    }
+}
+
+#[test]
+fn bip39_alphabet_is_plain_lowercase_latin() {
+    let alphabet = payload_alphabet("english", "bip39").expect("bip39 alphabet");
+    let expected: std::collections::BTreeSet<char> = ('a'..='z').collect();
+    assert_eq!(alphabet, expected);
+}
+
+#[test]
+fn declared_sigils_survive_a_real_encode_flush_against_a_payload_word() {
+    let wl = load_payload_words_for_wordlist("english", "bip39").expect("wordlist");
+    let markup = Markup::new(SIGILS, &wl).expect("sigils validate against bip39");
+    let set: std::collections::HashSet<String> = wl.iter().map(|w| w.to_lowercase()).collect();
+
+    // Every sigil placed directly against a payload word, no separating space.
+    for sigil in SIGILS {
+        let text = format!("{sigil}absorb {sigil}victory");
+        let got = payload_tokens_with_markup(&text, &markup, |w| set.contains(w));
+        assert_eq!(got, vec!["absorb", "victory"], "sigil {sigil:?} hid a payload word");
+    }
+}

--- a/tests/markup_collisions.rs
+++ b/tests/markup_collisions.rs
@@ -10,25 +10,52 @@ use glossia::generator::data::{
     all_payload_alphabets, load_payload_words_for_wordlist, markup_collisions, payload_alphabet,
 };
 
-/// The opcode sigils used by the prose address format.
-const SIGILS: [char; 8] = [
-    '\u{29C9}', // ⧉  OP_DUP
-    '\u{2317}', // ⌗  OP_HASH160
-    '\u{225F}', // ≟  OP_EQUALVERIFY
-    '\u{2713}', // ✓  OP_CHECKSIG
-    '\u{2A75}', // ⩵  OP_EQUAL
-    '\u{25BD}', // ▽  witness v0
-    '\u{25B3}', // △  witness v1
-    '\u{03B2}', // β  difficulty mark (letter-like: safe only because declared)
+/// The opcode glyphs the prose address format uses, taken from the Book of
+/// Bitcoin notation (`btc-prose.js` OPCODE_SYMBOLS) rather than invented here.
+///
+/// Two of them are the reason `Markup` exists. U+24EA and U+2460 are Unicode
+/// category `No` — alphanumeric — so `normalize_token` does NOT strip them, and
+/// flush against a payload word they would hide it. They are safe only because
+/// the format declares them.
+const SIGILS: [char; 7] = [
+    '\u{29C9}', // ⧉ OP_DUP
+    '\u{2316}', // ⌖ OP_HASH160
+    '\u{2261}', // ≡ OP_EQUALVERIFY
+    '\u{2207}', // ∇ OP_CHECKSIG
+    '=',         // OP_EQUAL
+    '\u{24EA}', // ⓪ OP_0
+    '\u{2460}', // ① OP_1
 ];
 
 #[test]
-fn address_sigils_collide_with_no_shipped_payload_wordlist() {
+fn sigils_are_valid_markup_for_the_wordlist_the_format_uses() {
+    // The address format encodes against english/bip39, whose alphabet is a-z.
+    // Every glyph must be outside it, or decoding would strip payload content.
+    let wl = load_payload_words_for_wordlist("english", "bip39").expect("wordlist");
+    Markup::new(SIGILS, &wl).expect("BoB notation must validate against bip39");
+}
+
+#[test]
+fn the_notation_is_not_portable_to_every_wordlist() {
+    // Not a defect — a boundary worth pinning. OP_EQUAL is '=', which is a PAYLOAD
+    // character in cs/base64 and cs/ascii7 (the latter uses all 95 printable
+    // ASCII). So this notation is safe for the wordlist this format uses, and is
+    // NOT automatically safe elsewhere. Reusing it against a CS wordlist needs a
+    // different glyph for OP_EQUAL.
     let collisions = markup_collisions(SIGILS);
+    let names: Vec<&str> = collisions.keys().map(|k| k.as_str()).collect();
     assert!(
-        collisions.is_empty(),
-        "prose-address sigils collide with payload wordlists: {collisions:?}"
+        names.iter().any(|n| n.starts_with("cs/")),
+        "expected the ASCII '=' glyph to collide with a cs wordlist, got {names:?}"
     );
+    for (name, chars) in &collisions {
+        assert_eq!(
+            chars,
+            &vec!['='],
+            "{name}: only OP_EQUAL's '=' should collide; a new clash means the \
+             notation or a wordlist changed"
+        );
+    }
 }
 
 #[test]

--- a/tests/placements.rs
+++ b/tests/placements.rs
@@ -1,0 +1,160 @@
+//! Payload word placements reported by the encoder (#76).
+//!
+//! The generator chooses which grammatical slot each payload word fills. These
+//! tests verify the reported placement actually describes the emitted text —
+//! index alignment is the part that would fail silently if it were wrong.
+
+use glossia::codec::normalize_token;
+use glossia::generator::core::{Placement, Role};
+use glossia::pipeline::{encode_words_into_language, encode_words_into_language_traced};
+
+fn payload() -> Vec<String> {
+    "insect victory ring creek bonus health logic mirror elevator abandon"
+        .split(' ')
+        .map(String::from)
+        .collect()
+}
+
+fn trace(seed: u64) -> (String, Vec<Placement>) {
+    let (text, _c, p) =
+        encode_words_into_language_traced(&payload(), "english", "default", "body", seed, 1)
+            .expect("encode");
+    (text, p)
+}
+
+#[test]
+fn traced_encode_returns_the_same_text_as_untraced() {
+    for seed in [1u64, 42, 9999] {
+        let (a, _) = encode_words_into_language(&payload(), "english", "default", "body", seed, 1)
+            .expect("encode");
+        let (b, _c, _p) =
+            encode_words_into_language_traced(&payload(), "english", "default", "body", seed, 1)
+                .expect("encode");
+        assert_eq!(a, b, "traced and untraced diverged at seed {seed}");
+    }
+}
+
+#[test]
+fn every_payload_word_is_placed_exactly_once_in_order() {
+    for seed in [1u64, 42, 9999] {
+        let (_text, p) = trace(seed);
+        let words = payload();
+        assert_eq!(p.len(), words.len(), "seed {seed}: expected one placement per payload word");
+        for (i, pl) in p.iter().enumerate() {
+            assert_eq!(pl.payload_index, i, "seed {seed}: placements out of order");
+            assert_eq!(pl.word, words[i], "seed {seed}: wrong word at index {i}");
+        }
+    }
+}
+
+#[test]
+fn token_index_points_at_the_word_in_the_emitted_text() {
+    // The alignment claim. If this is wrong, every downstream use is wrong.
+    for seed in [1u64, 42, 9999, 123456] {
+        let (text, p) = trace(seed);
+        let toks: Vec<&str> = text.split_whitespace().collect();
+        for pl in &p {
+            assert!(
+                pl.token_index < toks.len(),
+                "seed {seed}: token_index {} out of range ({} tokens)",
+                pl.token_index,
+                toks.len()
+            );
+            assert_eq!(
+                normalize_token(toks[pl.token_index]),
+                pl.word.to_lowercase(),
+                "seed {seed}: token {} is {:?}, placement claims {:?}",
+                pl.token_index,
+                toks[pl.token_index],
+                pl.word
+            );
+        }
+    }
+}
+
+#[test]
+fn sentence_numbers_are_monotonic_and_match_the_text() {
+    for seed in [1u64, 42, 9999] {
+        let (text, p) = trace(seed);
+        let toks: Vec<&str> = text.split_whitespace().collect();
+        let mut prev = 0;
+        for pl in &p {
+            assert!(pl.sentence >= prev, "seed {seed}: sentence numbers went backwards");
+            prev = pl.sentence;
+            // Count sentence boundaries before this token in the text.
+            let ends = toks[..pl.token_index].iter().filter(|w| w.ends_with('.')).count();
+            assert_eq!(
+                ends, pl.sentence,
+                "seed {seed}: {:?} claims sentence {} but {} sentences end before it",
+                pl.word, pl.sentence, ends
+            );
+        }
+    }
+}
+
+#[test]
+fn roles_are_only_assigned_to_nominal_slots() {
+    use glossia::Pos;
+    for seed in [1u64, 42, 9999] {
+        let (_text, p) = trace(seed);
+        for pl in &p {
+            if pl.role.is_some() {
+                assert!(
+                    matches!(pl.pos, Pos::N | Pos::Pron),
+                    "seed {seed}: {:?} has role {:?} but POS {:?}",
+                    pl.word, pl.role, pl.pos
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn reseeding_reassigns_roles_for_the_same_payload() {
+    // The property that makes role change a usable signal: identical payload,
+    // different cover seed, different grammatical roles.
+    let mut seen: Vec<Vec<Option<Role>>> = Vec::new();
+    for seed in [1u64, 42, 9999, 123456, 777] {
+        let (_text, p) = trace(seed);
+        seen.push(p.iter().map(|x| x.role).collect());
+    }
+    assert!(
+        seen.windows(2).any(|w| w[0] != w[1]),
+        "role assignment never changed across seeds — not a usable signal"
+    );
+}
+
+#[test]
+fn non_payload_words_are_rejected_rather_than_silently_dropped() {
+    // "map" is an English COVER word, not a BIP39 payload word. It has no allowed
+    // POS, so the generator cannot place it and would omit it — producing prose
+    // that decodes to a different payload than the caller passed in.
+    let mut words = payload();
+    words.insert(3, "map".to_string());
+    let err = encode_words_into_language(&words, "english", "default", "body", 1, 1)
+        .expect_err("a non-payload word must be rejected");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("map"), "error should name the offending word: {msg}");
+
+    // And the traced entry point must reject it identically.
+    assert!(
+        encode_words_into_language_traced(&words, "english", "default", "body", 1, 1).is_err(),
+        "traced entry point must validate too"
+    );
+}
+
+#[test]
+fn placements_account_for_every_word_that_reaches_the_text() {
+    // Cross-check against the decoder: what the tracer reports and what a decoder
+    // harvests must be the same words in the same order.
+    use glossia::codec::payload_tokens;
+    use glossia::generator::data::load_payload_words_for_wordlist;
+    let wl = load_payload_words_for_wordlist("english", "bip39").unwrap();
+    let set: std::collections::HashSet<String> = wl.iter().map(|w| w.to_lowercase()).collect();
+    for seed in [1u64, 42, 9999, 5, 777] {
+        let (text, p) = trace(seed);
+        let harvested = payload_tokens(&text, |w| set.contains(w));
+        let traced: Vec<String> = p.iter().map(|x| x.word.to_lowercase()).collect();
+        assert_eq!(harvested, traced, "seed {seed}: tracer and decoder disagree");
+    }
+}

--- a/tests/rng_pinning.rs
+++ b/tests/rng_pinning.rs
@@ -1,0 +1,57 @@
+//! The cover RNG is pinned to ChaCha12 rather than inherited from `StdRng` (#76).
+//!
+//! `StdRng`'s algorithm may change across `rand` major versions, which would
+//! silently change every rendering — fatal for verification by re-render. These
+//! tests pin the choice and document why ChaCha20 is not an upgrade.
+
+use glossia::CoverRng;
+use rand::{seq::SliceRandom, Rng, SeedableRng};
+use rand_chacha::{ChaCha12Rng, ChaCha20Rng};
+
+#[test]
+fn cover_rng_is_chacha12_and_matches_the_previous_stdrng_stream() {
+    let pool: Vec<&str> = "aid ban bed bet bit cap cop cow cut die dig".split(' ').collect();
+    for seed in [0u64, 1, 42, 12345, u64::MAX] {
+        let mut pinned = CoverRng::seed_from_u64(seed);
+        let mut std_equivalent = rand::rngs::StdRng::seed_from_u64(seed);
+
+        // Raw stream plus the exact draw shapes the generator uses.
+        let a: Vec<u64> = (0..8).map(|_| pinned.gen::<u64>()).collect();
+        let b: Vec<u64> = (0..8).map(|_| std_equivalent.gen::<u64>()).collect();
+        assert_eq!(a, b, "stream diverged at seed {seed}");
+
+        let fa: Vec<f64> = (0..4).map(|_| pinned.gen::<f64>()).collect();
+        let fb: Vec<f64> = (0..4).map(|_| std_equivalent.gen::<f64>()).collect();
+        assert_eq!(fa, fb, "gen::<f64>() diverged at seed {seed}");
+
+        let ca: Vec<&str> = (0..4).map(|_| *pool.choose(&mut pinned).unwrap()).collect();
+        let cb: Vec<&str> = (0..4).map(|_| *pool.choose(&mut std_equivalent).unwrap()).collect();
+        assert_eq!(ca, cb, "choose() diverged at seed {seed}");
+    }
+}
+
+#[test]
+fn chacha20_is_a_different_stream_and_must_not_be_substituted() {
+    // Guards against a well-meaning "upgrade": ChaCha20 would re-render every
+    // existing artifact differently. The RNG picks cover words only, never
+    // payload, so extra rounds buy no security here.
+    let mut twelve = ChaCha12Rng::seed_from_u64(42);
+    let mut twenty = ChaCha20Rng::seed_from_u64(42);
+    let a: Vec<u64> = (0..8).map(|_| twelve.gen::<u64>()).collect();
+    let b: Vec<u64> = (0..8).map(|_| twenty.gen::<u64>()).collect();
+    assert_ne!(a, b);
+}
+
+#[test]
+fn pinned_rng_reproduces_a_known_encoding() {
+    // A fixed seed must keep producing the same prose across dependency bumps.
+    let words: Vec<String> = "insect victory ring".split(' ').map(String::from).collect();
+    let (a, _) = glossia::pipeline::encode_words_into_language(
+        &words, "english", "default", "body", 99, 1,
+    ).expect("encode");
+    let (b, _) = glossia::pipeline::encode_words_into_language(
+        &words, "english", "default", "body", 99, 1,
+    ).expect("encode");
+    assert_eq!(a, b, "same seed must give same prose");
+    assert!(a.to_lowercase().contains("insect"), "payload word missing: {a}");
+}

--- a/web/index.html
+++ b/web/index.html
@@ -898,6 +898,17 @@ footer a:hover { text-decoration: underline; }
         .addr-repair { max-width: 720px; margin: 0.7rem auto 0; text-align: center;
           font-size: 0.76rem; line-height: 1.6; color: var(--text-dim); }
         .addr-repair strong { color: var(--accent); font-family: var(--font-mono); }
+        .tok-spell { text-decoration: underline wavy var(--error); text-underline-offset: 3px;
+          text-decoration-thickness: 1.5px; cursor: help; }
+        .tok-grammar { text-decoration: underline wavy var(--blue); text-underline-offset: 3px;
+          text-decoration-thickness: 1.5px; cursor: help; }
+        .addr-headline { margin-bottom: 0.4rem; }
+        .addr-suggest { list-style: none; padding: 0; margin: 0.4rem 0 0; text-align: left;
+          display: inline-block; font-size: 0.75rem; }
+        .addr-suggest li { margin: 0.25rem 0; font-family: var(--font-mono); }
+        .addr-suggest strong { color: var(--accent); }
+        .addr-suggest em { color: var(--text-dim); font-style: normal; font-family: var(--font-sans); }
+        .addr-foot { margin-top: 0.4rem; font-size: 0.7rem; opacity: 0.8; }
         mark.addr-bad { background: rgba(239,68,68,0.16); color: var(--error);
           border-bottom: 1px solid rgba(239,68,68,0.5); border-radius: 2px; padding: 0 1px; }
         .addr-cover { color: var(--text-dim); }
@@ -1101,6 +1112,17 @@ footer a:hover { text-decoration: underline; }
             different paragraph. Verification re-renders the address you decoded and compares:
             only the true bytes reproduce this exact wording. That costs no extra words, because
             the information rides in <em>which</em> prose was chosen rather than in any word's value.</p>
+            <p>Errors are reported the way a word processor does. An address word that is wrong or
+            not in the vocabulary gets a <span class="tok-spell">red spelling underline</span>; a
+            connective word that disagrees with what the address calls for gets a
+            <span class="tok-grammar">blue grammar underline</span>. The split is real rather than
+            cosmetic: an address word is either off the vocabulary or the wrong entry in it, while a
+            connective word is the wrong choice in an otherwise well-formed sentence.</p>
+            <p>Unlike an ordinary spell checker, a suggestion here is <strong>confirmed, not
+            guessed</strong>. Substituting the candidate and re-rendering either reproduces the
+            received wording or it does not &mdash; so the checker can say &ldquo;this is the word
+            that was meant&rdquo; rather than &ldquo;this is a word that looks similar&rdquo;. It is
+            still shown as a proposal and never applied.</p>
             <p>Try the damage buttons. A fumbled connective word still yields the right address but
             can no longer self-verify. A mistyped <em>address</em> word decodes to a different
             address &mdash; caught only by the wording. A lost word is caught by the word count,
@@ -2452,6 +2474,18 @@ function addrDamages() {
       },
     },
     {
+      label: 'misspell an address word',
+      why: 'The word leaves the vocabulary entirely, so it reads as a misspelling — and the checksum can confirm which word was meant.',
+      apply: () => {
+        const t = [...toks];
+        const w = mid.word;
+        // drop a middle letter: almost always leaves the wordlist
+        const bad = w.slice(0, Math.floor(w.length / 2)) + w.slice(Math.floor(w.length / 2) + 1);
+        t[mid.token_index] = addrSwapIn(t[mid.token_index], bad);
+        return t.join(' ');
+      },
+    },
+    {
       label: 'lose a word',
       why: 'A fixed-length address has a fixed word count, so a dropped word is caught before anything is decoded.',
       apply: () => { const t = [...toks]; t.splice(places[1].token_index, 1); return t.join(' '); },
@@ -2501,52 +2535,145 @@ function addrApplyDamage(i) {
 // Show WHERE the text disagrees with its own re-render, and — when the payload
 // itself is wrong — what single correction would explain it. Corrections are
 // surfaced as proposals and never applied: the search is not always unique.
+// Error reporting modelled on a word processor: payload words get SPELL errors
+// (red), cover words get GRAMMAR errors (blue). The two damage classes really do
+// behave that way — a payload word is either off the vocabulary or the wrong
+// entry in it, while a cover word is the wrong choice in a well-formed sentence.
+//
+// It is stronger than an ordinary spell checker in one respect: a suggestion is
+// not merely ranked by likelihood, it is CONFIRMED. Substituting the candidate
+// and re-rendering either reproduces the received text or it does not.
+const SPELL = 'spell', GRAMMAR = 'grammar';
+
+/// Analyse an artifact and return per-token annotations.
+/// { kind, suggest, note } keyed by token index; empty map means clean.
+function addrCheck(artifact, nBytes) {
+  const toks = artifact.split(/\s+/).filter(Boolean);
+  const core = t => [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('')
+                          .replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '').toLowerCase();
+  const marks = new Map();
+  const harvested = [];
+  const harvestIdx = [];
+  toks.forEach((t, i) => { const c = core(t); if (c && addrIndex.has(c)) { harvested.push(c); harvestIdx.push(i); } });
+
+  const expected = (nBytes * 8 + addrHeaderBits(nBytes)) / ADDR_BPW;
+
+  // ── too few address words: one has been mangled OFF the vocabulary ────
+  // That is a misspelling in the strict sense — the word is not in the
+  // dictionary at all — so look for a nearby dictionary word that restores the
+  // count AND explains the wording.
+  if (harvested.length < expected) {
+    for (let i = 0; i < toks.length; i++) {
+      const c = core(toks[i]);
+      if (!c || addrIndex.has(c)) continue;
+      for (const cand of addrEdit1(c)) {
+        const trial = toks.slice();
+        trial[i] = addrSwapIn(toks[i], cand);
+        const r = addrRead(trial.join(' '), nBytes);
+        if (r.verdict === 'verified') {
+          marks.set(i, { kind: SPELL, suggest: cand,
+            note: `not an address word; “${cand}” restores the address and matches the wording` });
+          return { marks, verdict: 'repairable' };
+        }
+      }
+    }
+    return { marks, verdict: 'short' };
+  }
+  if (harvested.length > expected) return { marks, verdict: 'long' };
+
+  // ── right count: compare against the re-render ────────────────────────
+  const program = addrUnpack(harvested, nBytes);
+  if (!program) return { marks, verdict: 'undecodable' };
+  const { bad } = addrDiffAgainstRerender(artifact, program);
+  if (bad.size === 0) return { marks, verdict: 'clean' };
+
+  const payloadPositions = new Set(harvestIdx);
+  const rr = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)),
+    'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
+  const expectedToks = rr.error ? [] : rr.encoded_text.split(/\s+/).filter(Boolean);
+
+  // Map diff indices (which count prose tokens) back to artifact token indices.
+  const proseIdx = toks.map((t, i) => core(t) ? i : -1).filter(i => i >= 0);
+
+  // If every address word is intact, the disagreement is cover-only: grammar.
+  const payloadBad = [...bad].some(k => payloadPositions.has(proseIdx[k]));
+  if (!payloadBad) {
+    for (const k of bad) {
+      const i = proseIdx[k];
+      if (i === undefined) continue;
+      marks.set(i, { kind: GRAMMAR, suggest: expectedToks[k],
+        note: expectedToks[k] ? `the address calls for “${expectedToks[k]}” here` : 'unexpected word' });
+    }
+    return { marks, verdict: 'cover-damage' };
+  }
+
+  // Otherwise an address word is wrong. The cover disagreement is a CONSEQUENCE,
+  // not a second fault, so flag only the address word — marking 25 cover words
+  // would be technically true and useless.
+  const hits = addrProposeRepairs(artifact, addrPack(program));
+  if (hits.length === 1) {
+    marks.set(harvestIdx[hits[0].index], { kind: SPELL, suggest: hits[0].to,
+      note: `wrong address word; “${hits[0].to}” explains this wording` });
+    return { marks, verdict: 'repairable' };
+  }
+  for (const i of harvestIdx) marks.set(i, { kind: SPELL, suggest: null, note: 'an address word here is wrong' });
+  return { marks, verdict: hits.length ? 'ambiguous' : 'unlocatable' };
+}
+
 function addrPaintDamage(box, artifact, res) {
   const note = document.getElementById('addr-repair');
-  note.textContent = '';
+  note.innerHTML = '';
   note.className = 'addr-repair hidden';
 
-  if (!res.program) {
-    box.textContent = artifact;
-    note.textContent = res.note || 'The text could not be read as an address.';
-    note.className = 'addr-repair';
-    return;
-  }
-
-  const { bad } = addrDiffAgainstRerender(artifact, res.program);
+  const nBytes = addrState ? addrState.program.length : 20;
+  const { marks, verdict } = addrCheck(artifact, nBytes);
   const toks = artifact.split(/\s+/).filter(Boolean);
-  let k = -1;
-  box.innerHTML = toks.map(t => {
-    const core = [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('');
-    if (!core.length) return `<span class="addr-cover">${t}</span>`;
-    k++;
-    return bad.has(k) ? `<mark class="addr-bad">${t}</mark>` : t;
+
+  box.innerHTML = toks.map((t, i) => {
+    const m = marks.get(i);
+    if (!m) return t;
+    const cls = m.kind === SPELL ? 'tok-spell' : 'tok-grammar';
+    return `<span class="${cls}" title="${m.note.replace(/"/g, '&quot;')}">${t}</span>`;
   }).join(' ');
 
-  if (res.verdict === 'unverified') {
-    note.textContent = `${bad.size} word${bad.size === 1 ? '' : 's'} ${bad.size === 1 ? 'disagrees' : 'disagree'} with the re-render — ` +
-      `highlighted above. The address words are intact, so the address itself is still right.`;
-    note.className = 'addr-repair';
-    return;
+  // The suggestion strip, the way a word processor lists what it found.
+  const items = [...marks.entries()].filter(([, m]) => m.suggest)
+    .map(([i, m]) => `<li><span class="${m.kind === SPELL ? 'tok-spell' : 'tok-grammar'}">${toks[i]}</span>` +
+                     ` &rarr; <strong>${m.suggest}</strong> <em>${m.note}</em></li>`);
+  const headline = {
+    'clean':       'No errors found.',
+    'cover-damage':`${marks.size} wording error${marks.size === 1 ? '' : 's'} — the address words are intact, so the address itself is correct.`,
+    'repairable':  'Address-word error. The correction below is confirmed: substituting it reproduces this exact wording.',
+    'ambiguous':   'An address word is wrong, and more than one correction would explain the text — it cannot be resolved automatically.',
+    'unlocatable': 'An address word is wrong, but no plausible misspelling explains the text, so the position cannot be recovered.',
+    'short':       'Too few address words — one is missing and no nearby word restores it.',
+    'long':        'Too many address words — a connective word has been read as address data.',
+    'undecodable': 'The address words do not decode.',
+  }[verdict] || '';
+
+  // Keep the badge consistent with what the checker actually found: a word count
+  // mismatch reads as "unreadable" to the decoder, but if the checker can name and
+  // confirm the misspelling, that is a spelling error, not an unreadable artifact.
+  const badge = {
+    'clean':       ['ok',   '\u2713 verified'],
+    'cover-damage':['warn', `\u26a0 ${marks.size} wording error${marks.size === 1 ? '' : 's'}`],
+    'repairable':  ['bad',  '\u2717 misspelled address word'],
+    'ambiguous':   ['bad',  '\u2717 wrong address (ambiguous)'],
+    'unlocatable': ['bad',  '\u2717 wrong address'],
+    'short':       ['bad',  '\u2717 missing an address word'],
+    'long':        ['bad',  '\u2717 extra address word'],
+    'undecodable': ['bad',  '\u2717 unreadable'],
+  }[verdict];
+  if (badge) {
+    const el = document.getElementById('addr-verdict');
+    el.className = 'addr-verdict ' + badge[0];
+    el.textContent = badge[1];
   }
-  if (res.verdict === 'mismatch') {
-    const words = addrPack(res.program);
-    const hits = addrProposeRepairs(artifact, words);
-    if (hits.length === 1) {
-      note.innerHTML = `Every word disagrees, because a wrong address word changes the whole ` +
-        `wording — the diff cannot point at it. A repair search can: replacing ` +
-        `<strong>${hits[0].from}</strong> with <strong>${hits[0].to}</strong> explains this text. ` +
-        `Shown as a proposal, not applied.`;
-    } else if (hits.length > 1) {
-      note.innerHTML = `Every word disagrees. The repair search found ${hits.length} corrections ` +
-        `that would explain this text (` + hits.map(h => `${h.from}&rarr;${h.to}`).join(', ') +
-        `), so it cannot be resolved automatically.`;
-    } else {
-      note.textContent = 'Every word disagrees, so an address word is wrong — but no single ' +
-        'plausible typo explains it, so the position cannot be recovered.';
-    }
-    note.className = 'addr-repair';
-  }
+
+  note.innerHTML = `<div class="addr-headline">${headline}</div>` +
+                   (items.length ? `<ul class="addr-suggest">${items.join('')}</ul>` : '') +
+                   (verdict === 'repairable' ? '<div class="addr-foot">Shown as a proposal — never applied automatically.</div>' : '');
+  note.className = 'addr-repair';
 }
 
 function addrToggleRoles() {

--- a/web/index.html
+++ b/web/index.html
@@ -895,6 +895,11 @@ footer a:hover { text-decoration: underline; }
         .addr-damage-label { font-size: 0.75rem; color: var(--text-dim); }
         .addr-damage-row { display: flex; gap: 0.4rem; justify-content: center; flex-wrap: wrap; margin-top: 0.5rem; }
         .addr-glyph { font-family: var(--font-mono); color: var(--accent); }
+        .addr-repair { max-width: 720px; margin: 0.7rem auto 0; text-align: center;
+          font-size: 0.76rem; line-height: 1.6; color: var(--text-dim); }
+        .addr-repair strong { color: var(--accent); font-family: var(--font-mono); }
+        mark.addr-bad { background: rgba(239,68,68,0.16); color: var(--error);
+          border-bottom: 1px solid rgba(239,68,68,0.5); border-radius: 2px; padding: 0 1px; }
         .addr-cover { color: var(--text-dim); }
         .addr-pay { text-decoration: underline; text-decoration-color: var(--accent); }
         .addr-pay sub { font-size: 0.6em; color: var(--accent); opacity: 0.85; }
@@ -1064,6 +1069,8 @@ footer a:hover { text-decoration: underline; }
             </div>
           </div>
         </div>
+
+        <div class="addr-repair hidden" id="addr-repair"></div>
 
         <div class="addr-damage">
           <span class="addr-damage-label">Now damage it, the way a person would:</span>
@@ -2283,6 +2290,77 @@ function addrRead(artifact, nBytes) {
     : { verdict: 'mismatch', program, match: best };
 }
 
+// Locate damage WITHOUT knowing the original. The re-render is the reference:
+// encode whatever the received text decodes to, and compare.
+//
+// Cover damage leaves the payload intact, so the re-render IS the correct
+// paragraph and a token diff points straight at the damaged words. Payload
+// damage changes the checksum and therefore the whole paragraph, so the diff
+// localizes nothing — only a repair search can, by proposing plausible typo
+// corrections and keeping those that explain the received text.
+function addrDiffAgainstRerender(artifact, program) {
+  const recv = artifact.split(/\s+/).filter(Boolean).map(t =>
+    [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('')).filter(t => t.length);
+  const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)),
+    'english', 'default', 'body', addrSeed(program, 0), ADDR_COUNTER_RANGE));
+  if (r.error) return { bad: new Set(), rendered: [] };
+  const got = r.encoded_text.split(/\s+/).filter(Boolean);
+  const bad = new Set();
+  for (let i = 0; i < Math.max(got.length, recv.length); i++) if (got[i] !== recv[i]) bad.add(i);
+  return { bad, rendered: got, recv };
+}
+
+// Replace a token's word while keeping its capitalization and punctuation, so the
+// only difference is the word itself. Replacing the whole token would drop a
+// trailing period or an initial capital and change more than intended.
+function addrSwapIn(token, replacement) {
+  const m = token.match(/^([^\p{L}\p{N}]*)(.*?)([^\p{L}\p{N}]*)$/u);
+  if (!m) return replacement;
+  const core = m[2];
+  const cased = core && core[0] === core[0].toUpperCase() && core[0] !== core[0].toLowerCase()
+    ? replacement[0].toUpperCase() + replacement.slice(1)
+    : replacement;
+  return m[1] + cased + m[3];
+}
+
+// Words one edit away that are also address words — the plausible-typo set.
+function addrEdit1(w) {
+  const out = new Set(), A = 'abcdefghijklmnopqrstuvwxyz';
+  for (let i = 0; i < w.length; i++) {
+    for (const c of A) { const s = w.slice(0, i) + c + w.slice(i + 1); if (s !== w && addrIndex.has(s)) out.add(s); }
+    const d = w.slice(0, i) + w.slice(i + 1); if (addrIndex.has(d)) out.add(d);
+  }
+  for (let i = 0; i <= w.length; i++)
+    for (const c of A) { const s = w.slice(0, i) + c + w.slice(i + 1 - 1); const t = w.slice(0, i) + c + w.slice(i); if (addrIndex.has(t)) out.add(t); }
+  return [...out];
+}
+
+// A correct repair reproduces the ORIGINAL, which differs from what was received
+// at exactly the damaged word — so the test is "differs in at most one token",
+// not "matches". A wrong candidate changes the checksum and mismatches almost
+// everywhere.
+function addrProposeRepairs(artifact, words) {
+  const recv = artifact.split(/\s+/).filter(Boolean).map(t =>
+    [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('')).filter(t => t.length);
+  const hits = [];
+  for (let i = 0; i < words.length; i++) {
+    for (const cand of addrEdit1(words[i])) {
+      const w = words.slice(); w[i] = cand;
+      const prog = addrUnpack(w, addrState ? addrState.program.length : 20);
+      if (!prog) continue;
+      const r = JSON.parse(wasmEncodeWords(JSON.stringify(w), 'english', 'default', 'body',
+        addrSeed(prog, 0), ADDR_COUNTER_RANGE));
+      if (r.error) continue;
+      const got = r.encoded_text.split(/\s+/).filter(Boolean);
+      let miss = 0;
+      for (let k = 0; k < Math.max(got.length, recv.length); k++) if (got[k] !== recv[k]) miss++;
+      if (miss <= 1) hits.push({ index: i, from: words[i], to: cand });
+      if (hits.length > 4) return hits;
+    }
+  }
+  return hits;
+}
+
 function addrSetVerdict(res) {
   const el = document.getElementById('addr-verdict');
   const map = {
@@ -2345,7 +2423,7 @@ function addrDamages() {
   const toks = pros.split(/\s+/);
   const payTok = new Set(places.map(p => p.token_index));
   const coverIdx = toks.map((_, i) => i).filter(i => !payTok.has(i) && toks[i].length > 2);
-  const mid = places[Math.floor(places.length / 2)];
+  const mid = places.find(p => addrEdit1(p.word).length) || places[Math.floor(places.length / 2)];
   return [
     {
       label: 'fumble a connective word',
@@ -2355,7 +2433,15 @@ function addrDamages() {
     {
       label: 'mistype an address word',
       why: 'The dangerous one. A valid substitute still decodes — to a DIFFERENT address. Only the wording catches it.',
-      apply: () => { const t = [...toks]; t[mid.token_index] = addrWords[(addrIndex.get(mid.word) + 977) % addrWords.length]; return t.join(' '); },
+      apply: () => {
+        const t = [...toks];
+        // Prefer a word one edit away — a plausible misreading, and the case the
+        // repair search can recover. Fall back to an arbitrary address word.
+        const near = addrEdit1(mid.word);
+        const sub = near.length ? near[0] : addrWords[(addrIndex.get(mid.word) + 977) % addrWords.length];
+        t[mid.token_index] = addrSwapIn(t[mid.token_index], sub);
+        return t.join(' ');
+      },
     },
     {
       label: 'lose a word',
@@ -2378,7 +2464,10 @@ function addrRenderDamage() {
   const reset = document.createElement('button');
   reset.className = 'btn-sm';
   reset.textContent = '↺ reset';
-  reset.onclick = () => addrUpdate();
+  reset.onclick = () => {
+    document.getElementById('addr-repair').className = 'addr-repair hidden';
+    addrUpdate();
+  };
   row.appendChild(reset);
 }
 
@@ -2392,13 +2481,64 @@ function addrApplyDamage(i) {
   const artifact = lead + damagedProse + trail;
   const box = document.getElementById('addr-output');
   box.classList.remove('empty');
-  box.textContent = artifact;
   const res = addrRead(artifact, addrState.program.length);
   addrSetVerdict(res);
+  addrPaintDamage(box, artifact, res);
   const hint = document.getElementById('addr-hint');
   const got = res.program ? addrHex(res.program) : null;
   hint.textContent = d.why + (got && got !== addrHex(addrState.program)
     ? ` It decodes to ${got.slice(0, 12)}… instead.` : '');
+}
+
+// Show WHERE the text disagrees with its own re-render, and — when the payload
+// itself is wrong — what single correction would explain it. Corrections are
+// surfaced as proposals and never applied: the search is not always unique.
+function addrPaintDamage(box, artifact, res) {
+  const note = document.getElementById('addr-repair');
+  note.textContent = '';
+  note.className = 'addr-repair hidden';
+
+  if (!res.program) {
+    box.textContent = artifact;
+    note.textContent = res.note || 'The text could not be read as an address.';
+    note.className = 'addr-repair';
+    return;
+  }
+
+  const { bad } = addrDiffAgainstRerender(artifact, res.program);
+  const toks = artifact.split(/\s+/).filter(Boolean);
+  let k = -1;
+  box.innerHTML = toks.map(t => {
+    const core = [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('');
+    if (!core.length) return `<span class="addr-cover">${t}</span>`;
+    k++;
+    return bad.has(k) ? `<mark class="addr-bad">${t}</mark>` : t;
+  }).join(' ');
+
+  if (res.verdict === 'unverified') {
+    note.textContent = `${bad.size} word${bad.size === 1 ? '' : 's'} ${bad.size === 1 ? 'disagrees' : 'disagree'} with the re-render — ` +
+      `highlighted above. The address words are intact, so the address itself is still right.`;
+    note.className = 'addr-repair';
+    return;
+  }
+  if (res.verdict === 'mismatch') {
+    const words = addrPack(res.program);
+    const hits = addrProposeRepairs(artifact, words);
+    if (hits.length === 1) {
+      note.innerHTML = `Every word disagrees, because a wrong address word changes the whole ` +
+        `wording — the diff cannot point at it. A repair search can: replacing ` +
+        `<strong>${hits[0].from}</strong> with <strong>${hits[0].to}</strong> explains this text. ` +
+        `Shown as a proposal, not applied.`;
+    } else if (hits.length > 1) {
+      note.innerHTML = `Every word disagrees. The repair search found ${hits.length} corrections ` +
+        `that would explain this text (` + hits.map(h => `${h.from}&rarr;${h.to}`).join(', ') +
+        `), so it cannot be resolved automatically.`;
+    } else {
+      note.textContent = 'Every word disagrees, so an address word is wrong — but no single ' +
+        'plausible typo explains it, so the position cannot be recovered.';
+    }
+    note.className = 'addr-repair';
+  }
 }
 
 function addrToggleRoles() {

--- a/web/index.html
+++ b/web/index.html
@@ -2143,7 +2143,13 @@ const ADDR_MARKUP = new Set(Object.values(ADDR_OPS).map(([g]) => g));
 const addrGlyphs = (type, which) => ((ADDR_SCRIPT[type] || {})[which] || []).map(k => ADDR_OPS[k][0]).join(' ');
 const addrLegend = type => ((ADDR_SCRIPT[type] || {}).lead || []).concat((ADDR_SCRIPT[type] || {}).trail || [])
   .map(k => ADDR_OPS[k][0] + ' ' + ADDR_OPS[k][1]).join('  \u00b7  ');
-const ADDR_COUNTER_RANGE = 4;
+// No counter sweep. The counter existed so the ENCODER could shop for a more
+// fluent rendering among N seeds — but verification does not generate anything,
+// it reproduces a fixed artifact, so every counter the encoder MAY have used is
+// one the verifier MUST try, and a repair search must try per candidate. Fixing
+// it makes encoding deterministic: one render to encode, one to verify, one per
+// repair candidate. Costs ~6% longer prose; saves a 2.4x multiplier everywhere.
+const ADDR_COUNTER_RANGE = 1;
 const ADDR_VERSION = 1;
 const ADDR_PRESETS = [
   { label: 'P2WPKH', addr: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4' },
@@ -2274,17 +2280,16 @@ function addrRead(artifact, nBytes) {
   // (⓪Insect vs ⓪ Insect) is a formatting difference rather than a failed check.
   const proseToks = toks.map(t => [...t].filter(ch => !ADDR_MARKUP.has(ch)).join(''))
                         .filter(t => t.length);
-  let best = 0;
-  for (let c = 0; c < ADDR_COUNTER_RANGE; c++) {
-    const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)), 'english', 'default', 'body', addrSeed(program, 0) + BigInt(c), 1));
-    if (r.error) continue;
-    const got = r.encoded_text.split(/\s+/).filter(Boolean);
-    if (got.join(' ') === proseToks.join(' ')) return { verdict: 'verified', program, match: 1 };
-    const n = Math.max(got.length, proseToks.length, 1);
-    let same = 0;
-    for (let i = 0; i < Math.min(got.length, proseToks.length); i++) if (got[i] === proseToks[i]) same++;
-    best = Math.max(best, same / n);
-  }
+  // One render. The address determines its prose exactly, so there is nothing to
+  // search over.
+  const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)), 'english', 'default', 'body', addrSeed(program, 0), 1));
+  if (r.error) return { verdict: 'unreadable', note: r.error };
+  const got = r.encoded_text.split(/\s+/).filter(Boolean);
+  if (got.join(' ') === proseToks.join(' ')) return { verdict: 'verified', program, match: 1 };
+  const n = Math.max(got.length, proseToks.length, 1);
+  let same = 0;
+  for (let i = 0; i < Math.min(got.length, proseToks.length); i++) if (got[i] === proseToks[i]) same++;
+  const best = same / n;
   return best > 0.75
     ? { verdict: 'unverified', program, match: best }
     : { verdict: 'mismatch', program, match: best };

--- a/web/index.html
+++ b/web/index.html
@@ -898,10 +898,22 @@ footer a:hover { text-decoration: underline; }
         .addr-repair { max-width: 720px; margin: 0.7rem auto 0; text-align: center;
           font-size: 0.76rem; line-height: 1.6; color: var(--text-dim); }
         .addr-repair strong { color: var(--accent); font-family: var(--font-mono); }
+        .addr-popup { position: absolute; z-index: 50; max-width: 340px; padding: 0.7rem 0.85rem;
+          background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+          box-shadow: 0 8px 24px rgba(0,0,0,0.25); font-size: 0.78rem; text-align: left; }
+        .addr-popup.spell { border-top: 3px solid var(--error); }
+        .addr-popup.grammar { border-top: 3px solid var(--blue); }
+        .addr-popup-h { font-weight: 600; margin-bottom: 0.35rem; }
+        .addr-popup-h strong { color: var(--accent); font-family: var(--font-mono); }
+        .addr-popup-b { color: var(--text-dim); line-height: 1.5; }
+        .addr-popup-t { margin: 0.5rem 0; font-family: var(--font-mono); font-size: 0.7rem; width: 100%; }
+        .addr-popup-t td:first-child { color: var(--text-dim); padding-right: 0.6rem; }
+        .addr-popup-warn { margin-top: 0.4rem; color: var(--error); font-size: 0.72rem; line-height: 1.45; }
+        .addr-popup-actions { display: flex; gap: 0.4rem; margin-top: 0.6rem; }
         .tok-spell { text-decoration: underline wavy var(--error); text-underline-offset: 3px;
-          text-decoration-thickness: 1.5px; cursor: help; }
+          text-decoration-thickness: 1.5px; cursor: pointer; }
         .tok-grammar { text-decoration: underline wavy var(--blue); text-underline-offset: 3px;
-          text-decoration-thickness: 1.5px; cursor: help; }
+          text-decoration-thickness: 1.5px; cursor: pointer; }
         .addr-headline { margin-bottom: 0.4rem; }
         .addr-suggest { list-style: none; padding: 0; margin: 0.4rem 0 0; text-align: left;
           display: inline-block; font-size: 0.75rem; }
@@ -2620,6 +2632,84 @@ function addrCheck(artifact, nBytes) {
   return { marks, verdict: hits.length ? 'ambiguous' : 'unlocatable' };
 }
 
+// "Did you mean…?" popups. The two kinds are NOT symmetric, and the popups say so:
+//
+//   SPELL   — the word carries address data. Accepting the correction CHANGES THE
+//             ADDRESS, so the popup shows both hash160s and never applies on its own.
+//   GRAMMAR — the word carries no data. The address is already correct; accepting
+//             only restores the canonical wording so the artifact self-verifies
+//             again. Safe to apply on a click.
+//
+// Collapsing the two into one "accept" button would hide exactly the distinction
+// that matters: one decides where money goes, the other is cosmetic.
+let addrCurrent = null;   // { artifact, marks, nBytes }
+
+function addrClosePopup() {
+  const el = document.getElementById('addr-popup');
+  if (el) el.remove();
+}
+
+function addrShowPopup(tokenEl, idx) {
+  addrClosePopup();
+  if (!addrCurrent) return;
+  const m = addrCurrent.marks.get(idx);
+  if (!m || !m.suggest) return;
+
+  const toks = addrCurrent.artifact.split(/\s+/).filter(Boolean);
+  const fixed = toks.slice();
+  fixed[idx] = addrSwapIn(toks[idx], m.suggest);
+
+  const pop = document.createElement('div');
+  pop.id = 'addr-popup';
+  pop.className = 'addr-popup ' + (m.kind === SPELL ? 'spell' : 'grammar');
+
+  if (m.kind === SPELL) {
+    // What the text says now, versus what it would say corrected. This is the
+    // decision the user is actually being asked to make.
+    const now = addrRead(addrCurrent.artifact, addrCurrent.nBytes);
+    const after = addrRead(fixed.join(' '), addrCurrent.nBytes);
+    pop.innerHTML =
+      `<div class="addr-popup-h">Did you mean <strong>${m.suggest}</strong>?</div>` +
+      `<div class="addr-popup-b">${m.note}</div>` +
+      `<table class="addr-popup-t">` +
+      `<tr><td>as written</td><td>${now.program ? addrHex(now.program).slice(0, 16) + '…' : 'does not decode'}</td></tr>` +
+      `<tr><td>corrected</td><td><strong>${after.program ? addrHex(after.program).slice(0, 16) + '…' : '—'}</strong></td></tr>` +
+      `</table>` +
+      `<div class="addr-popup-warn">This changes the address. Apply only if you agree it is the word that was meant.</div>` +
+      `<div class="addr-popup-actions"><button class="btn-sm" id="addr-pop-apply">Use “${m.suggest}”</button>` +
+      `<button class="btn-sm" id="addr-pop-close">Keep as written</button></div>`;
+  } else {
+    pop.innerHTML =
+      `<div class="addr-popup-h">The address calls for <strong>${m.suggest}</strong> here.</div>` +
+      `<div class="addr-popup-b">This word carries no address data, so the address is already correct. ` +
+      `Restoring it only lets the artifact verify itself again.</div>` +
+      `<div class="addr-popup-actions"><button class="btn-sm" id="addr-pop-apply">Fix wording</button>` +
+      `<button class="btn-sm" id="addr-pop-close">Leave it</button></div>`;
+  }
+
+  document.body.appendChild(pop);
+  const r = tokenEl.getBoundingClientRect();
+  pop.style.left = Math.max(8, Math.min(window.innerWidth - pop.offsetWidth - 8,
+                                        r.left + window.scrollX)) + 'px';
+  pop.style.top = (r.bottom + window.scrollY + 6) + 'px';
+
+  document.getElementById('addr-pop-close').onclick = addrClosePopup;
+  document.getElementById('addr-pop-apply').onclick = () => {
+    addrClosePopup();
+    const box = document.getElementById('addr-output');
+    const text = fixed.join(' ');
+    const res = addrRead(text, addrCurrent.nBytes);
+    addrSetVerdict(res);
+    addrPaintDamage(box, text, res);
+  };
+}
+
+document.addEventListener('click', e => {
+  if (!e.target.closest('#addr-popup') && !e.target.closest('.tok-spell') && !e.target.closest('.tok-grammar')) {
+    addrClosePopup();
+  }
+});
+
 function addrPaintDamage(box, artifact, res) {
   const note = document.getElementById('addr-repair');
   note.innerHTML = '';
@@ -2629,12 +2719,17 @@ function addrPaintDamage(box, artifact, res) {
   const { marks, verdict } = addrCheck(artifact, nBytes);
   const toks = artifact.split(/\s+/).filter(Boolean);
 
+  addrCurrent = { artifact, marks, nBytes };
   box.innerHTML = toks.map((t, i) => {
     const m = marks.get(i);
     if (!m) return t;
     const cls = m.kind === SPELL ? 'tok-spell' : 'tok-grammar';
-    return `<span class="${cls}" title="${m.note.replace(/"/g, '&quot;')}">${t}</span>`;
+    const hint = m.suggest ? ' \u2014 click for suggestion' : '';
+    return `<span class="${cls}" data-i="${i}" title="${(m.note + hint).replace(/"/g, '&quot;')}">${t}</span>`;
   }).join(' ');
+  box.querySelectorAll('[data-i]').forEach(el => {
+    el.onclick = ev => { ev.stopPropagation(); addrShowPopup(el, +el.dataset.i); };
+  });
 
   // The suggestion strip, the way a word processor lists what it found.
   const items = [...marks.entries()].filter(([, m]) => m.suggest)

--- a/web/index.html
+++ b/web/index.html
@@ -887,6 +887,8 @@ footer a:hover { text-decoration: underline; }
         .addr-panels .panel-right .panel-footer { justify-content: flex-start; }
         .addr-panels .panel-right .panel-footer .addr-meta { margin-right: auto; }
         .addr-addr { font-family: var(--font-mono); font-size: 0.85rem; word-break: break-all; }
+        .addr-editable { outline: none; cursor: text; }
+        .addr-editable:focus { box-shadow: inset 0 0 0 2px rgba(124,108,240,0.35); }
         .addr-picker { display: flex; gap: 0.35rem; justify-content: center; flex-wrap: wrap; margin-bottom: 0.9rem; }
         .addr-meta { font-family: var(--font-mono); font-size: 0.65rem; color: var(--text-dim); }
         .addr-verdict { margin-left: auto; font-size: 0.7rem; font-family: var(--font-mono);
@@ -2507,7 +2509,15 @@ function addrApplyMode() {
   document.getElementById('addr-damage').classList.toggle('hidden', !enc);
   document.getElementById('addr-picker').classList.toggle('hidden', !enc);
   document.getElementById('addr-roles-btn').classList.toggle('hidden', !enc);
-  document.getElementById('addr-output').classList.toggle('addr-addr', !enc);
+  const out = document.getElementById('addr-output');
+  out.classList.toggle('addr-addr', !enc);
+  // The prose is editable in the encode direction: the damage buttons cover the
+  // typical failures, but the point is that ANY edit is checkable, so let the
+  // reader make one. In decode the box holds the recovered address, an output.
+  out.contentEditable = enc ? 'true' : 'false';
+  out.spellcheck = false;
+  out.classList.toggle('addr-editable', enc);
+  out.title = enc ? 'Edit the prose — it is rechecked as you type' : '';
 }
 
 function addrToggle() {
@@ -2521,7 +2531,9 @@ function addrToggle() {
 
 function addrUpdate() {
   addrClosePopup();
-  document.getElementById('addr-repair').className = 'addr-repair hidden';
+  const note = document.getElementById('addr-repair');
+  note.innerHTML = '';
+  note.className = 'addr-repair hidden';
   return addrMode === 'encode' ? addrEncodeRun() : addrDecodeRun();
 }
 
@@ -2900,6 +2912,52 @@ function addrPaintDamage(box, artifact, res) {
   note.className = 'addr-repair';
 }
 
+// ── editing the prose in place ──────────────────────────────────────
+// Repainting replaces the box's children, which would drop the caret, so record
+// where it is as a character offset and put it back afterwards. Offsets are
+// taken against the rendered text, and the repaint normalizes whitespace, so
+// they line up unless the edit added runs of spaces.
+function addrCaretOffset(root) {
+  const sel = window.getSelection();
+  if (!sel || !sel.rangeCount || !root.contains(sel.anchorNode)) return null;
+  const cur = sel.getRangeAt(0);
+  const r = document.createRange();
+  r.selectNodeContents(root);
+  r.setEnd(cur.endContainer, cur.endOffset);
+  return r.toString().length;
+}
+
+function addrSetCaret(root, offset) {
+  if (offset === null) return;
+  const sel = window.getSelection(), r = document.createRange();
+  const walk = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let n, seen = 0;
+  while ((n = walk.nextNode())) {
+    if (seen + n.length >= offset) {
+      r.setStart(n, offset - seen);
+      r.collapse(true);
+      sel.removeAllRanges(); sel.addRange(r);
+      return;
+    }
+    seen += n.length;
+  }
+  r.selectNodeContents(root); r.collapse(false);
+  sel.removeAllRanges(); sel.addRange(r);
+}
+
+function addrRecheck() {
+  if (addrMode !== 'encode' || !addrState) return;
+  const box = document.getElementById('addr-output');
+  const caret = addrCaretOffset(box);
+  const text = box.textContent.replace(/\s+/g, ' ').trim();
+  if (!text) return;
+  const res = addrRead(text, addrState.program.length);
+  addrSetVerdict(res);
+  addrPaintDamage(box, text, res);
+  addrSetCaret(box, caret);
+  document.getElementById('addr-hint').textContent = ADDR_BASE_HINT;
+}
+
 function addrToggleRoles() {
   addrShowRoles = !addrShowRoles;
   document.getElementById('addr-roles-btn').textContent = addrShowRoles ? 'Hide roles' : 'Show roles';
@@ -2939,6 +2997,18 @@ function addrInit() {
     clearTimeout(input._t);
     input._t = setTimeout(addrUpdate, 250);
   });
+  const out = document.getElementById('addr-output');
+  out.addEventListener('input', () => {
+    clearTimeout(out._t);
+    out._t = setTimeout(addrRecheck, 400);
+  });
+  // Paste as plain text, or the browser drops styled markup into the box and the
+  // token diff picks up formatting rather than words.
+  out.addEventListener('paste', e => {
+    e.preventDefault();
+    document.execCommand('insertText', false, (e.clipboardData || window.clipboardData).getData('text'));
+  });
+
   input.textContent = ADDR_PRESETS[0].addr;
   document.getElementById('addr-hint').textContent = ADDR_BASE_HINT;
   addrApplyMode();

--- a/web/index.html
+++ b/web/index.html
@@ -2427,10 +2427,10 @@ function addrRead(artifact, nBytes) {
   if (rendered === null) return { verdict: 'unreadable', note: 'encode failed' };
   const got = rendered.split(/\s+/).filter(Boolean);
   if (got.join(' ') === proseToks.join(' ')) return { verdict: 'verified', program, match: 1 };
+  // Aligned, not positional: one dropped connective word should read as "one
+  // word out of thirty differs", not as "everything after it differs".
   const n = Math.max(got.length, proseToks.length, 1);
-  let same = 0;
-  for (let i = 0; i < Math.min(got.length, proseToks.length); i++) if (got[i] === proseToks[i]) same++;
-  const best = same / n;
+  const best = addrAlign(proseToks, got).matched / n;
   return best > 0.75
     ? { verdict: 'unverified', program, match: best }
     : { verdict: 'mismatch', program, match: best };
@@ -2444,15 +2444,48 @@ function addrRead(artifact, nBytes) {
 // damage changes the checksum and therefore the whole paragraph, so the diff
 // localizes nothing — only a repair search can, by proposing plausible typo
 // corrections and keeping those that explain the received text.
+// Align received tokens against rendered ones (longest common subsequence).
+//
+// Comparing position by position was wrong for the two edits people actually
+// make: dropping a word and adding one. Either shifts every token after it, so
+// a positional diff reports the whole tail as damaged — including the address
+// words, which are sitting there perfectly intact. The checker then concluded
+// an address word must be wrong and said so.
+//
+// Returns one op per received token plus the gaps: 'same', 'sub' (this token
+// should read `want`), 'ins' (this token is not in the rendering at all) and
+// 'del' (a word is missing before token `i`).
+function addrAlign(recv, got) {
+  const n = recv.length, m = got.length;
+  const L = Array.from({ length: n + 1 }, () => new Uint16Array(m + 1));
+  for (let i = n - 1; i >= 0; i--)
+    for (let j = m - 1; j >= 0; j--)
+      L[i][j] = recv[i] === got[j] ? L[i + 1][j + 1] + 1 : Math.max(L[i + 1][j], L[i][j + 1]);
+
+  const ops = [];
+  let i = 0, j = 0;
+  while (i < n && j < m) {
+    if (recv[i] === got[j]) { ops.push({ op: 'same', i, want: got[j] }); i++; j++; }
+    // Skipping either side costs the same, so this is one word written in place
+    // of another — report it that way. "this should say X" beats "delete this,
+    // then insert that", and it keeps a substitution to a single mark.
+    else if (L[i + 1][j] === L[i][j + 1]) { ops.push({ op: 'sub', i, want: got[j] }); i++; j++; }
+    else if (L[i + 1][j] > L[i][j + 1]) { ops.push({ op: 'ins', i, want: null }); i++; }
+    else { ops.push({ op: 'del', i, want: got[j] }); j++; }
+  }
+  while (i < n) { ops.push({ op: 'ins', i, want: null }); i++; }
+  while (j < m) { ops.push({ op: 'del', i: Math.max(0, n - 1), want: got[j] }); j++; }
+  return { ops, matched: L[0][0] };
+}
+
 function addrDiffAgainstRerender(artifact, program) {
   const recv = artifact.split(/\s+/).filter(Boolean).map(t =>
     [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('')).filter(t => t.length);
   const text = addrProse(program);
-  if (text === null) return { bad: new Set(), rendered: [] };
+  if (text === null) return { ops: [], rendered: [], recv };
   const got = text.split(/\s+/).filter(Boolean);
-  const bad = new Set();
-  for (let i = 0; i < Math.max(got.length, recv.length); i++) if (got[i] !== recv[i]) bad.add(i);
-  return { bad, rendered: got, recv };
+  const { ops } = addrAlign(recv, got);
+  return { ops: ops.filter(o => o.op !== 'same'), rendered: got, recv };
 }
 
 // Replace a token's word while keeping its capitalization and punctuation, so the
@@ -2484,11 +2517,11 @@ function addrEdit1(w) {
 // at exactly the damaged word — so the test is "differs in at most one token",
 // not "matches". A wrong candidate changes the checksum and mismatches almost
 // everywhere.
-function addrProposeRepairs(artifact, words) {
+function addrProposeRepairs(artifact, words, budgetMs = ADDR_SEARCH_MS) {
   const recv = artifact.split(/\s+/).filter(Boolean).map(t =>
     [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('')).filter(t => t.length);
   const hits = [];
-  const deadline = performance.now() + ADDR_SEARCH_MS;
+  const deadline = performance.now() + budgetMs;
   for (let i = 0; i < words.length; i++) {
     for (const cand of addrEdit1(words[i])) {
       if (performance.now() > deadline) return hits;
@@ -2768,10 +2801,13 @@ const SPELL = 'spell', GRAMMAR = 'grammar';
 // memoized, a repeat check picks up where this one left off for free, so the
 // search completes across a pause instead of blocking one keystroke.
 const ADDR_SEARCH_MS = 250;
+/// Where the widening passes stop. Past this the text really has no single-typo
+/// explanation, and saying so is the honest answer.
+const ADDR_SEARCH_MAX_MS = 4000;
 
 /// Analyse an artifact and return per-token annotations.
 /// { kind, suggest, note } keyed by token index; empty map means clean.
-function addrCheck(artifact, nBytes) {
+function addrCheck(artifact, nBytes, budgetMs = ADDR_SEARCH_MS) {
   const toks = artifact.split(/\s+/).filter(Boolean);
   const core = t => [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('')
                           .replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '').toLowerCase();
@@ -2801,7 +2837,7 @@ function addrCheck(artifact, nBytes) {
       sites.push([i, c, addrCover && addrCover.has(c) ? 1 : 0]);
     }
     sites.sort((a, b) => a[2] - b[2]);
-    const deadline = performance.now() + ADDR_SEARCH_MS;
+    const deadline = performance.now() + budgetMs;
     for (const [i, c] of sites) {
       for (const cand of addrEdit1(c)) {
         const trial = toks.slice();
@@ -2824,22 +2860,32 @@ function addrCheck(artifact, nBytes) {
   if (!program) return { marks, verdict: 'undecodable' };
   // `rendered` IS the expected wording — the diff just computed it, so asking
   // for it again was a second full generation for an answer already in hand.
-  const { bad, rendered: expectedToks } = addrDiffAgainstRerender(artifact, program);
-  if (bad.size === 0) return { marks, verdict: 'clean' };
+  const { ops } = addrDiffAgainstRerender(artifact, program);
+  if (ops.length === 0) return { marks, verdict: 'clean' };
 
   const payloadPositions = new Set(harvestIdx);
 
   // Map diff indices (which count prose tokens) back to artifact token indices.
   const proseIdx = toks.map((t, i) => core(t) ? i : -1).filter(i => i >= 0);
 
-  // If every address word is intact, the disagreement is cover-only: grammar.
-  const payloadBad = [...bad].some(k => payloadPositions.has(proseIdx[k]));
-  if (!payloadBad) {
-    for (const k of bad) {
-      const i = proseIdx[k];
+  // Which of these mean an ADDRESS word is wrong? Only a substitution landing on
+  // a payload position whose WORD differs — "ring" written where the rendering
+  // says "ring." is the same address word with a sentence break lost, which is
+  // wording, not spelling. A missing or extra word is never an address-word
+  // fault here either: the word count already agreed, so anything inserted or
+  // dropped was connective prose.
+  const wrongAddressWord = ops.some(o =>
+    o.op === 'sub' && payloadPositions.has(proseIdx[o.i]) &&
+    core(toks[proseIdx[o.i]] || '') !== core(o.want || ''));
+
+  if (!wrongAddressWord) {
+    for (const o of ops) {
+      const i = proseIdx[o.i];
       if (i === undefined) continue;
-      marks.set(i, { kind: GRAMMAR, suggest: expectedToks[k],
-        note: expectedToks[k] ? `the address calls for “${expectedToks[k]}” here` : 'unexpected word' });
+      const note = o.op === 'del' ? `a word is missing here: “${o.want}”`
+                 : o.op === 'ins' ? 'this word is not part of the address’s wording'
+                 : `the address calls for “${o.want}” here`;
+      marks.set(i, { kind: GRAMMAR, suggest: o.op === 'ins' ? null : o.want, note });
     }
     return { marks, verdict: 'cover-damage' };
   }
@@ -2847,7 +2893,7 @@ function addrCheck(artifact, nBytes) {
   // Otherwise an address word is wrong. The cover disagreement is a CONSEQUENCE,
   // not a second fault, so flag only the address word — marking 25 cover words
   // would be technically true and useless.
-  const hits = addrProposeRepairs(artifact, addrPack(program));
+  const hits = addrProposeRepairs(artifact, addrPack(program), budgetMs);
   if (hits.length === 1) {
     marks.set(harvestIdx[hits[0].index], { kind: SPELL, suggest: hits[0].to,
       note: `wrong address word; “${hits[0].to}” explains this wording` });
@@ -2918,13 +2964,13 @@ document.addEventListener('click', e => {
   }
 });
 
-function addrPaintDamage(box, artifact, res) {
+function addrPaintDamage(box, artifact, res, budgetMs = ADDR_SEARCH_MS) {
   const note = document.getElementById('addr-repair');
   note.innerHTML = '';
   note.className = 'addr-repair hidden';
 
   const nBytes = addrState ? addrState.program.length : 20;
-  const { marks, verdict } = addrCheck(artifact, nBytes);
+  const { marks, verdict } = addrCheck(artifact, nBytes, budgetMs);
   const toks = artifact.split(/\s+/).filter(Boolean);
 
   addrCurrent = { artifact, marks, nBytes };
@@ -2977,6 +3023,7 @@ function addrPaintDamage(box, artifact, res) {
                    (items.length ? `<ul class="addr-suggest">${items.join('')}</ul>` : '') +
                    (verdict === 'repairable' ? '<div class="addr-foot">Shown as a proposal — never applied automatically.</div>' : '');
   note.className = 'addr-repair';
+  return verdict;
 }
 
 // ── editing the prose in place ──────────────────────────────────────
@@ -3030,14 +3077,29 @@ function addrRecheck() {
   el.textContent = '… checking';
   const token = ++addrCheckToken;
 
-  requestAnimationFrame(() => {
-    if (token !== addrCheckToken) return;
-    const res = addrRead(text, addrState.program.length);
-    addrSetVerdict(res);
-    addrPaintDamage(box, text, res);
-    addrSetCaret(box, caret);
-    document.getElementById('addr-hint').textContent = ADDR_BASE_HINT;
-  });
+  requestAnimationFrame(() => addrRunCheck(box, text, caret, token, ADDR_SEARCH_MS));
+}
+
+/// One checking pass, then a wider one if the budget cut the search short.
+///
+/// A budget that stops the search early can stop it before the answer: a word
+/// two sites down the text has a perfectly good correction that a 250ms pass
+/// never reaches, and "cannot locate it" is a worse answer than a slow right
+/// one. So a pass that finds nothing schedules a wider pass on a later tick.
+/// Every candidate the last pass rendered is memoized, so the next one resumes
+/// where it stopped instead of repeating the work — and the user reads a fast
+/// provisional verdict that sharpens rather than a frozen page.
+function addrRunCheck(box, text, caret, token, budgetMs) {
+  if (token !== addrCheckToken || addrMode !== 'encode' || !addrState) return;
+  const res = addrRead(text, addrState.program.length);
+  addrSetVerdict(res);
+  const verdict = addrPaintDamage(box, text, res, budgetMs);
+  addrSetCaret(box, caret);
+  document.getElementById('addr-hint').textContent = ADDR_BASE_HINT;
+
+  if ((verdict === 'short' || verdict === 'unlocatable') && budgetMs < ADDR_SEARCH_MAX_MS) {
+    setTimeout(() => addrRunCheck(box, text, caret, token, budgetMs * 4), 0);
+  }
 }
 
 function addrToggleRoles() {

--- a/web/index.html
+++ b/web/index.html
@@ -884,19 +884,9 @@ footer a:hover { text-decoration: underline; }
         /* Prose address */
         .addr-legend { text-align: center; font-family: var(--font-mono); font-size: 0.68rem;
           color: var(--text-dim); margin: -0.4rem 0 0.9rem; }
-        .addr-solo { max-width: 760px; margin: 0 auto; }
-        .addr-solo .panel-footer { display: flex; align-items: center; gap: 0.5rem; }
-        .addr-solo .panel-footer .addr-meta { margin-right: auto; }
-        .addr-raw { max-width: 720px; margin: 1rem auto 0; }
-        .addr-raw > summary { list-style: none; cursor: pointer; color: var(--text-dim);
-          font-size: 0.75rem; text-align: center; }
-        .addr-raw > summary::-webkit-details-marker { display: none; }
-        .addr-raw > summary::after { content: "\25be"; margin-left: 0.3rem; font-size: 0.75em; opacity: 0.7; }
-        .addr-raw[open] > summary::after { display: inline-block; transform: rotate(180deg); }
-        .addr-raw-body { margin-top: 0.6rem; }
-        .addr-raw-body p { font-size: 0.75rem; color: var(--text-dim); text-align: center; margin: 0 0 0.6rem; }
-        .addr-raw-input { border: 1px solid var(--border); border-radius: 6px; min-height: 40px;
-          background: var(--surface); }
+        .addr-panels .panel-right .panel-footer { justify-content: flex-start; }
+        .addr-panels .panel-right .panel-footer .addr-meta { margin-right: auto; }
+        .addr-addr { font-family: var(--font-mono); font-size: 0.85rem; word-break: break-all; }
         .addr-picker { display: flex; gap: 0.35rem; justify-content: center; flex-wrap: wrap; margin-bottom: 0.9rem; }
         .addr-meta { font-family: var(--font-mono); font-size: 0.65rem; color: var(--text-dim); }
         .addr-verdict { margin-left: auto; font-size: 0.7rem; font-family: var(--font-mono);
@@ -918,10 +908,6 @@ footer a:hover { text-decoration: underline; }
         .addr-popup.grammar { border-top: 3px solid var(--blue); }
         .addr-popup-h { font-weight: 600; margin-bottom: 0.35rem; }
         .addr-popup-h strong { color: var(--accent); font-family: var(--font-mono); }
-        .addr-popup-b { color: var(--text-dim); line-height: 1.5; }
-        .addr-popup-t { margin: 0.5rem 0; font-family: var(--font-mono); font-size: 0.7rem; width: 100%; }
-        .addr-popup-t td:first-child { color: var(--text-dim); padding-right: 0.6rem; }
-        .addr-popup-warn { margin-top: 0.4rem; color: var(--error); font-size: 0.72rem; line-height: 1.45; }
         .addr-popup-actions { display: flex; gap: 0.4rem; margin-top: 0.6rem; }
         .tok-spell { text-decoration: underline wavy var(--error); text-underline-offset: 3px;
           text-decoration-thickness: 1.5px; cursor: pointer; }
@@ -1075,39 +1061,47 @@ footer a:hover { text-decoration: underline; }
         <div class="addr-picker" id="addr-picker"></div>
         <div class="addr-legend" id="addr-legend"></div>
 
-        <div class="panel addr-solo">
-          <div class="panel-header">
-            <span class="dialect-label">Prose address</span>
-            <span class="addr-verdict" id="addr-verdict"></span>
+        <div class="panels addr-panels">
+          <div class="panel panel-left">
+            <div class="panel-header">
+              <span class="dialect-label" id="addr-left-label">Bitcoin address</span>
+            </div>
+            <div class="panel-body">
+              <div contenteditable="true" spellcheck="false" id="addr-input" class="io-input"
+                   data-placeholder="Paste a bc1&hellip; / 1&hellip; / 3&hellip; address"></div>
+            </div>
+            <div class="panel-footer">
+              <div id="addr-error" class="error-msg hidden" style="padding:0;"></div>
+            </div>
           </div>
-          <div class="panel-body">
-            <div class="output-area empty" id="addr-output">Output will appear here</div>
-          </div>
-          <div class="panel-footer">
-            <span class="addr-meta" id="addr-meta"></span>
-            <button class="btn-sm" id="addr-roles-btn" onclick="addrToggleRoles()"
-                    title="Show the grammatical role of each address word">Show roles</button>
-            <button class="btn-sm" onclick="addrCopy()">Copy</button>
+
+          <button class="swap-btn" id="addr-swap-btn" onclick="addrToggle()" title="Switch between Encode and Decode" aria-label="Swap encode/decode">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"/></svg>
+          </button>
+
+          <div class="panel panel-right">
+            <div class="panel-header">
+              <span class="dialect-label" id="addr-right-label">Prose address</span>
+              <span class="addr-verdict" id="addr-verdict"></span>
+            </div>
+            <div class="panel-body">
+              <div class="output-area empty" id="addr-output">Output will appear here</div>
+            </div>
+            <div class="panel-footer">
+              <span class="addr-meta" id="addr-meta"></span>
+              <button class="btn-sm" id="addr-roles-btn" onclick="addrToggleRoles()"
+                      title="Show the grammatical role of each address word">Show roles</button>
+              <button class="btn-sm" onclick="addrCopy()">Copy</button>
+            </div>
           </div>
         </div>
 
         <div class="addr-repair hidden" id="addr-repair"></div>
 
-        <div class="addr-damage">
+        <div class="addr-damage" id="addr-damage">
           <span class="addr-damage-label">Now damage it, the way a person would:</span>
           <div class="addr-damage-row" id="addr-damage-row"></div>
         </div>
-
-        <details class="addr-raw">
-          <summary>Enter or view the same address in base58</summary>
-          <div class="addr-raw-body">
-            <p>Checking the prose never requires this. It is here so you can paste your own
-            address, and so a sceptic can confirm the words really are the script.</p>
-            <div contenteditable="true" spellcheck="false" id="addr-input" class="io-input addr-raw-input"
-                 data-placeholder="Paste a bc1&hellip; / 1&hellip; / 3&hellip; address"></div>
-            <div id="addr-error" class="error-msg hidden" style="padding:0;"></div>
-          </div>
-        </details>
 
         <details class="demo-details" id="addr-how">
           <summary id="addr-hint"></summary>
@@ -1148,6 +1142,11 @@ footer a:hover { text-decoration: underline; }
             can no longer self-verify. A mistyped <em>address</em> word decodes to a different
             address &mdash; caught only by the wording. A lost word is caught by the word count,
             since a fixed-length address has a fixed number of words.</p>
+            <p>Press <strong>&#8646;</strong> to run it backwards. The words are not a label
+            attached to an address; they <em>are</em> the address, and decoding hands back the
+            string they were made from. Swap after damaging the prose and you can watch it hand
+            back a <em>different</em> address &mdash; which is the whole reason the wording has to
+            be checkable.</p>
           </div>
         </details>
       </div>
@@ -2263,6 +2262,57 @@ async function addrParse(text) {
   return { type: 'P2TR', program };
 }
 
+// ── the inverse: rebuild the address string from what the prose decoded to ──
+// Only needed for the decode direction, which is what makes the claim falsifiable:
+// the words are not a label attached to an address, they ARE the address, and
+// running them backwards has to produce the string you started from.
+function b58encode(bytes) {
+  let n = 0n;
+  for (const b of bytes) n = n * 256n + BigInt(b);
+  let s = '';
+  while (n > 0n) { s = B58A[Number(n % 58n)] + s; n /= 58n; }
+  for (const b of bytes) { if (b !== 0) break; s = '1' + s; }
+  return s;
+}
+async function b58checkEncode(version, program) {
+  const body = new Uint8Array(1 + program.length);
+  body[0] = version; body.set(program, 1);
+  const d = (await sha256d(body)).slice(0, 4);
+  const full = new Uint8Array(body.length + 4);
+  full.set(body); full.set(d, body.length);
+  return b58encode(full);
+}
+function bech32Encode(hrp, witver, program) {
+  const data = [witver].concat(convertBits([...program], 8, 5, true));
+  const constVal = witver === 0 ? 1 : 0x2bc830a3;
+  const pm = (bech32Poly(bech32Expand(hrp).concat(data, [0, 0, 0, 0, 0, 0])) ^ constVal) >>> 0;
+  const chk = [];
+  for (let i = 0; i < 6; i++) chk.push((pm >> (5 * (5 - i))) & 31);
+  return hrp + '1' + data.concat(chk).map(v => BECH32A[v]).join('');
+}
+function addrFormat(type, program) {
+  switch (type) {
+    case 'P2PKH':  return b58checkEncode(0x00, program);
+    case 'P2SH':   return b58checkEncode(0x05, program);
+    case 'P2TR':   return Promise.resolve(bech32Encode('bc', 1, program));
+    default:       return Promise.resolve(bech32Encode('bc', 0, program));
+  }
+}
+
+/// Which script the leading glyphs describe. The opcodes are written verbatim,
+/// so the script type survives transcription without costing a payload word;
+/// ⓪ is shared by P2WPKH and P2WSH, and the word count separates those.
+function addrTypeFromGlyphs(text, nBytes) {
+  const lead = (text.trim().split(/\s+/)[0] || '');
+  const g = [...lead].filter(c => ADDR_MARKUP.has(c));
+  const first = g[0];
+  if (first === ADDR_OPS.DUP[0]) return 'P2PKH';
+  if (first === ADDR_OPS.HASH160[0]) return 'P2SH';
+  if (first === ADDR_OPS.ONE[0]) return 'P2TR';
+  if (first === ADDR_OPS.ZERO[0]) return nBytes === 20 ? 'P2WPKH' : 'P2WSH';
+  return null;
+}
+
 // ── bit packing: program bits, then the header, filling the slack exactly ──
 const ADDR_BPW = 11;
 function addrHeaderBits(n) { return Math.ceil(n * 8 / ADDR_BPW) * ADDR_BPW - n * 8; }
@@ -2442,7 +2492,91 @@ function addrPaint(artifact, placements) {
   box.innerHTML = `<span class="addr-cover">${lead}</span>${html}`;
 }
 
-async function addrUpdate() {
+// ── direction ───────────────────────────────────────────────────────
+// Encode is the demonstration; decode is what makes it falsifiable. Running the
+// words backwards has to hand back the address string they came from — otherwise
+// "the prose IS the address" is just an assertion.
+let addrMode = 'encode';
+
+function addrApplyMode() {
+  const enc = addrMode === 'encode';
+  document.getElementById('addr-left-label').textContent = enc ? 'Bitcoin address' : 'Prose address';
+  document.getElementById('addr-right-label').textContent = enc ? 'Prose address' : 'Bitcoin address';
+  document.getElementById('addr-input').dataset.placeholder =
+    enc ? 'Paste a bc1… / 1… / 3… address' : 'Paste a prose address';
+  document.getElementById('addr-damage').classList.toggle('hidden', !enc);
+  document.getElementById('addr-picker').classList.toggle('hidden', !enc);
+  document.getElementById('addr-roles-btn').classList.toggle('hidden', !enc);
+  document.getElementById('addr-output').classList.toggle('addr-addr', !enc);
+}
+
+function addrToggle() {
+  addrClosePopup();
+  const out = document.getElementById('addr-output').textContent || '';
+  addrMode = addrMode === 'encode' ? 'decode' : 'encode';
+  addrApplyMode();
+  document.getElementById('addr-input').textContent = out;
+  addrUpdate();
+}
+
+function addrUpdate() {
+  addrClosePopup();
+  document.getElementById('addr-repair').className = 'addr-repair hidden';
+  return addrMode === 'encode' ? addrEncodeRun() : addrDecodeRun();
+}
+
+/// Address words in a text, in order — the decoder's whole view of it.
+function addrHarvest(text) {
+  const strip = w => [...w].filter(ch => !ADDR_MARKUP.has(ch)).join('')
+                           .replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '').toLowerCase();
+  return text.split(/\s+/).filter(Boolean).map(strip).filter(w => w && addrIndex.has(w));
+}
+
+async function addrDecodeRun() {
+  const errEl = document.getElementById('addr-error');
+  const metaEl = document.getElementById('addr-meta');
+  const box = document.getElementById('addr-output');
+  const verdictEl = document.getElementById('addr-verdict');
+  const text = (document.getElementById('addr-input').textContent || '').trim();
+  errEl.classList.add('hidden');
+
+  const blank = () => {
+    box.textContent = 'Output will appear here';
+    box.classList.add('empty');
+    metaEl.textContent = '';
+    verdictEl.textContent = '';
+    verdictEl.className = 'addr-verdict';
+  };
+  const fail = note => {
+    blank();
+    verdictEl.className = 'addr-verdict bad';
+    verdictEl.textContent = '✗ unreadable';
+    verdictEl.title = note;
+    errEl.textContent = note;
+    errEl.classList.remove('hidden');
+  };
+  if (!text) return blank();
+
+  // A fixed-length address has a fixed word count, so the count picks the size.
+  const words = addrHarvest(text);
+  const nBytes = { 15: 20, 24: 32 }[words.length];
+  if (!nBytes) return fail(`${words.length} address words — a prose address has 15 or 24`);
+  const type = addrTypeFromGlyphs(text, nBytes);
+  if (!type) return fail('no opcode symbol, so the script type is unknown');
+  const res = addrRead(text, nBytes);
+  if (!res.program) return fail(res.note || 'does not decode');
+
+  box.classList.remove('empty');
+  box.textContent = await addrFormat(type, res.program);
+  // Count prose words only, so the figure means the same thing in both
+  // directions — the opcode glyphs are script, not wording.
+  const prose = text.split(/\s+/).filter(t => [...t].some(c => !ADDR_MARKUP.has(c)));
+  metaEl.textContent = `${type} · ${words.length} address words · ${prose.length} words total`;
+  document.getElementById('addr-legend').textContent = addrLegend(type);
+  addrSetVerdict(res);
+}
+
+async function addrEncodeRun() {
   const errEl = document.getElementById('addr-error');
   const metaEl = document.getElementById('addr-meta');
   try {
@@ -2644,16 +2778,13 @@ function addrCheck(artifact, nBytes) {
   return { marks, verdict: hits.length ? 'ambiguous' : 'unlocatable' };
 }
 
-// "Did you mean…?" popups. The two kinds are NOT symmetric, and the popups say so:
+// "Did you mean…?" popups — the question and the two answers, nothing else.
 //
-//   SPELL   — the word carries address data. Accepting the correction CHANGES THE
-//             ADDRESS, so the popup shows both hash160s and never applies on its own.
-//   GRAMMAR — the word carries no data. The address is already correct; accepting
-//             only restores the canonical wording so the artifact self-verifies
-//             again. Safe to apply on a click.
-//
-// Collapsing the two into one "accept" button would hide exactly the distinction
-// that matters: one decides where money goes, the other is cosmetic.
+// The two kinds are NOT symmetric: a SPELL correction changes which address the
+// text refers to, a GRAMMAR one only restores wording the address already
+// determined. That asymmetry is carried by the border colour and by the
+// suggestion strip below the prose, not by paragraphs inside the popup — a
+// spell checker that lectured you would not get read.
 let addrCurrent = null;   // { artifact, marks, nBytes }
 
 function addrClosePopup() {
@@ -2675,31 +2806,15 @@ function addrShowPopup(tokenEl, idx) {
   pop.id = 'addr-popup';
   pop.className = 'addr-popup ' + (m.kind === SPELL ? 'spell' : 'grammar');
 
-  if (m.kind === SPELL) {
-    // Deliberately NOT a hex comparison. The claim of this format is that reading
-    // the prose is a valid check in its own right; falling back to "here are two
-    // hashes, compare them" would concede the opposite and hand the user the exact
-    // character-by-character task the words exist to replace. The meaningful
-    // statement is about agreement: as written, the words and the wording describe
-    // different addresses, and only one substitution makes them agree.
-    pop.innerHTML =
-      `<div class="addr-popup-h">Did you mean <strong>${m.suggest}</strong>?</div>` +
-      `<div class="addr-popup-b">As written, these words spell a <strong>different address</strong> ` +
-      `&mdash; and the rest of the sentence does not match that address.</div>` +
-      `<div class="addr-popup-b">With <strong>${m.suggest}</strong>, the words and the wording agree, ` +
-      `which is what makes an address readable as correct.</div>` +
-      `<div class="addr-popup-warn">This changes which address the text refers to. Apply only if you ` +
-      `agree it is the word that was meant.</div>` +
-      `<div class="addr-popup-actions"><button class="btn-sm" id="addr-pop-apply">Use &ldquo;${m.suggest}&rdquo;</button>` +
-      `<button class="btn-sm" id="addr-pop-close">Keep as written</button></div>`;
-  } else {
-    pop.innerHTML =
-      `<div class="addr-popup-h">The address calls for <strong>${m.suggest}</strong> here.</div>` +
-      `<div class="addr-popup-b">This word carries no address data, so the address is already correct. ` +
-      `Restoring it only lets the artifact verify itself again.</div>` +
-      `<div class="addr-popup-actions"><button class="btn-sm" id="addr-pop-apply">Fix wording</button>` +
-      `<button class="btn-sm" id="addr-pop-close">Leave it</button></div>`;
-  }
+  // Just the question and the two answers, the way a spell checker asks it. The
+  // suggestion is already CONFIRMED by re-rendering, so there is nothing to
+  // caveat; the red/blue border carries the spell-vs-grammar distinction and the
+  // button labels carry the consequence.
+  pop.innerHTML =
+    `<div class="addr-popup-h">Did you mean <strong>${m.suggest}</strong>?</div>` +
+    `<div class="addr-popup-actions">` +
+    `<button class="btn-sm" id="addr-pop-apply">Use &ldquo;${m.suggest}&rdquo;</button>` +
+    `<button class="btn-sm" id="addr-pop-close">Keep as written</button></div>`;
 
   document.body.appendChild(pop);
   const r = tokenEl.getBoundingClientRect();
@@ -2810,6 +2925,7 @@ function addrInit() {
     b.onclick = () => {
       picker.querySelectorAll('.lang-btn').forEach(x => x.classList.remove('active'));
       b.classList.add('active');
+      if (addrMode !== 'encode') { addrMode = 'encode'; addrApplyMode(); }
       document.getElementById('addr-input').textContent = p.addr;
       addrUpdate();
       document.getElementById('addr-hint').textContent = ADDR_BASE_HINT;
@@ -2825,6 +2941,7 @@ function addrInit() {
   });
   input.textContent = ADDR_PRESETS[0].addr;
   document.getElementById('addr-hint').textContent = ADDR_BASE_HINT;
+  addrApplyMode();
   addrUpdate();
 }
 
@@ -2833,6 +2950,7 @@ const ADDR_BASE_HINT = 'Opcodes stay as symbols; only the entropy-carrying progr
 
 // Exposed for debugging and for driving the panel from a test harness.
 window.addrRead = addrRead;
+window.addrToggle = addrToggle;
 window.addrToggleRoles = addrToggleRoles;
 window.addrCopy = addrCopy;
 

--- a/web/index.html
+++ b/web/index.html
@@ -143,6 +143,31 @@ body {
   flex-shrink: 0;
 }
 .theme-toggle:hover { border-color: var(--accent); }
+.top-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-shrink: 0;
+}
+.book-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s;
+}
+.book-link:hover { border-color: var(--accent); color: var(--accent); }
+.book-link-glyph { color: var(--accent); font-size: 0.9em; }
 
 /* Controls section */
 .controls-section {
@@ -795,6 +820,14 @@ footer a:hover { text-decoration: underline; }
   select, input { font-size: 0.8rem; padding: 0.35rem 0.5rem; }
   .top-bar h1 { font-size: 1.3rem; }
   .top-bar .tagline { font-size: 0.8rem; }
+  /* The title already wraps at this width; a full-width button beside it would
+     squeeze it further, so the link keeps its glyph and drops its words —
+     matching the theme toggle it sits next to. */
+  .book-link {
+    width: 36px; height: 36px; padding: 0; gap: 0;
+    border-radius: 50%; justify-content: center; font-size: 0;
+  }
+  .book-link-glyph { font-size: 1.1rem; }
   #random-btns { width: 100%; }
   #random-btns button { flex: 1 1 auto; min-width: 70px; font-size: 0.65rem; padding: 0.25rem 0.4rem; }
   .preset-tab { padding: 0.4rem 0.6rem; font-size: 0.7rem; }
@@ -817,7 +850,14 @@ footer a:hover { text-decoration: underline; }
       <h1>GLOSSIA:</h1>
       <span class="tagline">human interfaces for machine data</span>
     </div>
-    <button class="theme-toggle" id="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle theme">&#9790;</button>
+    <div class="top-bar-actions">
+      <a class="book-link" href="https://asherp.github.io/Book-of-Bitcoin/bitcoin-book.html"
+         target="_blank" rel="noopener"
+         title="The Book of Bitcoin — the chain read as prose">
+        <span class="book-link-glyph" aria-hidden="true">&#9635;</span>The Book of Bitcoin
+      </a>
+      <button class="theme-toggle" id="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle theme">&#9790;</button>
+    </div>
   </div>
 
   <div id="loading" class="loading">
@@ -1343,7 +1383,7 @@ footer a:hover { text-decoration: underline; }
       <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
       <a href="bulletin.html">Bulletins</a>
       <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
-      <a href="https://asherp.github.io/Book-of-Bitcoin/bitcoin-book.html">The Bitcoin Book</a>
+      <a href="https://asherp.github.io/Book-of-Bitcoin/bitcoin-book.html">The Book of Bitcoin</a>
       <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>
       <a href="docs/">Documentation</a>
       <span style="margin:0 0.5rem;color:var(--border);">&bull;</span>

--- a/web/index.html
+++ b/web/index.html
@@ -143,31 +143,6 @@ body {
   flex-shrink: 0;
 }
 .theme-toggle:hover { border-color: var(--accent); }
-.top-bar-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  flex-shrink: 0;
-}
-.book-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.4rem 0.8rem;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--surface);
-  box-shadow: var(--shadow);
-  color: var(--text);
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  letter-spacing: 0.03em;
-  text-decoration: none;
-  white-space: nowrap;
-  transition: border-color 0.15s, color 0.15s;
-}
-.book-link:hover { border-color: var(--accent); color: var(--accent); }
-.book-link-glyph { color: var(--accent); font-size: 0.9em; }
 
 /* Controls section */
 .controls-section {
@@ -511,6 +486,12 @@ footer a:hover { text-decoration: underline; }
 }
 .hero .cta {
   margin-top: 2rem;
+  /* Three buttons no longer fit one line on a narrow screen, and margin-left
+     spacing leaves a stray gap when they wrap. */
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
 }
 .hero .cta a {
   display: inline-block;
@@ -528,6 +509,15 @@ footer a:hover { text-decoration: underline; }
   transform: translateY(-2px);
   box-shadow: 0 6px 16px rgba(124, 108, 240, 0.4);
 }
+/* Secondary actions: the same shape, outlined rather than filled, so "Try the
+   Demo" stays the one obvious thing to press. */
+.hero .cta a.ghost {
+  background: transparent;
+  color: var(--accent);
+  border: 2px solid var(--accent);
+  padding: calc(0.75rem - 2px) calc(2rem - 2px);
+}
+.hero .cta a.ghost:hover { background: var(--accent); color: #fff; }
 
 /* Section headings */
 .section-header {
@@ -820,14 +810,6 @@ footer a:hover { text-decoration: underline; }
   select, input { font-size: 0.8rem; padding: 0.35rem 0.5rem; }
   .top-bar h1 { font-size: 1.3rem; }
   .top-bar .tagline { font-size: 0.8rem; }
-  /* The title already wraps at this width; a full-width button beside it would
-     squeeze it further, so the link keeps its glyph and drops its words —
-     matching the theme toggle it sits next to. */
-  .book-link {
-    width: 36px; height: 36px; padding: 0; gap: 0;
-    border-radius: 50%; justify-content: center; font-size: 0;
-  }
-  .book-link-glyph { font-size: 1.1rem; }
   #random-btns { width: 100%; }
   #random-btns button { flex: 1 1 auto; min-width: 70px; font-size: 0.65rem; padding: 0.25rem 0.4rem; }
   .preset-tab { padding: 0.4rem 0.6rem; font-size: 0.7rem; }
@@ -850,14 +832,7 @@ footer a:hover { text-decoration: underline; }
       <h1>GLOSSIA:</h1>
       <span class="tagline">human interfaces for machine data</span>
     </div>
-    <div class="top-bar-actions">
-      <a class="book-link" href="https://asherp.github.io/Book-of-Bitcoin/bitcoin-book.html"
-         target="_blank" rel="noopener"
-         title="The Book of Bitcoin — the chain read as prose">
-        <span class="book-link-glyph" aria-hidden="true">&#9635;</span>The Book of Bitcoin
-      </a>
-      <button class="theme-toggle" id="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle theme">&#9790;</button>
-    </div>
+    <button class="theme-toggle" id="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle theme">&#9790;</button>
   </div>
 
   <div id="loading" class="loading">
@@ -880,7 +855,9 @@ footer a:hover { text-decoration: underline; }
 
       <div class="cta">
         <a href="#demo">Try the Demo</a>
-        <a href="compose.html" style="background:transparent; color:var(--accent); border:2px solid var(--accent); margin-left:0.75rem;">Create Bulletin</a>
+        <a class="ghost" href="compose.html">Create Bulletin</a>
+        <a class="ghost" href="https://asherp.github.io/Book-of-Bitcoin/bitcoin-book.html"
+           target="_blank" rel="noopener">The Book of Bitcoin</a>
       </div>
     </section>
 

--- a/web/index.html
+++ b/web/index.html
@@ -17,7 +17,16 @@
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="Glossia">
+<meta name="glossia-build" content="dev">
 <script>
+  // Which build is this page? Two rounds of "the feature you shipped isn't
+  // here" turned out to be a cache serving the previous deploy, so the answer
+  // is now printed in the footer rather than reasoned about.
+  window.GLOSSIA_BUILD = (document.querySelector('meta[name="glossia-build"]') || {}).content || 'dev';
+  window.addEventListener('DOMContentLoaded', () => {
+    const el = document.getElementById('build-stamp');
+    if (el) el.textContent = ' • build ' + window.GLOSSIA_BUILD;
+  });
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('./sw.js').catch((e) => console.warn('SW registration failed:', e));
@@ -1345,6 +1354,7 @@ footer a:hover { text-decoration: underline; }
     </p>
     <p style="font-size:0.7rem;color:var(--text-dim);">
       Client-side WebAssembly &bull; Your keys never leave your device
+      <span id="build-stamp" style="font-family:var(--font-mono);opacity:0.7;"></span>
     </p>
   </footer>
 </div>

--- a/web/index.html
+++ b/web/index.html
@@ -1373,6 +1373,7 @@ import init, {
   decode_raw_base_n as wasmDecodeRawBaseN,
   encode_words as wasmEncodeWords,
   get_payload_words as wasmGetPayloadWords,
+  get_cover_words as wasmGetCoverWords,
   checksum_seed_for as wasmChecksumSeed,
 } from './glossia.js';
 // Shared, authenticated message pipeline (also used by the bulletin board):
@@ -2230,6 +2231,7 @@ const ADDR_PRESETS = [
 
 let addrWords = null;         // BIP39 wordlist, index order
 let addrIndex = null;         // word -> index
+let addrCover = null;         // the connective vocabulary, for locating misspellings
 let addrState = null;         // { program, type, artifact, placements }
 let addrShowRoles = false;
 
@@ -2367,10 +2369,28 @@ function addrSeed(program, counter) {
   return wasmChecksumSeed(addrHex(program) + ADDR_BPW.toString(16).padStart(2, '0') + ADDR_VERSION.toString(16).padStart(2, '0'), BigInt(counter));
 }
 
+// An address determines its prose exactly, so the rendering is a pure function
+// of the program bytes — and the checker asks for the SAME one repeatedly: once
+// to verify, once to diff, and once per keystroke while the payload is untouched
+// (which is every edit to a cover word). Each of those is ~100ms of generation.
+// Memoize on the program.
+const addrProseCache = new Map();
+function addrProse(program) {
+  const key = addrHex(program);
+  if (addrProseCache.has(key)) return addrProseCache.get(key);
+  const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)),
+    'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
+  const text = r.error ? null : r.encoded_text;
+  if (addrProseCache.size > 400) addrProseCache.clear();
+  addrProseCache.set(key, text);
+  return text;
+}
+
 function addrRender(program, type) {
   const words = addrPack(program);
   const r = JSON.parse(wasmEncodeWords(JSON.stringify(words), 'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
   if (r.error) throw new Error(r.error);
+  addrProseCache.set(addrHex(program), r.encoded_text);   // the checker will ask for this
   const lead = addrGlyphs(type, 'lead'), trail = addrGlyphs(type, 'trail');
   return {
     prose: r.encoded_text,
@@ -2403,9 +2423,9 @@ function addrRead(artifact, nBytes) {
                         .filter(t => t.length);
   // One render. The address determines its prose exactly, so there is nothing to
   // search over.
-  const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)), 'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
-  if (r.error) return { verdict: 'unreadable', note: r.error };
-  const got = r.encoded_text.split(/\s+/).filter(Boolean);
+  const rendered = addrProse(program);
+  if (rendered === null) return { verdict: 'unreadable', note: 'encode failed' };
+  const got = rendered.split(/\s+/).filter(Boolean);
   if (got.join(' ') === proseToks.join(' ')) return { verdict: 'verified', program, match: 1 };
   const n = Math.max(got.length, proseToks.length, 1);
   let same = 0;
@@ -2427,10 +2447,9 @@ function addrRead(artifact, nBytes) {
 function addrDiffAgainstRerender(artifact, program) {
   const recv = artifact.split(/\s+/).filter(Boolean).map(t =>
     [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('')).filter(t => t.length);
-  const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)),
-    'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
-  if (r.error) return { bad: new Set(), rendered: [] };
-  const got = r.encoded_text.split(/\s+/).filter(Boolean);
+  const text = addrProse(program);
+  if (text === null) return { bad: new Set(), rendered: [] };
+  const got = text.split(/\s+/).filter(Boolean);
   const bad = new Set();
   for (let i = 0; i < Math.max(got.length, recv.length); i++) if (got[i] !== recv[i]) bad.add(i);
   return { bad, rendered: got, recv };
@@ -2469,15 +2488,16 @@ function addrProposeRepairs(artifact, words) {
   const recv = artifact.split(/\s+/).filter(Boolean).map(t =>
     [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('')).filter(t => t.length);
   const hits = [];
+  const deadline = performance.now() + ADDR_SEARCH_MS;
   for (let i = 0; i < words.length; i++) {
     for (const cand of addrEdit1(words[i])) {
+      if (performance.now() > deadline) return hits;
       const w = words.slice(); w[i] = cand;
       const prog = addrUnpack(w, addrState ? addrState.program.length : 20);
       if (!prog) continue;
-      const r = JSON.parse(wasmEncodeWords(JSON.stringify(w), 'english', 'default', 'body',
-        addrSeed(prog, 0), ADDR_BEST_OF));
-      if (r.error) continue;
-      const got = r.encoded_text.split(/\s+/).filter(Boolean);
+      const text = addrProse(prog);
+      if (text === null) continue;
+      const got = text.split(/\s+/).filter(Boolean);
       let miss = 0;
       for (let k = 0; k < Math.max(got.length, recv.length); k++) if (got[k] !== recv[k]) miss++;
       if (miss <= 1) hits.push({ index: i, from: words[i], to: cand });
@@ -2740,6 +2760,15 @@ function addrApplyDamage(i) {
 // and re-rendering either reproduces the received text or it does not.
 const SPELL = 'spell', GRAMMAR = 'grammar';
 
+// A repair search that FAILS is the expensive one: a word two typos away from
+// any address word has no single-edit explanation, so the search only learns
+// that by trying everything. Cap it. Nothing is lost by stopping — the verdict
+// for "searched and found nothing" and "stopped searching" is the same claim,
+// that no single typo explains the text. And because every candidate render is
+// memoized, a repeat check picks up where this one left off for free, so the
+// search completes across a pause instead of blocking one keystroke.
+const ADDR_SEARCH_MS = 250;
+
 /// Analyse an artifact and return per-token annotations.
 /// { kind, suggest, note } keyed by token index; empty map means clean.
 function addrCheck(artifact, nBytes) {
@@ -2758,9 +2787,22 @@ function addrCheck(artifact, nBytes) {
   // dictionary at all — so look for a nearby dictionary word that restores the
   // count AND explains the wording.
   if (harvested.length < expected) {
+    // Candidate sites are tokens that are not address words — but the connective
+    // prose is not in the address wordlist either, so taking every such token
+    // meant trying edit-neighbours of "may", "to", "a" and the rest, each a full
+    // re-render. Sites the cover vocabulary explains come SECOND, not never: a
+    // mistyped address word can land on a real cover word, and that case still
+    // has to be findable. Ordering it this way makes the common case ~10x less
+    // work without giving up any answer.
+    const sites = [];
     for (let i = 0; i < toks.length; i++) {
       const c = core(toks[i]);
       if (!c || addrIndex.has(c)) continue;
+      sites.push([i, c, addrCover && addrCover.has(c) ? 1 : 0]);
+    }
+    sites.sort((a, b) => a[2] - b[2]);
+    const deadline = performance.now() + ADDR_SEARCH_MS;
+    for (const [i, c] of sites) {
       for (const cand of addrEdit1(c)) {
         const trial = toks.slice();
         trial[i] = addrSwapIn(toks[i], cand);
@@ -2770,6 +2812,7 @@ function addrCheck(artifact, nBytes) {
             note: `not an address word; “${cand}” restores the address and matches the wording` });
           return { marks, verdict: 'repairable' };
         }
+        if (performance.now() > deadline) return { marks, verdict: 'short' };
       }
     }
     return { marks, verdict: 'short' };
@@ -2779,13 +2822,12 @@ function addrCheck(artifact, nBytes) {
   // ── right count: compare against the re-render ────────────────────────
   const program = addrUnpack(harvested, nBytes);
   if (!program) return { marks, verdict: 'undecodable' };
-  const { bad } = addrDiffAgainstRerender(artifact, program);
+  // `rendered` IS the expected wording — the diff just computed it, so asking
+  // for it again was a second full generation for an answer already in hand.
+  const { bad, rendered: expectedToks } = addrDiffAgainstRerender(artifact, program);
   if (bad.size === 0) return { marks, verdict: 'clean' };
 
   const payloadPositions = new Set(harvestIdx);
-  const rr = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)),
-    'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
-  const expectedToks = rr.error ? [] : rr.encoded_text.split(/\s+/).filter(Boolean);
 
   // Map diff indices (which count prose tokens) back to artifact token indices.
   const proseIdx = toks.map((t, i) => core(t) ? i : -1).filter(i => i >= 0);
@@ -2970,17 +3012,32 @@ function addrSetCaret(root, offset) {
   sel.removeAllRanges(); sel.addRange(r);
 }
 
+// A check is one generation in the easy cases and up to sixteen when an address
+// word is wrong, so it can take a beat. Yield a frame first and say so, rather
+// than freezing mid-keystroke with a stale verdict still on screen. The token
+// drops a result whose text has already been superseded.
+let addrCheckToken = 0;
+
 function addrRecheck() {
   if (addrMode !== 'encode' || !addrState) return;
   const box = document.getElementById('addr-output');
   const caret = addrCaretOffset(box);
   const text = box.textContent.replace(/\s+/g, ' ').trim();
   if (!text) return;
-  const res = addrRead(text, addrState.program.length);
-  addrSetVerdict(res);
-  addrPaintDamage(box, text, res);
-  addrSetCaret(box, caret);
-  document.getElementById('addr-hint').textContent = ADDR_BASE_HINT;
+
+  const el = document.getElementById('addr-verdict');
+  el.className = 'addr-verdict';
+  el.textContent = '… checking';
+  const token = ++addrCheckToken;
+
+  requestAnimationFrame(() => {
+    if (token !== addrCheckToken) return;
+    const res = addrRead(text, addrState.program.length);
+    addrSetVerdict(res);
+    addrPaintDamage(box, text, res);
+    addrSetCaret(box, caret);
+    document.getElementById('addr-hint').textContent = ADDR_BASE_HINT;
+  });
 }
 
 function addrToggleRoles() {
@@ -2999,6 +3056,8 @@ function addrInit() {
   if (wl.error) { console.error('address panel:', wl.error); return; }
   addrWords = wl;
   addrIndex = new Map(wl.map((w, i) => [w.toLowerCase(), i]));
+  const cw = JSON.parse(wasmGetCoverWords('english', 'bip39'));
+  addrCover = new Set(cw.error ? [] : cw);
 
   const picker = document.getElementById('addr-picker');
   ADDR_PRESETS.forEach((p, i) => {
@@ -3023,9 +3082,12 @@ function addrInit() {
     input._t = setTimeout(addrUpdate, 250);
   });
   const out = document.getElementById('addr-output');
-  out.addEventListener('input', () => {
+  out.addEventListener('input', e => {
     clearTimeout(out._t);
-    out._t = setTimeout(addrRecheck, 400);
+    // A spell checker flags a word when you leave it, not while you are inside
+    // it — so finishing a word checks almost at once, and typing mid-word waits.
+    const left = typeof e.data === 'string' && /[\s.,;:!?]/.test(e.data);
+    out._t = setTimeout(addrRecheck, left ? 60 : 250);
   });
   // Paste as plain text, or the browser drops styled markup into the box and the
   // token diff picks up formatting rather than words.

--- a/web/index.html
+++ b/web/index.html
@@ -2143,13 +2143,16 @@ const ADDR_MARKUP = new Set(Object.values(ADDR_OPS).map(([g]) => g));
 const addrGlyphs = (type, which) => ((ADDR_SCRIPT[type] || {})[which] || []).map(k => ADDR_OPS[k][0]).join(' ');
 const addrLegend = type => ((ADDR_SCRIPT[type] || {}).lead || []).concat((ADDR_SCRIPT[type] || {}).trail || [])
   .map(k => ADDR_OPS[k][0] + ' ' + ADDR_OPS[k][1]).join('  \u00b7  ');
-// No counter sweep. The counter existed so the ENCODER could shop for a more
-// fluent rendering among N seeds — but verification does not generate anything,
-// it reproduces a fixed artifact, so every counter the encoder MAY have used is
-// one the verifier MUST try, and a repair search must try per candidate. Fixing
-// it makes encoding deterministic: one render to encode, one to verify, one per
-// repair candidate. Costs ~6% longer prose; saves a 2.4x multiplier everywhere.
-const ADDR_COUNTER_RANGE = 1;
+// Fluency budget, locked at 4. This is a fixed PARAMETER, not a search: the
+// encoder renders best-of-4 from the checksum seed, and the verifier renders
+// best-of-4 from the same seed and compares. One address, one prose — there is
+// no counter to sweep and no ambiguity about which rendering is canonical.
+//
+// 4 is where the marginal return falls off. Measured over 96 payloads x 128
+// candidates at both address sizes, density rises 0.53 -> 0.59 (20B) going from
+// N=1 to N=4, and every doubling past N=8 buys under one word while costing
+// linearly more to verify.
+const ADDR_BEST_OF = 4;
 const ADDR_VERSION = 1;
 const ADDR_PRESETS = [
   { label: 'P2WPKH', addr: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4' },
@@ -2248,7 +2251,7 @@ function addrSeed(program, counter) {
 
 function addrRender(program, type) {
   const words = addrPack(program);
-  const r = JSON.parse(wasmEncodeWords(JSON.stringify(words), 'english', 'default', 'body', addrSeed(program, 0), ADDR_COUNTER_RANGE));
+  const r = JSON.parse(wasmEncodeWords(JSON.stringify(words), 'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
   if (r.error) throw new Error(r.error);
   const lead = addrGlyphs(type, 'lead'), trail = addrGlyphs(type, 'trail');
   return {
@@ -2282,7 +2285,7 @@ function addrRead(artifact, nBytes) {
                         .filter(t => t.length);
   // One render. The address determines its prose exactly, so there is nothing to
   // search over.
-  const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)), 'english', 'default', 'body', addrSeed(program, 0), 1));
+  const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)), 'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
   if (r.error) return { verdict: 'unreadable', note: r.error };
   const got = r.encoded_text.split(/\s+/).filter(Boolean);
   if (got.join(' ') === proseToks.join(' ')) return { verdict: 'verified', program, match: 1 };
@@ -2307,7 +2310,7 @@ function addrDiffAgainstRerender(artifact, program) {
   const recv = artifact.split(/\s+/).filter(Boolean).map(t =>
     [...t].filter(ch => !ADDR_MARKUP.has(ch)).join('')).filter(t => t.length);
   const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)),
-    'english', 'default', 'body', addrSeed(program, 0), ADDR_COUNTER_RANGE));
+    'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
   if (r.error) return { bad: new Set(), rendered: [] };
   const got = r.encoded_text.split(/\s+/).filter(Boolean);
   const bad = new Set();
@@ -2354,7 +2357,7 @@ function addrProposeRepairs(artifact, words) {
       const prog = addrUnpack(w, addrState ? addrState.program.length : 20);
       if (!prog) continue;
       const r = JSON.parse(wasmEncodeWords(JSON.stringify(w), 'english', 'default', 'body',
-        addrSeed(prog, 0), ADDR_COUNTER_RANGE));
+        addrSeed(prog, 0), ADDR_BEST_OF));
       if (r.error) continue;
       const got = r.encoded_text.split(/\s+/).filter(Boolean);
       let miss = 0;

--- a/web/index.html
+++ b/web/index.html
@@ -879,7 +879,22 @@ footer a:hover { text-decoration: underline; }
         /* Stacked demos (no tabs): encryption first, each visually separated. */
         .demo-section { display: flex; flex-direction: column; }
         #panel-encrypt { order: -1; }
-        #panel-bip39, #panel-apikey { border-top: 1px solid var(--border); padding-top: 0.5rem; }
+        #panel-address { order: 0; }
+        #panel-bip39, #panel-apikey, #panel-address { border-top: 1px solid var(--border); padding-top: 0.5rem; }
+        /* Prose address */
+        .addr-picker { display: flex; gap: 0.35rem; justify-content: center; flex-wrap: wrap; margin-bottom: 0.9rem; }
+        .addr-meta { font-family: var(--font-mono); font-size: 0.65rem; color: var(--text-dim); }
+        .addr-verdict { margin-left: auto; font-size: 0.7rem; font-family: var(--font-mono);
+          padding: 0.15rem 0.5rem; border-radius: 999px; border: 1px solid transparent; white-space: nowrap; }
+        .addr-verdict.ok   { color: var(--success); border-color: rgba(34,197,94,0.4);  background: rgba(34,197,94,0.1); }
+        .addr-verdict.warn { color: var(--orange);  border-color: rgba(249,115,22,0.4); background: rgba(249,115,22,0.1); }
+        .addr-verdict.bad  { color: var(--error);   border-color: rgba(239,68,68,0.4);  background: rgba(239,68,68,0.1); }
+        .addr-damage { max-width: 720px; margin: 0.9rem auto 0; text-align: center; }
+        .addr-damage-label { font-size: 0.75rem; color: var(--text-dim); }
+        .addr-damage-row { display: flex; gap: 0.4rem; justify-content: center; flex-wrap: wrap; margin-top: 0.5rem; }
+        .addr-cover { color: var(--text-dim); }
+        .addr-pay { text-decoration: underline; text-decoration-color: var(--accent); }
+        .addr-pay sub { font-size: 0.6em; color: var(--accent); opacity: 0.85; }
         .enc-password-row { display: flex; align-items: center; justify-content: center;
           gap: 0.6rem; margin-bottom: 1rem; flex-wrap: wrap; }
         .enc-password-row input { min-width: 260px; }
@@ -1002,6 +1017,75 @@ footer a:hover { text-decoration: underline; }
             bits, recovering the key in whichever format you pick — <strong>ASCII</strong>,
             <strong>hex</strong>, or <strong>base64</strong>. Press <strong>⇄</strong> to switch
             direction; the output format defaults to the one detected when encoding.</p>
+          </div>
+        </details>
+      </div>
+
+      <!-- ─── Prose Bitcoin address panel ──────────────────────────── -->
+      <div id="panel-address">
+        <div class="section-header">
+          <h3>Bitcoin Address as Prose</h3>
+          <p>A locking script you can read, dictate, and check by eye &mdash; and that tells you when it has been damaged</p>
+        </div>
+
+        <div class="addr-picker" id="addr-picker"></div>
+
+        <div class="panels">
+          <div class="panel panel-left">
+            <div class="panel-header">
+              <span class="dialect-label">Bitcoin address</span>
+            </div>
+            <div class="panel-body">
+              <div contenteditable="true" spellcheck="false" id="addr-input" class="io-input"
+                   data-placeholder="Pick an address above, or paste a bc1&hellip; / 1&hellip; / 3&hellip; address"></div>
+            </div>
+            <div class="panel-footer">
+              <span class="addr-meta" id="addr-meta"></span>
+              <div id="addr-error" class="error-msg hidden" style="padding:0;"></div>
+            </div>
+          </div>
+
+          <div class="panel panel-right">
+            <div class="panel-header">
+              <span class="dialect-label">Prose address</span>
+              <span class="addr-verdict" id="addr-verdict"></span>
+            </div>
+            <div class="panel-body">
+              <div class="output-area empty" id="addr-output">Output will appear here</div>
+            </div>
+            <div class="panel-footer">
+              <button class="btn-sm" id="addr-roles-btn" onclick="addrToggleRoles()"
+                      title="Show the grammatical role of each address word">Show roles</button>
+              <button class="btn-sm" onclick="addrCopy()">Copy</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="addr-damage">
+          <span class="addr-damage-label">Now damage it, the way a person would:</span>
+          <div class="addr-damage-row" id="addr-damage-row"></div>
+        </div>
+
+        <details class="demo-details" id="addr-how">
+          <summary id="addr-hint"></summary>
+          <div class="enc-how-body">
+            <p>The opcodes are shown as symbols (<strong>&#9661;</strong> witness v0,
+            <strong>&#9651;</strong> v1/Taproot, <strong>&#8981;</strong> hash160), so Glossia only
+            encodes the part that carries entropy &mdash; the 20- or 32-byte program. That is
+            <strong>15 words</strong> for a hash160 address and <strong>24</strong> for a 32-byte one.</p>
+            <p>The format's version and wordlist size ride in the <strong>bit-packing slack</strong>
+            and cost nothing: 160 data bits + 5 header bits is exactly 15 words, and 256 + 8 is
+            exactly 24. Wordlist size is stored as its log&#8322;, which fits in 4 bits because
+            payload wordlists are powers of two.</p>
+            <p><strong>The wording is the checksum.</strong> The cover words are chosen by a seed
+            derived from a CRC-32 of the address, so a different address produces a visibly
+            different paragraph. Verification re-renders the address you decoded and compares:
+            only the true bytes reproduce this exact wording. That costs no extra words, because
+            the information rides in <em>which</em> prose was chosen rather than in any word's value.</p>
+            <p>Try the damage buttons. A fumbled connective word still yields the right address but
+            can no longer self-verify. A mistyped <em>address</em> word decodes to a different
+            address &mdash; caught only by the wording. A lost word is caught by the word count,
+            since a fixed-length address has a fixed number of words.</p>
           </div>
         </details>
       </div>
@@ -1200,6 +1284,10 @@ import init, {
   get_default_wordlist as wasmGetDefaultWordlist,
   encode_raw_base_n as wasmEncodeRawBaseN,
   decode_raw_base_n as wasmDecodeRawBaseN,
+  encode_words as wasmEncodeWords,
+  get_payload_words as wasmGetPayloadWords,
+  checksum_seed_for as wasmChecksumSeed,
+  payload_crc32 as wasmPayloadCrc32,
 } from './glossia.js';
 // Shared, authenticated message pipeline (also used by the bulletin board):
 // AES-256-GCM, with the plumbing carried as a Latin "— attribution" trailer.
@@ -1997,6 +2085,324 @@ toggleBtn.addEventListener('click', () => {
 });
 updateToggleIcon();
 
+// ─── Prose Bitcoin address ────────────────────────────────────────────
+// A locking script rendered as prose whose COVER WORDS carry the checksum:
+// the cover seed is derived from a CRC-32 of the address, so a different
+// address yields a visibly different paragraph, and re-rendering what you
+// decoded is the verification step. Opcodes are shown as symbols, so Glossia
+// encodes only the entropy-carrying program (20 or 32 bytes).
+//
+// The bit packing lives here rather than in the codec because the layout is a
+// property of the ADDRESS FORMAT, not of Glossia: the header rides in the
+// bit-packing slack (160+5 = 15 words exactly; 256+8 = 24 words exactly).
+
+const ADDR_SIGILS = { P2PKH: '⧉ ⌗', P2SH: '⌗', P2WPKH: '▽', P2WSH: '▽', P2TR: '△' };
+const ADDR_TRAIL = { P2PKH: '≟ ✓', P2SH: '⩵', P2WPKH: '', P2WSH: '', P2TR: '' };
+const ADDR_COUNTER_RANGE = 4;
+const ADDR_VERSION = 1;
+const ADDR_PRESETS = [
+  { label: 'P2WPKH', addr: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4' },
+  { label: 'P2TR',   addr: 'bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9' },
+  { label: 'P2PKH',  addr: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa' },
+  { label: 'P2SH',   addr: '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy' },
+];
+
+let addrWords = null;         // BIP39 wordlist, index order
+let addrIndex = null;         // word -> index
+let addrState = null;         // { program, type, artifact, placements }
+let addrShowRoles = false;
+
+const B58A = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const BECH32A = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+
+async function sha256d(b) {
+  const a = await crypto.subtle.digest('SHA-256', b);
+  return new Uint8Array(await crypto.subtle.digest('SHA-256', a));
+}
+
+async function b58check(s) {
+  let n = 0n;
+  for (const c of s) { const i = B58A.indexOf(c); if (i < 0) throw new Error('bad base58 character'); n = n * 58n + BigInt(i); }
+  const raw = new Uint8Array(25);
+  for (let i = 24; i >= 0; i--) { raw[i] = Number(n & 0xffn); n >>= 8n; }
+  const body = raw.slice(0, 21), chk = raw.slice(21);
+  const d = (await sha256d(body)).slice(0, 4);
+  if (chk.some((v, i) => v !== d[i])) throw new Error('address checksum failed');
+  return { version: body[0], program: body.slice(1) };
+}
+
+function bech32Poly(v) {
+  const G = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+  let chk = 1;
+  for (const x of v) { const b = chk >> 25; chk = ((chk & 0x1ffffff) << 5) ^ x; for (let i = 0; i < 5; i++) if ((b >> i) & 1) chk ^= G[i]; }
+  return chk >>> 0;
+}
+function bech32Expand(h) { const o = []; for (const c of h) o.push(c.charCodeAt(0) >> 5); o.push(0); for (const c of h) o.push(c.charCodeAt(0) & 31); return o; }
+function convertBits(data, from, to, pad) {
+  let acc = 0, bits = 0; const out = [], maxv = (1 << to) - 1;
+  for (const v of data) { acc = (acc << from) | v; bits += from; while (bits >= to) { bits -= to; out.push((acc >> bits) & maxv); } }
+  if (pad && bits) out.push((acc << (to - bits)) & maxv);
+  return out;
+}
+function bech32Decode(addr) {
+  const i = addr.lastIndexOf('1');
+  if (i < 1) throw new Error('not a bech32 address');
+  const hrp = addr.slice(0, i), dp = addr.slice(i + 1);
+  const data = [...dp].map(c => { const k = BECH32A.indexOf(c); if (k < 0) throw new Error('bad bech32 character'); return k; });
+  const witver = data[0];
+  const want = witver === 0 ? 1 : 0x2bc830a3;
+  if (bech32Poly(bech32Expand(hrp).concat(data)) !== want) throw new Error('address checksum failed');
+  return { witver, program: Uint8Array.from(convertBits(data.slice(1, -6), 5, 8, false)) };
+}
+
+async function addrParse(text) {
+  const s = (text || '').trim();
+  if (!s) throw new Error('');
+  if (s[0] === '1' || s[0] === '3') {
+    const { version, program } = await b58check(s);
+    return { type: version === 0 ? 'P2PKH' : 'P2SH', program };
+  }
+  const { witver, program } = bech32Decode(s.toLowerCase());
+  if (witver === 0) return { type: program.length === 20 ? 'P2WPKH' : 'P2WSH', program };
+  return { type: 'P2TR', program };
+}
+
+// ── bit packing: program bits, then the header, filling the slack exactly ──
+const ADDR_BPW = 11;
+function addrHeaderBits(n) { return Math.ceil(n * 8 / ADDR_BPW) * ADDR_BPW - n * 8; }
+function addrPack(program) {
+  const hb = addrHeaderBits(program.length);
+  const header = (ADDR_BPW << (hb - 4)) | ADDR_VERSION;
+  const db = program.length * 8, n = (db + hb) / ADDR_BPW, out = [];
+  const bit = i => i < db ? (program[i >> 3] >> (7 - (i & 7))) & 1 : (header >> (hb - 1 - (i - db))) & 1;
+  for (let w = 0; w < n; w++) { let v = 0; for (let b = 0; b < ADDR_BPW; b++) v = (v << 1) | bit(w * ADDR_BPW + b); out.push(addrWords[v]); }
+  return out;
+}
+function addrUnpack(words, nBytes) {
+  const hb = addrHeaderBits(nBytes);
+  if (words.length !== (nBytes * 8 + hb) / ADDR_BPW) return null;
+  const bits = [];
+  for (const w of words) { const i = addrIndex.get(w.toLowerCase()); if (i === undefined) return null; for (let b = ADDR_BPW - 1; b >= 0; b--) bits.push((i >> b) & 1); }
+  const prog = new Uint8Array(nBytes);
+  for (let i = 0; i < nBytes; i++) { let v = 0; for (let b = 0; b < 8; b++) v = (v << 1) | bits[i * 8 + b]; prog[i] = v; }
+  return prog;
+}
+const addrHex = b => [...b].map(x => x.toString(16).padStart(2, '0')).join('');
+
+// The checksum covers the program plus the header bytes, i.e. exactly the
+// encoded bits. Derived in Rust so browser and core agree bit-for-bit.
+function addrSeed(program, counter) {
+  return wasmChecksumSeed(addrHex(program) + ADDR_BPW.toString(16).padStart(2, '0') + ADDR_VERSION.toString(16).padStart(2, '0'), BigInt(counter));
+}
+
+function addrRender(program, type) {
+  const words = addrPack(program);
+  const r = JSON.parse(wasmEncodeWords(JSON.stringify(words), 'english', 'default', 'body', addrSeed(program, 0), ADDR_COUNTER_RANGE));
+  if (r.error) throw new Error(r.error);
+  const lead = ADDR_SIGILS[type] || '', trail = ADDR_TRAIL[type] || '';
+  return {
+    prose: r.encoded_text,
+    artifact: [lead, r.encoded_text, trail].filter(Boolean).join(' '),
+    placements: r.placements || [],
+    words,
+  };
+}
+
+// Decode + verify. Mirrors the Rust walkthrough: word count first (a fixed-length
+// address has a fixed word count), then re-render and compare.
+function addrRead(artifact, nBytes) {
+  const toks = artifact.split(/\s+/).filter(Boolean);
+  const harvested = toks.map(w => w.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '').toLowerCase())
+                        .filter(w => w && addrIndex.has(w));
+  const expected = (nBytes * 8 + addrHeaderBits(nBytes)) / ADDR_BPW;
+  if (harvested.length !== expected)
+    return { verdict: 'unreadable', note: `wrong number of address words (${harvested.length}, expected ${expected})` };
+  const program = addrUnpack(harvested, nBytes);
+  if (!program) return { verdict: 'unreadable', note: 'word not in the address vocabulary' };
+
+  const proseToks = toks.filter(t => t.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '') !== '' &&
+                                     !/^[▽△⌗⧉≟✓⩵ ]+$/u.test(t));
+  let best = 0;
+  for (let c = 0; c < ADDR_COUNTER_RANGE; c++) {
+    const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)), 'english', 'default', 'body', addrSeed(program, 0) + BigInt(c), 1));
+    if (r.error) continue;
+    const got = r.encoded_text.split(/\s+/).filter(Boolean);
+    if (got.join(' ') === proseToks.join(' ')) return { verdict: 'verified', program, match: 1 };
+    const n = Math.max(got.length, proseToks.length, 1);
+    let same = 0;
+    for (let i = 0; i < Math.min(got.length, proseToks.length); i++) if (got[i] === proseToks[i]) same++;
+    best = Math.max(best, same / n);
+  }
+  return best > 0.75
+    ? { verdict: 'unverified', program, match: best }
+    : { verdict: 'mismatch', program, match: best };
+}
+
+function addrSetVerdict(res) {
+  const el = document.getElementById('addr-verdict');
+  const map = {
+    verified:   ['ok',   '✓ verified'],
+    unverified: ['warn', '⚠ readable, not verified'],
+    mismatch:   ['bad',  '✗ wrong address'],
+    unreadable: ['bad',  '✗ unreadable'],
+  };
+  const [cls, label] = map[res.verdict];
+  el.className = 'addr-verdict ' + cls;
+  const pct = res.match !== undefined && res.verdict !== 'verified' ? ` (${Math.round(res.match * 100)}% wording)` : '';
+  el.textContent = label + pct;
+  el.title = res.note || '';
+}
+
+function addrPaint(artifact, placements) {
+  const box = document.getElementById('addr-output');
+  box.classList.remove('empty');
+  if (!addrShowRoles) { box.textContent = artifact; return; }
+  const byTok = new Map(placements.map(p => [p.token_index, p]));
+  const lead = artifact.slice(0, artifact.length - addrState.prose.length);
+  const toks = addrState.prose.split(/\s+/);
+  const html = toks.map((t, i) => {
+    const p = byTok.get(i);
+    if (!p) return `<span class="addr-cover">${t}</span>`;
+    const role = p.role ? `<sub>${p.role === 'subject' ? 'subj' : 'obj'}</sub>` : '';
+    return `<u class="addr-pay">${t}${role}</u>`;
+  }).join(' ');
+  box.innerHTML = `<span class="addr-cover">${lead}</span>${html}`;
+}
+
+async function addrUpdate() {
+  const errEl = document.getElementById('addr-error');
+  const metaEl = document.getElementById('addr-meta');
+  try {
+    const { type, program } = await addrParse(document.getElementById('addr-input').textContent);
+    const r = addrRender(program, type);
+    addrState = { program, type, ...r };
+    errEl.classList.add('hidden');
+    metaEl.textContent = `${type} · ${program.length}-byte program · ${r.words.length} address words · crc32 ${wasmPayloadCrc32(addrHex(program)).toString(16).padStart(8, '0')}`;
+    addrPaint(r.artifact, r.placements);
+    addrSetVerdict(addrRead(r.artifact, program.length));
+    addrRenderDamage();
+  } catch (e) {
+    addrState = null;
+    metaEl.textContent = '';
+    document.getElementById('addr-output').textContent = 'Output will appear here';
+    document.getElementById('addr-output').classList.add('empty');
+    document.getElementById('addr-verdict').textContent = '';
+    if (e.message) { errEl.textContent = e.message; errEl.classList.remove('hidden'); }
+    else errEl.classList.add('hidden');
+  }
+}
+
+// Damage simulations, each a real transcription failure mode.
+function addrDamages() {
+  if (!addrState) return [];
+  const pros = addrState.prose, places = addrState.placements;
+  const toks = pros.split(/\s+/);
+  const payTok = new Set(places.map(p => p.token_index));
+  const coverIdx = toks.map((_, i) => i).filter(i => !payTok.has(i) && toks[i].length > 2);
+  const mid = places[Math.floor(places.length / 2)];
+  return [
+    {
+      label: 'fumble a connective word',
+      why: 'The address words are untouched, so the address is still right — but the wording no longer matches, so it cannot self-verify.',
+      apply: () => { const t = [...toks]; if (coverIdx.length) t[coverIdx[0]] = t[coverIdx[0]] + 's'; return t.join(' '); },
+    },
+    {
+      label: 'mistype an address word',
+      why: 'The dangerous one. A valid substitute still decodes — to a DIFFERENT address. Only the wording catches it.',
+      apply: () => { const t = [...toks]; t[mid.token_index] = addrWords[(addrIndex.get(mid.word) + 977) % addrWords.length]; return t.join(' '); },
+    },
+    {
+      label: 'lose a word',
+      why: 'A fixed-length address has a fixed word count, so a dropped word is caught before anything is decoded.',
+      apply: () => { const t = [...toks]; t.splice(places[1].token_index, 1); return t.join(' '); },
+    },
+  ];
+}
+
+function addrRenderDamage() {
+  const row = document.getElementById('addr-damage-row');
+  row.innerHTML = '';
+  addrDamages().forEach((d, i) => {
+    const b = document.createElement('button');
+    b.className = 'btn-sm';
+    b.textContent = d.label;
+    b.onclick = () => addrApplyDamage(i);
+    row.appendChild(b);
+  });
+  const reset = document.createElement('button');
+  reset.className = 'btn-sm';
+  reset.textContent = '↺ reset';
+  reset.onclick = () => addrUpdate();
+  row.appendChild(reset);
+}
+
+function addrApplyDamage(i) {
+  if (!addrState) return;
+  const d = addrDamages()[i];
+  const damagedProse = d.apply();
+  const lead = addrState.artifact.slice(0, addrState.artifact.length - addrState.prose.length);
+  const trail = ADDR_TRAIL[addrState.type] ? ' ' + ADDR_TRAIL[addrState.type] : '';
+  const artifact = lead + damagedProse + trail;
+  const box = document.getElementById('addr-output');
+  box.classList.remove('empty');
+  box.textContent = artifact;
+  const res = addrRead(artifact, addrState.program.length);
+  addrSetVerdict(res);
+  const hint = document.getElementById('addr-hint');
+  const got = res.program ? addrHex(res.program) : null;
+  hint.textContent = d.why + (got && got !== addrHex(addrState.program)
+    ? ` It decodes to ${got.slice(0, 12)}… instead.` : '');
+}
+
+function addrToggleRoles() {
+  addrShowRoles = !addrShowRoles;
+  document.getElementById('addr-roles-btn').textContent = addrShowRoles ? 'Hide roles' : 'Show roles';
+  if (addrState) addrPaint(addrState.artifact, addrState.placements);
+}
+
+function addrCopy() {
+  const t = document.getElementById('addr-output').textContent;
+  navigator.clipboard.writeText(t);
+}
+
+function addrInit() {
+  const wl = JSON.parse(wasmGetPayloadWords('english', 'bip39'));
+  if (wl.error) { console.error('address panel:', wl.error); return; }
+  addrWords = wl;
+  addrIndex = new Map(wl.map((w, i) => [w.toLowerCase(), i]));
+
+  const picker = document.getElementById('addr-picker');
+  ADDR_PRESETS.forEach((p, i) => {
+    const b = document.createElement('button');
+    b.className = 'btn-sm lang-btn' + (i === 0 ? ' active' : '');
+    b.textContent = p.label;
+    b.onclick = () => {
+      picker.querySelectorAll('.lang-btn').forEach(x => x.classList.remove('active'));
+      b.classList.add('active');
+      document.getElementById('addr-input').textContent = p.addr;
+      addrUpdate();
+      document.getElementById('addr-hint').textContent = ADDR_BASE_HINT;
+    };
+    picker.appendChild(b);
+  });
+
+  const input = document.getElementById('addr-input');
+  input.addEventListener('input', () => {
+    picker.querySelectorAll('.lang-btn').forEach(x => x.classList.remove('active'));
+    clearTimeout(input._t);
+    input._t = setTimeout(addrUpdate, 250);
+  });
+  input.textContent = ADDR_PRESETS[0].addr;
+  document.getElementById('addr-hint').textContent = ADDR_BASE_HINT;
+  addrUpdate();
+}
+
+const ADDR_BASE_HINT = 'Opcodes stay as symbols; only the entropy-carrying program is encoded. ' +
+  'The cover words are chosen by a seed derived from the address itself, so the wording IS the checksum.';
+
+window.addrToggleRoles = addrToggleRoles;
+window.addrCopy = addrCopy;
+
 // ─── Startup ─────────────────────────────────────────────────────────
 
 async function startup() {
@@ -2018,6 +2424,9 @@ async function startup() {
     });
     updateChrome();
     generateSeed();
+
+    // Prose Bitcoin address panel
+    try { addrInit(); } catch (e) { console.error('address panel failed to start:', e); }
 
     // API Key panel
     akBuildButtons();

--- a/web/index.html
+++ b/web/index.html
@@ -301,7 +301,9 @@ mark {
   height: 48px;
   border-radius: 50%;
   background: var(--surface);
-  border: 2px solid var(--border);
+  /* The neutral border disappeared against a dark surface — a control nobody
+     can find is a control that does not exist. */
+  border: 2px solid var(--accent);
   color: var(--accent);
   display: flex;
   align-items: center;
@@ -319,7 +321,19 @@ mark {
   box-shadow: 0 4px 12px rgba(124, 108, 240, 0.3);
   transform: translate(-50%, -50%) scale(1.05);
 }
-.swap-btn svg { width: 20px; height: 20px; fill: currentColor; }
+.swap-btn svg { width: 22px; height: 22px; fill: currentColor; }
+.swap-btn::after {
+  content: attr(data-label);
+  position: absolute;
+  top: 100%;
+  margin-top: 0.4rem;
+  font-size: 0.6rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  white-space: nowrap;
+  pointer-events: none;
+}
 
 /* Buttons */
 button {
@@ -2506,6 +2520,7 @@ function addrApplyMode() {
   document.getElementById('addr-right-label').textContent = enc ? 'Prose address' : 'Bitcoin address';
   document.getElementById('addr-input').dataset.placeholder =
     enc ? 'Paste a bc1… / 1… / 3… address' : 'Paste a prose address';
+  document.getElementById('addr-swap-btn').dataset.label = enc ? 'encode' : 'decode';
   document.getElementById('addr-damage').classList.toggle('hidden', !enc);
   document.getElementById('addr-picker').classList.toggle('hidden', !enc);
   document.getElementById('addr-roles-btn').classList.toggle('hidden', !enc);

--- a/web/index.html
+++ b/web/index.html
@@ -884,6 +884,19 @@ footer a:hover { text-decoration: underline; }
         /* Prose address */
         .addr-legend { text-align: center; font-family: var(--font-mono); font-size: 0.68rem;
           color: var(--text-dim); margin: -0.4rem 0 0.9rem; }
+        .addr-solo { max-width: 760px; margin: 0 auto; }
+        .addr-solo .panel-footer { display: flex; align-items: center; gap: 0.5rem; }
+        .addr-solo .panel-footer .addr-meta { margin-right: auto; }
+        .addr-raw { max-width: 720px; margin: 1rem auto 0; }
+        .addr-raw > summary { list-style: none; cursor: pointer; color: var(--text-dim);
+          font-size: 0.75rem; text-align: center; }
+        .addr-raw > summary::-webkit-details-marker { display: none; }
+        .addr-raw > summary::after { content: "\25be"; margin-left: 0.3rem; font-size: 0.75em; opacity: 0.7; }
+        .addr-raw[open] > summary::after { display: inline-block; transform: rotate(180deg); }
+        .addr-raw-body { margin-top: 0.6rem; }
+        .addr-raw-body p { font-size: 0.75rem; color: var(--text-dim); text-align: center; margin: 0 0 0.6rem; }
+        .addr-raw-input { border: 1px solid var(--border); border-radius: 6px; min-height: 40px;
+          background: var(--surface); }
         .addr-picker { display: flex; gap: 0.35rem; justify-content: center; flex-wrap: wrap; margin-bottom: 0.9rem; }
         .addr-meta { font-family: var(--font-mono); font-size: 0.65rem; color: var(--text-dim); }
         .addr-verdict { margin-left: auto; font-size: 0.7rem; font-family: var(--font-mono);
@@ -1062,34 +1075,19 @@ footer a:hover { text-decoration: underline; }
         <div class="addr-picker" id="addr-picker"></div>
         <div class="addr-legend" id="addr-legend"></div>
 
-        <div class="panels">
-          <div class="panel panel-left">
-            <div class="panel-header">
-              <span class="dialect-label">Bitcoin address</span>
-            </div>
-            <div class="panel-body">
-              <div contenteditable="true" spellcheck="false" id="addr-input" class="io-input"
-                   data-placeholder="Pick an address above, or paste a bc1&hellip; / 1&hellip; / 3&hellip; address"></div>
-            </div>
-            <div class="panel-footer">
-              <span class="addr-meta" id="addr-meta"></span>
-              <div id="addr-error" class="error-msg hidden" style="padding:0;"></div>
-            </div>
+        <div class="panel addr-solo">
+          <div class="panel-header">
+            <span class="dialect-label">Prose address</span>
+            <span class="addr-verdict" id="addr-verdict"></span>
           </div>
-
-          <div class="panel panel-right">
-            <div class="panel-header">
-              <span class="dialect-label">Prose address</span>
-              <span class="addr-verdict" id="addr-verdict"></span>
-            </div>
-            <div class="panel-body">
-              <div class="output-area empty" id="addr-output">Output will appear here</div>
-            </div>
-            <div class="panel-footer">
-              <button class="btn-sm" id="addr-roles-btn" onclick="addrToggleRoles()"
-                      title="Show the grammatical role of each address word">Show roles</button>
-              <button class="btn-sm" onclick="addrCopy()">Copy</button>
-            </div>
+          <div class="panel-body">
+            <div class="output-area empty" id="addr-output">Output will appear here</div>
+          </div>
+          <div class="panel-footer">
+            <span class="addr-meta" id="addr-meta"></span>
+            <button class="btn-sm" id="addr-roles-btn" onclick="addrToggleRoles()"
+                    title="Show the grammatical role of each address word">Show roles</button>
+            <button class="btn-sm" onclick="addrCopy()">Copy</button>
           </div>
         </div>
 
@@ -1099,6 +1097,17 @@ footer a:hover { text-decoration: underline; }
           <span class="addr-damage-label">Now damage it, the way a person would:</span>
           <div class="addr-damage-row" id="addr-damage-row"></div>
         </div>
+
+        <details class="addr-raw">
+          <summary>Enter or view the same address in base58</summary>
+          <div class="addr-raw-body">
+            <p>Checking the prose never requires this. It is here so you can paste your own
+            address, and so a sceptic can confirm the words really are the script.</p>
+            <div contenteditable="true" spellcheck="false" id="addr-input" class="io-input addr-raw-input"
+                 data-placeholder="Paste a bc1&hellip; / 1&hellip; / 3&hellip; address"></div>
+            <div id="addr-error" class="error-msg hidden" style="padding:0;"></div>
+          </div>
+        </details>
 
         <details class="demo-details" id="addr-how">
           <summary id="addr-hint"></summary>
@@ -1340,7 +1349,6 @@ import init, {
   encode_words as wasmEncodeWords,
   get_payload_words as wasmGetPayloadWords,
   checksum_seed_for as wasmChecksumSeed,
-  payload_crc32 as wasmPayloadCrc32,
 } from './glossia.js';
 // Shared, authenticated message pipeline (also used by the bulletin board):
 // AES-256-GCM, with the plumbing carried as a Latin "— attribution" trailer.
@@ -2442,7 +2450,10 @@ async function addrUpdate() {
     const r = addrRender(program, type);
     addrState = { program, type, ...r };
     errEl.classList.add('hidden');
-    metaEl.textContent = `${type} · ${program.length}-byte program · ${r.words.length} address words · crc32 ${wasmPayloadCrc32(addrHex(program)).toString(16).padStart(8, '0')}`;
+    // Structural facts a reader can act on. The checksum and the hash are machine
+    // detail — surfacing them invites checking the prose against them, which is
+    // the habit this format exists to remove.
+    metaEl.textContent = `${type} · ${r.words.length} address words · ${r.prose.split(/\s+/).length} words total`;
     document.getElementById('addr-legend').textContent = addrLegend(type);
     addrPaint(r.artifact, r.placements);
     addrSetVerdict(addrRead(r.artifact, program.length));
@@ -2538,10 +2549,11 @@ function addrApplyDamage(i) {
   const res = addrRead(artifact, addrState.program.length);
   addrSetVerdict(res);
   addrPaintDamage(box, artifact, res);
+  // Say what happened in words. "It decodes to 741e76e8…" would be true and
+  // would also invite exactly the character-comparison this format replaces.
   const hint = document.getElementById('addr-hint');
-  const got = res.program ? addrHex(res.program) : null;
-  hint.textContent = d.why + (got && got !== addrHex(addrState.program)
-    ? ` It decodes to ${got.slice(0, 12)}… instead.` : '');
+  const changed = res.program && addrHex(res.program) !== addrHex(addrState.program);
+  hint.textContent = d.why + (changed ? ' The text now refers to a different address.' : '');
 }
 
 // Show WHERE the text disagrees with its own re-render, and — when the payload
@@ -2664,19 +2676,21 @@ function addrShowPopup(tokenEl, idx) {
   pop.className = 'addr-popup ' + (m.kind === SPELL ? 'spell' : 'grammar');
 
   if (m.kind === SPELL) {
-    // What the text says now, versus what it would say corrected. This is the
-    // decision the user is actually being asked to make.
-    const now = addrRead(addrCurrent.artifact, addrCurrent.nBytes);
-    const after = addrRead(fixed.join(' '), addrCurrent.nBytes);
+    // Deliberately NOT a hex comparison. The claim of this format is that reading
+    // the prose is a valid check in its own right; falling back to "here are two
+    // hashes, compare them" would concede the opposite and hand the user the exact
+    // character-by-character task the words exist to replace. The meaningful
+    // statement is about agreement: as written, the words and the wording describe
+    // different addresses, and only one substitution makes them agree.
     pop.innerHTML =
       `<div class="addr-popup-h">Did you mean <strong>${m.suggest}</strong>?</div>` +
-      `<div class="addr-popup-b">${m.note}</div>` +
-      `<table class="addr-popup-t">` +
-      `<tr><td>as written</td><td>${now.program ? addrHex(now.program).slice(0, 16) + '…' : 'does not decode'}</td></tr>` +
-      `<tr><td>corrected</td><td><strong>${after.program ? addrHex(after.program).slice(0, 16) + '…' : '—'}</strong></td></tr>` +
-      `</table>` +
-      `<div class="addr-popup-warn">This changes the address. Apply only if you agree it is the word that was meant.</div>` +
-      `<div class="addr-popup-actions"><button class="btn-sm" id="addr-pop-apply">Use “${m.suggest}”</button>` +
+      `<div class="addr-popup-b">As written, these words spell a <strong>different address</strong> ` +
+      `&mdash; and the rest of the sentence does not match that address.</div>` +
+      `<div class="addr-popup-b">With <strong>${m.suggest}</strong>, the words and the wording agree, ` +
+      `which is what makes an address readable as correct.</div>` +
+      `<div class="addr-popup-warn">This changes which address the text refers to. Apply only if you ` +
+      `agree it is the word that was meant.</div>` +
+      `<div class="addr-popup-actions"><button class="btn-sm" id="addr-pop-apply">Use &ldquo;${m.suggest}&rdquo;</button>` +
       `<button class="btn-sm" id="addr-pop-close">Keep as written</button></div>`;
   } else {
     pop.innerHTML =

--- a/web/index.html
+++ b/web/index.html
@@ -882,6 +882,8 @@ footer a:hover { text-decoration: underline; }
         #panel-address { order: 0; }
         #panel-bip39, #panel-apikey, #panel-address { border-top: 1px solid var(--border); padding-top: 0.5rem; }
         /* Prose address */
+        .addr-legend { text-align: center; font-family: var(--font-mono); font-size: 0.68rem;
+          color: var(--text-dim); margin: -0.4rem 0 0.9rem; }
         .addr-picker { display: flex; gap: 0.35rem; justify-content: center; flex-wrap: wrap; margin-bottom: 0.9rem; }
         .addr-meta { font-family: var(--font-mono); font-size: 0.65rem; color: var(--text-dim); }
         .addr-verdict { margin-left: auto; font-size: 0.7rem; font-family: var(--font-mono);
@@ -892,6 +894,7 @@ footer a:hover { text-decoration: underline; }
         .addr-damage { max-width: 720px; margin: 0.9rem auto 0; text-align: center; }
         .addr-damage-label { font-size: 0.75rem; color: var(--text-dim); }
         .addr-damage-row { display: flex; gap: 0.4rem; justify-content: center; flex-wrap: wrap; margin-top: 0.5rem; }
+        .addr-glyph { font-family: var(--font-mono); color: var(--accent); }
         .addr-cover { color: var(--text-dim); }
         .addr-pay { text-decoration: underline; text-decoration-color: var(--accent); }
         .addr-pay sub { font-size: 0.6em; color: var(--accent); opacity: 0.85; }
@@ -1029,6 +1032,7 @@ footer a:hover { text-decoration: underline; }
         </div>
 
         <div class="addr-picker" id="addr-picker"></div>
+        <div class="addr-legend" id="addr-legend"></div>
 
         <div class="panels">
           <div class="panel panel-left">
@@ -1069,10 +1073,18 @@ footer a:hover { text-decoration: underline; }
         <details class="demo-details" id="addr-how">
           <summary id="addr-hint"></summary>
           <div class="enc-how-body">
-            <p>The opcodes are shown as symbols (<strong>&#9661;</strong> witness v0,
-            <strong>&#9651;</strong> v1/Taproot, <strong>&#8981;</strong> hash160), so Glossia only
-            encodes the part that carries entropy &mdash; the 20- or 32-byte program. That is
+            <p>Opcodes use the <strong>Book of Bitcoin notation</strong> &mdash; the same glyphs a
+            script gets when it is read in the book (<span class="addr-glyph">&#9450;</span> OP_0,
+            <span class="addr-glyph">&#9312;</span> OP_1, <span class="addr-glyph">&#8961;</span> OP_DUP,
+            <span class="addr-glyph">&#8982;</span> OP_HASH160, <span class="addr-glyph">&#8801;</span>
+            OP_EQUALVERIFY, <span class="addr-glyph">&#8711;</span> OP_CHECKSIG). Glossia encodes only the
+            part that carries entropy &mdash; the 20- or 32-byte program &mdash; which is
             <strong>15 words</strong> for a hash160 address and <strong>24</strong> for a 32-byte one.</p>
+            <p><strong>&#9450;</strong> and <strong>&#9312;</strong> are worth a note: Unicode counts them
+            as <em>alphanumeric</em>, so the decoder&rsquo;s token trim does not strip them. Written flush
+            against an address word they would hide it entirely. They are safe here because the format
+            <em>declares</em> its glyphs and they are removed by name &mdash; a rule based on character
+            category would silently lose a word.</p>
             <p>The format's version and wordlist size ride in the <strong>bit-packing slack</strong>
             and cost nothing: 160 data bits + 5 header bits is exactly 15 words, and 256 + 8 is
             exactly 24. Wordlist size is stored as its log&#8322;, which fits in 4 bits because
@@ -2096,8 +2108,34 @@ updateToggleIcon();
 // property of the ADDRESS FORMAT, not of Glossia: the header rides in the
 // bit-packing slack (160+5 = 15 words exactly; 256+8 = 24 words exactly).
 
-const ADDR_SIGILS = { P2PKH: '⧉ ⌗', P2SH: '⌗', P2WPKH: '▽', P2WSH: '▽', P2TR: '△' };
-const ADDR_TRAIL = { P2PKH: '≟ ✓', P2SH: '⩵', P2WPKH: '', P2WSH: '', P2TR: '' };
+// Opcode glyphs are the Book of Bitcoin notation (btc-prose.js OPCODE_SYMBOLS),
+// not a set invented here — a script renders the same way whether it is being
+// read in the book or handled as an address.
+//
+// Note ⓪ (OP_0) and ① (OP_1) are Unicode category No: ALPHANUMERIC. They survive
+// the decoder's token trim, so placed flush against a payload word they would
+// hide it. They are safe here only because they are declared as markup and
+// stripped by name — a category-based rule would leave them attached.
+const ADDR_OPS = {
+  DUP:         ['\u29C9', 'OP_DUP'],
+  HASH160:     ['\u2316', 'OP_HASH160'],
+  EQUALVERIFY: ['\u2261', 'OP_EQUALVERIFY'],
+  CHECKSIG:    ['\u2207', 'OP_CHECKSIG'],
+  EQUAL:       ['=',       'OP_EQUAL'],
+  ZERO:        ['\u24EA', 'OP_0'],
+  ONE:         ['\u2460', 'OP_1'],
+};
+const ADDR_SCRIPT = {
+  P2PKH:  { lead: ['DUP', 'HASH160'], trail: ['EQUALVERIFY', 'CHECKSIG'] },
+  P2SH:   { lead: ['HASH160'],        trail: ['EQUAL'] },
+  P2WPKH: { lead: ['ZERO'],           trail: [] },
+  P2WSH:  { lead: ['ZERO'],           trail: [] },
+  P2TR:   { lead: ['ONE'],            trail: [] },
+};
+const ADDR_MARKUP = new Set(Object.values(ADDR_OPS).map(([g]) => g));
+const addrGlyphs = (type, which) => ((ADDR_SCRIPT[type] || {})[which] || []).map(k => ADDR_OPS[k][0]).join(' ');
+const addrLegend = type => ((ADDR_SCRIPT[type] || {}).lead || []).concat((ADDR_SCRIPT[type] || {}).trail || [])
+  .map(k => ADDR_OPS[k][0] + ' ' + ADDR_OPS[k][1]).join('  \u00b7  ');
 const ADDR_COUNTER_RANGE = 4;
 const ADDR_VERSION = 1;
 const ADDR_PRESETS = [
@@ -2199,7 +2237,7 @@ function addrRender(program, type) {
   const words = addrPack(program);
   const r = JSON.parse(wasmEncodeWords(JSON.stringify(words), 'english', 'default', 'body', addrSeed(program, 0), ADDR_COUNTER_RANGE));
   if (r.error) throw new Error(r.error);
-  const lead = ADDR_SIGILS[type] || '', trail = ADDR_TRAIL[type] || '';
+  const lead = addrGlyphs(type, 'lead'), trail = addrGlyphs(type, 'trail');
   return {
     prose: r.encoded_text,
     artifact: [lead, r.encoded_text, trail].filter(Boolean).join(' '),
@@ -2212,16 +2250,23 @@ function addrRender(program, type) {
 // address has a fixed word count), then re-render and compare.
 function addrRead(artifact, nBytes) {
   const toks = artifact.split(/\s+/).filter(Boolean);
-  const harvested = toks.map(w => w.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '').toLowerCase())
-                        .filter(w => w && addrIndex.has(w));
+  const stripMarkup = w => {
+    let a = 0, b = w.length;
+    while (a < b && (ADDR_MARKUP.has(w[a]) || !/[\p{L}\p{N}]/u.test(w[a]))) a++;
+    while (b > a && (ADDR_MARKUP.has(w[b - 1]) || !/[\p{L}\p{N}]/u.test(w[b - 1]))) b--;
+    return w.slice(a, b).toLowerCase();
+  };
+  const harvested = toks.map(stripMarkup).filter(w => w && addrIndex.has(w));
   const expected = (nBytes * 8 + addrHeaderBits(nBytes)) / ADDR_BPW;
   if (harvested.length !== expected)
     return { verdict: 'unreadable', note: `wrong number of address words (${harvested.length}, expected ${expected})` };
   const program = addrUnpack(harvested, nBytes);
   if (!program) return { verdict: 'unreadable', note: 'word not in the address vocabulary' };
 
-  const proseToks = toks.filter(t => t.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, '') !== '' &&
-                                     !/^[▽△⌗⧉≟✓⩵ ]+$/u.test(t));
+  // Compare against the re-render with markup removed, so spacing around a glyph
+  // (⓪Insect vs ⓪ Insect) is a formatting difference rather than a failed check.
+  const proseToks = toks.map(t => [...t].filter(ch => !ADDR_MARKUP.has(ch)).join(''))
+                        .filter(t => t.length);
   let best = 0;
   for (let c = 0; c < ADDR_COUNTER_RANGE; c++) {
     const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)), 'english', 'default', 'body', addrSeed(program, 0) + BigInt(c), 1));
@@ -2278,6 +2323,7 @@ async function addrUpdate() {
     addrState = { program, type, ...r };
     errEl.classList.add('hidden');
     metaEl.textContent = `${type} · ${program.length}-byte program · ${r.words.length} address words · crc32 ${wasmPayloadCrc32(addrHex(program)).toString(16).padStart(8, '0')}`;
+    document.getElementById('addr-legend').textContent = addrLegend(type);
     addrPaint(r.artifact, r.placements);
     addrSetVerdict(addrRead(r.artifact, program.length));
     addrRenderDamage();
@@ -2341,7 +2387,8 @@ function addrApplyDamage(i) {
   const d = addrDamages()[i];
   const damagedProse = d.apply();
   const lead = addrState.artifact.slice(0, addrState.artifact.length - addrState.prose.length);
-  const trail = ADDR_TRAIL[addrState.type] ? ' ' + ADDR_TRAIL[addrState.type] : '';
+  const t2 = addrGlyphs(addrState.type, 'trail');
+  const trail = t2 ? ' ' + t2 : '';
   const artifact = lead + damagedProse + trail;
   const box = document.getElementById('addr-output');
   box.classList.remove('empty');
@@ -2400,6 +2447,8 @@ function addrInit() {
 const ADDR_BASE_HINT = 'Opcodes stay as symbols; only the entropy-carrying program is encoded. ' +
   'The cover words are chosen by a seed derived from the address itself, so the wording IS the checksum.';
 
+// Exposed for debugging and for driving the panel from a test harness.
+window.addrRead = addrRead;
 window.addrToggleRoles = addrToggleRoles;
 window.addrCopy = addrCopy;
 

--- a/web/sw.js
+++ b/web/sw.js
@@ -3,19 +3,35 @@
  * Strategy:
  *   - Precache the app shell on install (resilient: a missing entry, e.g. an
  *     unbuilt WASM artifact, does not abort the install).
- *   - Same-origin GET requests are served stale-while-revalidate: the cached
- *     copy answers instantly (offline-capable) while a background fetch refreshes
- *     the cache for next time. This lets rebuilt JS/WASM propagate on the next
- *     visit without any manual cache-busting.
+ *   - App code — the HTML pages and the JS/WASM built alongside them — is served
+ *     NETWORK-FIRST, falling back to cache when offline.
+ *   - Everything else (vendor libraries, icons, the manifest) is served
+ *     stale-while-revalidate: cache now, refresh in the background.
  *   - Navigations fall back to the cached page, then to index.html, when offline.
  *   - Cross-origin requests (nostr relays over wss://, remote images) are left
  *     untouched — the SW never intercepts them.
+ *
+ * App code is network-first because stale-while-revalidate left every visitor
+ * exactly one deploy behind: the cached page answered instantly and the fresh
+ * one only landed in the cache for NEXT time, so a change looked like it had
+ * not shipped until the second reload. Worse, index.html and glossia.js are
+ * rebuilt together, and a fresh page paired with a stale module is a version
+ * skew nothing in the app can detect. Vendor files and icons change on their
+ * own schedule and keep the fast path.
  *
  * Bump CACHE when the shell list changes or you want to force-evict old caches.
  * Everything here is scoped to the directory sw.js is served from, so it works
  * unchanged at the site root (glossia.io) and under a per-PR preview subpath.
  */
-const CACHE = 'glossia-shell-v4';
+const CACHE = 'glossia-shell-v5';
+
+/// App code: rebuilt with every deploy and required to agree with itself.
+function isAppCode(req, url) {
+  if (req.mode === 'navigate') return true;
+  const path = url.pathname;
+  if (/\.(html|wasm)$/.test(path)) return true;
+  return /\/glossia(-\w+)?\.js$/.test(path);   // glossia.js, glossia-msg.js, glossia-nostr.js
+}
 
 // App shell, relative to the SW scope. glossia.js / glossia_bg.wasm are
 // gitignored build artifacts — present after a build/deploy, possibly absent in
@@ -87,8 +103,13 @@ self.addEventListener('fetch', (event) => {
       return res;
     }).catch(() => null);
 
-    // Stale-while-revalidate: cached copy now, refresh in the background.
-    if (cached) {
+    if (isAppCode(req, url)) {
+      // Network-first: what was just deployed wins, cache is the offline net.
+      const fresh = await network;
+      if (fresh) return fresh;
+      if (cached) return cached;
+    } else if (cached) {
+      // Stale-while-revalidate: cached copy now, refresh in the background.
       event.waitUntil(network);
       return cached;
     }


### PR DESCRIPTION
Implements the engine groundwork for #76 — deriving the cover seed from a payload checksum so the choice of prose carries its own verification data — and works it through to a prose Bitcoin address format for Book-of-Bitcoin.

No existing signature or output changes. 435 tests pass.

## What the measurements said

The issue assumed the checksum width sets the verification strength. It doesn't. Verification works only through the cover, because a candidate payload is derived *from* the received payload words and so reproduces them by construction. The binding constraint is how many distinct cover realizations a seed can produce:

| payload | realization entropy |
|---|---|
| 4 bytes | 3.3 bits |
| 7 bytes | 8.1 bits |
| 12 bytes | 19.7 bits |
| 32 bytes | >25 bits (no collisions in 8192 draws) |

Roughly two bits per cover word, because `pick_cover` narrows to the *shortest* candidates and Det/Prep/Modal/Cop/Aux/To/Pron have exactly one option each. Standard locking scripts are 20–32 bytes, comfortably in range; the short-payload cliff only mattered for chain citations, which are out of scope.

The reader-facing question turned out to be the more useful one. Over 416 single-bit flips:

| | 20-byte | 32-byte |
|---|---|---|
| payload words changed | 1 of 15 | 1 of 24 |
| mean token match | 13% | 10% |
| worst case | 44% | 39% |
| median shared prefix | 1 token | 1 token |

A flipped bit lands in one 11-bit group, so exactly one payload word changes and the rest are identical — easy to miss on its own. The checksum-seeded cover is what turns it into a different paragraph. **The tail is the risk**: the worst case reproduces the entire opening sentence verbatim (2 of 160, and 7 of 256 for 32-byte). So the format's guidance must be *read it through*, not *recognize the opening*.

## Reproducibility

Verification by re-render makes cover generation consensus-critical, which nothing previously guaranteed. Same seed, one environment variable apart, produced completely different prose. Addressed by:

- **RNG pinned** to ChaCha12 via `glossia::CoverRng`. `StdRng`'s algorithm may change across `rand` major versions, and the tree already resolves both 0.8.7 and 0.9.5. Byte-identical today — verified over raw stream, `gen::<f64>()` and `choose()` draws, and end-to-end by diffing CLI prose before and after. ChaCha20 is a *different* stream; `tests/rng_pinning.rs` asserts that so it can't be substituted by good intentions.
- **Wordlist size encoded** rather than frozen, as its log₂ (4 bits covers every list up to 2^15).

## The address format

Opcodes render as Unicode symbols, so Glossia encodes only the entropy-carrying program. The header rides in bit-packing slack that the codec currently zero-fills and the decoder ignores — **160 + 5 = 165 = 15 words exactly**, and **256 + 8 = 264 = 24 words exactly**. It costs nothing.

```
▽ Insect may see victory to ring. Creek get bonus per health. A map is false.
  The logic is easy. Mirror trip elevator before son over a foot.
```

All five standard script types round-trip byte-exact and verify.

## Unicode hazard

`char::is_alphanumeric` is Unicode-aware, so `β` (category `Ll`, same as `a`) survives the token trim and, placed flush against a payload word, silently swallows it. No category rule can fix that. Instead `Markup` lets a format **declare** its symbols, validated against the payload wordlist — the checkable condition is "not a character any payload word uses", not "non-alphanumeric".

That distinction caught a real error: an early draft used `=` for OP_EQUAL because it is non-alphanumeric. It is also a payload character in `cs/base64` and `cs/ascii7`, which uses all 95 printable ASCII. `tests/markup_collisions.rs` guards the sigil set against all 24 shipped wordlists, with ASCII punctuation as a negative control so it cannot pass vacuously.

## API additions

All additive:

- `codec`: `normalize_token` / `payload_tokens` / `alnum_token_count` (the decode-side tokenizer existed as **twelve inlined copies** that had already drifted), `crc32` / `mix64` / `checksum_seed` (the crate had no checksum at all), `Markup`
- `generator::core`: `Placement` / `Role`, `fill_slots_traced`, `generate_text_traced`, `generate_text_best_of_indexed` (returns the winning candidate, which a verifier needs)
- `pipeline`: `encode_words_into_language[_traced]`, and `ZoneGenerator` / `build_zone_generator` made public — payload mapping and cover insertion were always separate stages, the seam just wasn't reachable
- `generator::data`: `payload_alphabet`, `all_payload_alphabets`, `markup_collisions`
- WASM: `encode_words`, `get_payload_words`, `checksum_seed_for`, `payload_crc32`

Bit packing deliberately stays in the app layer — the address layout belongs to Book-of-Bitcoin, not to Glossia.

## Bug fixed

`encode_words_into_language` silently dropped words absent from the payload wordlist (no allowed POS ⇒ unplaceable), yielding prose that decodes to a different payload than the caller supplied. Now errors naming the offending words. Found when a test payload of mine contained `map`, which is an English *cover* word.

Also renamed `generate_text_merkle_segmented` → `generate_text_segmented`: it runs on every pipeline encode, not just merkle mode.

## Demo

`web/index.html` gains a **Bitcoin Address as Prose** panel — pick a script type, see the prose with a live verdict badge, toggle grammatical roles, and damage it:

| damage | verdict |
|---|---|
| fumble a connective word | ⚠ readable, not verified (96% wording) |
| mistype an address word | ✗ wrong address (15% wording) |
| lose a word | ✗ unreadable |

Driven in Chromium to verify; console clean. `web/glossia.js` and `web/glossia_bg.wasm` are gitignored — run `./build_web.sh` first.

## Still open

- Whether cover entropy at 20/32 bytes clears **32 bits**. It exceeds 25; resolving it needs ~2^17 samples (~90 min). This decides whether CRC-32 is fully usable or the honest width is narrower.
- The full-pool cover mode (~doubles entropy, +16% characters, same word count) is measured but not landed — it would also close the shared-opening tail, since that comes from the same forced function-word slots.
- `decode_raw_base_n_verified` and token alignment from the issue's task list are not implemented; this PR builds what they need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KJarR9EtwFA963f9L3cP8

---
_Generated by [Claude Code](https://claude.ai/code/session_011KJarR9EtwFA963f9L3cP8)_