### PR TITLE
v0.3.0: canonical encoding — versioned, deterministic, backward compatible

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,7 @@ Glossia is **a readable encoding, not steganography**. The goal is not to hide t
 - **Type-driven layer** (`grammar.yaml` files): Montague-style semantic types constrain POS slots via lambda calculus
 - **Generator** (`src/generator/`): embeds payload words into POS slots using maximum subsequence matching, fills remaining slots with cover words
 - **Semantic planning** (`src/generator/semantics.rs`): optional layer that biases word choice toward coherent verb-argument pairings (see below)
+- **Canonical layer** (`src/canonical.rs`): versioned, deterministic encode/decode — one payload, one prose form, stable across releases (see below)
 - **Merkle system** (`src/merkle.rs`): append-only wordlist trees with merkleization for cryptographic proofs
 - **Build system** (`build.rs`): embeds all `languages/` YAML at compile time; debug builds embed English only
 
@@ -110,7 +111,27 @@ All project documentation lives in `docs/src/` (mdBook format). When creating or
 - Wordlists are **strictly append-only** for backward compatibility
 - Payload words and cover words must be disjoint sets
 - Function-word POS slots (Aux, Cop, To, Prefix, Dot) are reserved for cover words only
-- `semantics.yaml` is the exception — it *annotates* existing words (classes/frames) rather than defining the wordlist, so it is regenerable, not append-only (see Semantic sentence planning)
+- `semantics.yaml` is the exception — it *annotates* existing words (classes/frames) rather than defining the wordlist, so it is regenerable, not append-only (see Semantic sentence planning). **Caveat**: once a canonical version lists a language in its `semantics_languages`, that language's semantics.yaml is frozen — regeneration requires a new canonical version (see Canonical encoding)
+
+## Canonical encoding (`src/canonical.rs`)
+
+`canonical_encode`/`canonical_decode` (also WASM exports): payload is prefixed with a
+version byte, packed via the self-describing `bitpack` codec, and rendered with cover
+seeded from a checksum of the encoded bytes. Decode reads the version byte and verifies
+by re-rendering **under that version's frozen rules** (`rules_for` registry: best_of,
+dialect, which languages use semantics) — so rendering improvements ship as new versions
+and old artifacts keep verifying. v1: best_of=4, dialect `body`, semantics=english only.
+
+**Freeze discipline**: verification-by-re-render makes everything the renderer reads part
+of the format. For languages with shipped canonical artifacts, grammar/dialect/cover data
+and the version's semantics.yaml must not change in place — even cover *appends* change
+RNG draws. Any such change = new version entry + `CANONICAL_VERSION` bump.
+`tests/canonical.rs` pins exact golden renderings (english/latin/czech); a golden failure
+means "add a version", never "update the golden". `examples/canonical_probe.rs` prints
+renderings for pinning new goldens. The canonical path ignores `GLOSSIA_DISABLE_SEMANTICS`
+(via `load_semantics_cached_ignore_env`). Note: `generate_text_best_of_indexed` selects by
+density (deterministic, lowest-offset tie-break) when a language has no semantic model —
+best-of is meaningful for semantics-less languages too.
 
 ## Agents
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [package]
 name = "glossia"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Encode binary data (BIP39 mnemonics, keys, arbitrary payloads) into grammatically correct, human-readable natural language"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Usage](./usage.md)
 - [Examples](./examples.md)
 - [How It Works](./how-it-works.md)
+- [Canonical Encoding](./canonical-encoding.md)
 - [Prose Quality (Semantic Planning)](./prose-quality.md)
 - [Grammar](./grammar.md)
 - [Dialect Calculus](./dialect-calculus.md)

--- a/docs/src/canonical-encoding.md
+++ b/docs/src/canonical-encoding.md
@@ -72,10 +72,20 @@ new version entry, never an updated golden.
 `examples/canonical_probe.rs` prints the renderings for pinning a new
 version's goldens.
 
+## The address format uses it
+
+The prose Bitcoin address panel (`web/index.html`) is the first consumer: an
+address's program bytes go through `canonical_encode`, so a 20-byte hash160 is
+17 words (version byte + pad word included) and a 32-byte witness program is
+25. The panel's checker builds on `canonical_encode_traced` (grammatical-role
+annotations), `canonical_decode_raw` (repair-search candidates without a
+verify render), and the `canonical_text` returned by `canonical_decode`
+(wording diff without a second generation). The opcode glyphs remain page-side
+markup around the canonical prose.
+
 ## When not to use it
 
-Formats that pack their own bits — a fixed-length address with a header in the
-bit-packing slack, custom seeds, their own best-of policy — should keep using
-the unversioned seams (`encode_words_into_language`, `ZoneGenerator`,
-`checksum_seed`). Those are deliberately flexible; the canonical pair is
-deliberately rigid.
+Callers that need their own seeds, packing, or best-of policy — or prose that
+deliberately is not stable across releases — should use the unversioned seams
+(`encode_words_into_language`, `ZoneGenerator`, `checksum_seed`). Those are
+deliberately flexible; the canonical pair is deliberately rigid.

--- a/docs/src/canonical-encoding.md
+++ b/docs/src/canonical-encoding.md
@@ -1,0 +1,81 @@
+# Canonical Encoding
+
+`canonical_encode` and `canonical_decode` are the stability contract of the
+library: one payload has exactly one prose form, and that form stays valid
+across library releases. Everything else in the API is free to evolve;
+canonical artifacts are not.
+
+```rust
+use glossia::{canonical_encode, canonical_decode};
+
+let payload: Vec<u8> = /* any bytes */;
+let text = canonical_encode(&payload, "english", "bip39")?;
+
+let d = canonical_decode(&text, "english", "bip39")?;
+assert_eq!(d.payload, payload);
+assert!(d.verified);   // the wording matches the canonical re-render
+```
+
+From WASM the same pair is exposed as `canonical_encode(payload_hex, language,
+wordlist)` and `canonical_decode(text, language, wordlist)`, returning JSON.
+
+## How it works
+
+Encoding prefixes the payload with a **version byte**, packs
+`[version | payload]` into payload words with the self-describing `bitpack`
+codec, and renders cover prose seeded from a checksum of those exact bytes. The
+seed makes the *wording* carry the checksum: change any payload bit and the
+whole paragraph re-renders differently, which is what makes damage visible to
+someone reading the text.
+
+Decoding filters the text against the payload wordlist, unpacks the version
+byte, and verifies by re-rendering the payload **under the rules of the version
+the artifact carries** — not the current ones — and comparing wording.
+Comparison is over normalized alphanumeric tokens, so punctuation spacing,
+case, and surrounding markup are formatting, not damage.
+
+## Versioning: how rendering improves without breaking artifacts
+
+Each version freezes a `VersionRules`: the best-of budget, the dialect, and
+which languages render with a semantic model. `rules_for(version)` is the
+registry; a library at version *n* keeps the rules for every version ≤ *n*.
+
+Version 1: `best_of: 4`, dialect `body`, semantics for English only.
+
+The worked example: today Latin and Czech have no `semantics.yaml`, so v1
+renders them with POS-only planning. When a Latin semantics model ships later,
+it gets **version 2** with Latin added to `semantics_languages` — new artifacts
+are written at v2, and every v1 artifact keeps verifying because its version
+byte selects the v1 rules, under which the Latin model does not exist.
+
+A version byte the library does not recognize is refused by name
+(`UnsupportedVersion`), not reported as damage: the artifact is from a newer
+release and this build cannot verify it.
+
+## What a shipped version freezes
+
+Verification-by-re-render makes the whole rendering path part of the format.
+Once a canonical version has shipped, for its languages:
+
+- **Grammar, dialect config, and cover wordlists** must not change in place.
+  Cover appends change RNG draws and therefore renderings, so even an
+  append-only cover change needs a new version if canonical artifacts exist.
+- **`semantics.yaml`** for languages in `semantics_languages` is frozen —
+  regenerating English's model is a v2, not an edit.
+- **The RNG** is pinned to ChaCha12 (`CoverRng`, see `tests/rng_pinning.rs`).
+- **`GLOSSIA_DISABLE_SEMANTICS` is ignored** by the canonical path — an
+  environment variable must not change what an artifact looks like.
+
+`tests/canonical.rs` pins exact golden renderings per language. A golden test
+failing means a change re-rendered a shipped version's artifacts; the fix is a
+new version entry, never an updated golden.
+`examples/canonical_probe.rs` prints the renderings for pinning a new
+version's goldens.
+
+## When not to use it
+
+Formats that pack their own bits — a fixed-length address with a header in the
+bit-packing slack, custom seeds, their own best-of policy — should keep using
+the unversioned seams (`encode_words_into_language`, `ZoneGenerator`,
+`checksum_seed`). Those are deliberately flexible; the canonical pair is
+deliberately rigid.

--- a/examples/canonical_probe.rs
+++ b/examples/canonical_probe.rs
@@ -1,0 +1,24 @@
+//! Scratch probe for canonical goldens: prints the canonical rendering of a few
+//! fixed payloads per language so exact strings can be pinned in tests.
+
+fn main() {
+    let payloads: Vec<(&str, Vec<u8>)> = vec![
+        ("20B hash160", (0u8..20).collect()),
+        ("zeros", vec![0u8; 8]),
+        ("one byte", vec![0xAB]),
+        ("32B", (100u8..132).collect()),
+    ];
+    for (language, wordlist) in [("english", "bip39"), ("latin", "default"), ("czech", "default")] {
+        for (name, p) in &payloads {
+            match glossia::canonical_encode(p, language, wordlist) {
+                Ok(text) => {
+                    let d = glossia::canonical_decode(&text, language, wordlist).unwrap();
+                    assert_eq!(&d.payload, p, "{language} {name} round trip");
+                    assert!(d.verified, "{language} {name} verified");
+                    println!("=== {language}/{wordlist} {name} (v{}) ===\n{text}\n", d.version);
+                }
+                Err(e) => println!("=== {language}/{wordlist} {name} ERROR: {e} ===\n"),
+            }
+        }
+    }
+}

--- a/glossia-cli/Cargo.toml
+++ b/glossia-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glossia-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Command-line interface for glossia: encode binary data into grammatical natural language"
@@ -20,5 +20,5 @@ path = "src/main.rs"
 # Both `path` and `version` so it builds from the workspace during development
 # and resolves to the published crate when installed from crates.io. Publish the
 # `glossia` library first, then this CLI.
-glossia = { path = "..", version = "0.2.0", features = ["native"] }
+glossia = { path = "..", version = "0.3.0", features = ["native"] }
 rand = "0.8"

--- a/languages/latin/cover.yaml
+++ b/languages/latin/cover.yaml
@@ -6,7 +6,11 @@
 # Excluded payload words from: languages/latin/payload.yaml
 # Maximum length: 8
 # Maximum words per POS: 100
-# Total cover words: 128
+# Total cover words: 117
+#
+# Manually removed 11 Wiktionary abbreviation artifacts (not Latin words,
+# but carrying usable POS tags so they surfaced in prose):
+#   bn cp cu ed n nq qa qn s u v
 #
 # POS Tag Distribution:
 #   Adv: 21
@@ -51,16 +55,10 @@ ave:
   Intj: 1.0
 bee:
   Intj: 1.0
-bn:
-  Adv: 1.0
 chaere:
   Intj: 1.0
 cocococo:
   Intj: 1.0
-cp:
-  Adv: 1.0
-cu:
-  Prep: 1.0
 de:
   Prep: 1.0
 debent:
@@ -79,8 +77,6 @@ ecce:
   Intj: 1.0
 eccere:
   Intj: 1.0
-ed:
-  Conj: 1.0
 edepol:
   Intj: 1.0
 ehem:
@@ -178,8 +174,6 @@ mecastor:
   Intj: 1.0
 mehercle:
   Intj: 1.0
-n:
-  Adv: 1.0
 ne:
   Adv: 1.0
   Conj: 1.0
@@ -195,10 +189,7 @@ noenum:
   Adv: 1.0
 non:
   Adv: 1.0
-nq:
-  Conj: 1.0
 o:
-  Adv: 1.0
   Intj: 1.0
 ob:
   Prep: 1.0
@@ -222,18 +213,12 @@ potest:
   Modal: 1.0
 prox:
   Intj: 1.0
-qa:
-  Conj: 1.0
-qn:
-  Adv: 1.0
 quippe:
   Adv: 1.0
 quippini:
   Adv: 1.0
 ruct:
   Intj: 1.0
-s:
-  Adv: 1.0
 salve:
   Intj: 1.0
 scaccus:
@@ -258,12 +243,8 @@ tu:
   Pron: 1.0
 tuxtax:
   Intj: 1.0
-u:
-  Conj: 1.0
 ut:
   Adv: 1.0
-  Conj: 1.0
-v:
   Conj: 1.0
 vae:
   Intj: 1.0

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -1,0 +1,250 @@
+//! Canonical, versioned encoding.
+//!
+//! [`canonical_encode`] produces exactly one prose form for a given
+//! `(payload, language, wordlist)`: the payload is prefixed with a version
+//! byte, packed into payload words, and rendered with the cover seeded from a
+//! checksum of the encoded bytes. Because the rendering rules are frozen per
+//! version in [`rules_for`], an artifact produced under version *n* renders —
+//! and therefore verifies — identically under every later library release:
+//! [`canonical_decode`] reads the version byte from the artifact itself and
+//! re-renders under that version's rules, never the current ones.
+//!
+//! This is what makes it safe to improve generation later. Shipping a
+//! `semantics.yaml` for a language, changing the best-of budget, or any other
+//! change to how prose is rendered gets a new version entry; existing
+//! artifacts keep verifying because their version byte selects the old rules.
+//! The flip side is a freeze: everything a version's rendering reads — the
+//! grammar, dialect and cover data for its languages, plus the semantic model
+//! for languages listed in its rules — must not change in place once the
+//! version has shipped. Wordlists are already append-only; appends are safe
+//! for decoding but DO change cover selection, so a wordlist append also
+//! requires a new canonical version if canonical artifacts exist for that
+//! language. The golden tests in `tests/canonical.rs` enforce the freeze.
+//!
+//! Callers that want more flexibility — their own seeds, bit packing, headers,
+//! best-of budgets — should use [`crate::pipeline::encode_words_into_language`]
+//! and friends; those entry points are unversioned by design.
+
+use std::collections::HashSet;
+use std::fmt;
+
+use crate::codec::{checksum_seed, decode_base_n, encode_base_n, normalize_token, payload_tokens};
+use crate::pipeline::{cached_payload_tree, prepare_words_encode, resolve_wordlist_name};
+
+/// The version new canonical artifacts are written at.
+pub const CANONICAL_VERSION: u8 = 1;
+
+/// The byte↔word packing used to carry the version byte. Deliberately NOT part
+/// of [`VersionRules`]: the version byte must be readable before the version is
+/// known, so the packing itself can never be versioned. (`bitpack` self-describes
+/// its padding with a leading pad word; non-power-of-two wordlists fall back to
+/// base-N big-integer packing inside `encode_base_n`, deterministically.)
+const ENVELOPE_CODEC: &str = "bitpack";
+
+/// The rendering rules a canonical version freezes.
+///
+/// Editing an existing version's rules is a format break — every artifact
+/// written under it stops verifying. To change how canonical prose is
+/// rendered, add a new version and bump [`CANONICAL_VERSION`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VersionRules {
+    /// Fluency budget: the densest of this many consecutive seeds is the
+    /// canonical rendering. A verifier repeats the same selection.
+    pub best_of: usize,
+    /// Grammar dialect the rendering uses, regardless of the language's
+    /// default.
+    pub dialect: &'static str,
+    /// Languages whose semantic model participates in rendering under this
+    /// version. A language absent here renders with POS-only planning even if
+    /// a later release ships a `semantics.yaml` for it — that is the mechanism
+    /// that lets semantics arrive for a language without re-rendering its
+    /// existing artifacts.
+    pub semantics_languages: &'static [&'static str],
+}
+
+static V1: VersionRules = VersionRules {
+    best_of: 4,
+    dialect: "body",
+    // English's semantics.yaml is load-bearing for v1 renderings and is
+    // therefore frozen: regenerating it requires a new canonical version.
+    semantics_languages: &["english"],
+};
+
+/// The frozen rules for a canonical version, or `None` if this library release
+/// does not know the version (i.e. the artifact was written by a newer one).
+pub fn rules_for(version: u8) -> Option<&'static VersionRules> {
+    match version {
+        1 => Some(&V1),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CanonicalError {
+    /// Canonical artifacts always carry at least the version byte plus one
+    /// payload byte.
+    EmptyPayload,
+    /// The version byte names rules this library release does not have —
+    /// the artifact comes from a newer release (or the byte is corrupted).
+    UnsupportedVersion(u8),
+    /// No payload words were found in the text.
+    NoPayloadWords,
+    Encode(String),
+    Decode(String),
+}
+
+impl fmt::Display for CanonicalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CanonicalError::EmptyPayload => write!(f, "payload is empty"),
+            CanonicalError::UnsupportedVersion(v) => {
+                write!(f, "canonical version {} is not supported by this build (max {})", v, CANONICAL_VERSION)
+            }
+            CanonicalError::NoPayloadWords => write!(f, "no payload words found in text"),
+            CanonicalError::Encode(e) => write!(f, "encode error: {}", e),
+            CanonicalError::Decode(e) => write!(f, "decode error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for CanonicalError {}
+
+/// Result of [`canonical_decode`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalDecoded {
+    /// The version byte the artifact carries.
+    pub version: u8,
+    /// The payload bytes (version byte stripped).
+    pub payload: Vec<u8>,
+    /// Whether the received wording matches the canonical re-render for this
+    /// payload and version, compared as normalized alphanumeric tokens — so
+    /// punctuation spacing and surrounding markup are formatting, not damage.
+    /// `false` means the payload decoded but the prose is not the canonical
+    /// rendering of it: transcription damage, or text produced some other way.
+    pub verified: bool,
+}
+
+/// Encode `payload` as canonical prose at [`CANONICAL_VERSION`].
+///
+/// Deterministic: one payload has exactly one canonical rendering per
+/// `(language, wordlist)`. The cover seed is a checksum of the encoded bytes
+/// (version byte included), so any change to the payload re-renders the whole
+/// paragraph, which is what makes damage legible to a reader.
+pub fn canonical_encode(
+    payload: &[u8],
+    language: &str,
+    wordlist: &str,
+) -> Result<String, CanonicalError> {
+    canonical_encode_at(payload, language, wordlist, CANONICAL_VERSION)
+}
+
+/// Encode at an explicit version — the re-render half of verification, and the
+/// escape hatch for writing artifacts compatible with an older release.
+pub fn canonical_encode_at(
+    payload: &[u8],
+    language: &str,
+    wordlist: &str,
+    version: u8,
+) -> Result<String, CanonicalError> {
+    let rules = rules_for(version).ok_or(CanonicalError::UnsupportedVersion(version))?;
+    if payload.is_empty() {
+        return Err(CanonicalError::EmptyPayload);
+    }
+
+    let mut bytes = Vec::with_capacity(1 + payload.len());
+    bytes.push(version);
+    bytes.extend_from_slice(payload);
+
+    let wl = resolve_wordlist_name(language, wordlist);
+    let tree = cached_payload_tree(language, wl)
+        .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
+    let words = encode_base_n(&bytes, &tree, ENVELOPE_CODEC)
+        .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
+
+    render_canonical(&words, &bytes, language, wl, rules)
+}
+
+/// Decode canonical prose: harvest the payload words, unpack the version byte,
+/// and verify by re-rendering under that version's rules.
+pub fn canonical_decode(
+    text: &str,
+    language: &str,
+    wordlist: &str,
+) -> Result<CanonicalDecoded, CanonicalError> {
+    let wl = resolve_wordlist_name(language, wordlist);
+    let tree = cached_payload_tree(language, wl)
+        .map_err(|e| CanonicalError::Decode(format!("{:?}", e)))?;
+    let payload_set: HashSet<String> =
+        tree.words().iter().map(|w| w.to_lowercase()).collect();
+
+    let words = payload_tokens(text, |w| payload_set.contains(w));
+    if words.is_empty() {
+        return Err(CanonicalError::NoPayloadWords);
+    }
+
+    let bytes = decode_base_n(&words, &tree, ENVELOPE_CODEC)
+        .map_err(|e| CanonicalError::Decode(format!("{:?}", e)))?;
+    if bytes.len() < 2 {
+        return Err(CanonicalError::Decode("decoded to fewer than 2 bytes".to_string()));
+    }
+    let version = bytes[0];
+    let payload = bytes[1..].to_vec();
+    // Unknown version: the payload words still decode, but there is no way to
+    // verify the wording without the version's rules. Refusing outright is the
+    // honest answer — "unverifiable" from a canonical decoder would be
+    // indistinguishable from damage.
+    rules_for(version).ok_or(CanonicalError::UnsupportedVersion(version))?;
+
+    let reference = canonical_encode_at(&payload, language, wl, version)?;
+    let verified = same_wording(text, &reference);
+
+    Ok(CanonicalDecoded { version, payload, verified })
+}
+
+/// Render payload words under a version's frozen rules. Env-independent:
+/// semantics is attached or detached from the rules alone, so
+/// `GLOSSIA_DISABLE_SEMANTICS` cannot change what a canonical artifact looks
+/// like.
+fn render_canonical(
+    words: &[String],
+    bytes: &[u8],
+    language: &str,
+    wordlist: &str,
+    rules: &VersionRules,
+) -> Result<String, CanonicalError> {
+    let (toks, payload_word_set, mut gen) =
+        prepare_words_encode(words, language, wordlist, rules.dialect)
+            .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
+
+    if rules.semantics_languages.contains(&language) {
+        let model = crate::generator::data::load_semantics_cached_ignore_env(language)
+            .ok_or_else(|| {
+                CanonicalError::Encode(format!(
+                    "canonical rules expect a semantic model for {} but none is embedded",
+                    language
+                ))
+            })?;
+        gen.lex = gen.lex.with_semantics(model);
+    } else {
+        gen.lex = gen.lex.without_semantics();
+    }
+
+    let seed = checksum_seed(bytes, 0);
+    let (text, _set, _k) = crate::generator::core::generate_text_best_of_indexed(
+        seed, rules.best_of, &gen.lex, &toks, Some(&payload_word_set), false,
+        gen.mode, language, Some(rules.dialect), gen.k_min, gen.k_max, gen.length_mode, " ",
+    );
+    Ok(text)
+}
+
+/// Wording equality over normalized alphanumeric tokens: word-exact,
+/// punctuation- and markup-insensitive.
+fn same_wording(a: &str, b: &str) -> bool {
+    let norm = |s: &str| -> Vec<String> {
+        s.split_whitespace()
+            .map(normalize_token)
+            .filter(|t| !t.is_empty())
+            .collect()
+    };
+    norm(a) == norm(b)
+}

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -122,6 +122,11 @@ pub struct CanonicalDecoded {
     /// `false` means the payload decoded but the prose is not the canonical
     /// rendering of it: transcription damage, or text produced some other way.
     pub verified: bool,
+    /// The canonical rendering of the decoded payload — the reference the
+    /// verification compared against. Verification computes it anyway, and a
+    /// checker UI diffing received wording against expected wording needs it,
+    /// so returning it saves that caller a duplicate generation.
+    pub canonical_text: String,
 }
 
 /// Encode `payload` as canonical prose at [`CANONICAL_VERSION`].
@@ -171,6 +176,24 @@ pub fn canonical_decode(
     language: &str,
     wordlist: &str,
 ) -> Result<CanonicalDecoded, CanonicalError> {
+    let (version, payload) = canonical_decode_raw(text, language, wordlist)?;
+    let reference = canonical_encode_at(&payload, language, wordlist, version)?;
+    let verified = same_wording(text, &reference);
+    Ok(CanonicalDecoded { version, payload, verified, canonical_text: reference })
+}
+
+/// The decode half alone: payload words → version byte + payload bytes, with
+/// the version checked against the registry but the wording NOT verified.
+///
+/// This is for callers doing many decodes per verification — a repair search
+/// proposing typo corrections decodes every candidate but only needs each
+/// candidate's rendering once, from its own (often memoized) encode call.
+/// [`canonical_decode`] is this plus the verify re-render.
+pub fn canonical_decode_raw(
+    text: &str,
+    language: &str,
+    wordlist: &str,
+) -> Result<(u8, Vec<u8>), CanonicalError> {
     let wl = resolve_wordlist_name(language, wordlist);
     let tree = cached_payload_tree(language, wl)
         .map_err(|e| CanonicalError::Decode(format!("{:?}", e)))?;
@@ -194,24 +217,65 @@ pub fn canonical_decode(
     // honest answer — "unverifiable" from a canonical decoder would be
     // indistinguishable from damage.
     rules_for(version).ok_or(CanonicalError::UnsupportedVersion(version))?;
-
-    let reference = canonical_encode_at(&payload, language, wl, version)?;
-    let verified = same_wording(text, &reference);
-
-    Ok(CanonicalDecoded { version, payload, verified })
+    Ok((version, payload))
 }
 
-/// Render payload words under a version's frozen rules. Env-independent:
+/// Canonical encode with placements: the current-version rendering plus where
+/// each payload word landed (POS, sentence, subject/object role), for UIs that
+/// annotate the prose. The text is identical to [`canonical_encode`]'s.
+pub fn canonical_encode_traced(
+    payload: &[u8],
+    language: &str,
+    wordlist: &str,
+) -> Result<(String, Vec<crate::generator::core::Placement>), CanonicalError> {
+    let version = CANONICAL_VERSION;
+    let rules = rules_for(version).expect("current version must be registered");
+    if payload.is_empty() {
+        return Err(CanonicalError::EmptyPayload);
+    }
+
+    let mut bytes = Vec::with_capacity(1 + payload.len());
+    bytes.push(version);
+    bytes.extend_from_slice(payload);
+
+    let wl = resolve_wordlist_name(language, wordlist);
+    let tree = cached_payload_tree(language, wl)
+        .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
+    let words = encode_base_n(&bytes, &tree, ENVELOPE_CODEC)
+        .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
+
+    let (toks, payload_word_set, gen) = prepare_render(&words, language, wl, rules)?;
+    let seed = checksum_seed(&bytes, 0);
+    let (text, _set, k) = crate::generator::core::generate_text_best_of_indexed(
+        seed, rules.best_of, &gen.lex, &toks, Some(&payload_word_set), false,
+        gen.mode, language, Some(rules.dialect), gen.k_min, gen.k_max, gen.length_mode, " ",
+    );
+    let mut rng = <crate::CoverRng as rand::SeedableRng>::seed_from_u64(seed.wrapping_add(k));
+    let (traced_text, _s, placements) = crate::generator::core::generate_text_traced(
+        &mut rng, &gen.lex, &toks, Some(&payload_word_set), false, gen.mode, language,
+        Some(rules.dialect), gen.k_min, gen.k_max, gen.length_mode, " ",
+    );
+    debug_assert_eq!(traced_text, text, "traced re-render must match the selected candidate");
+    Ok((text, placements))
+}
+
+/// Shared render setup under a version's frozen rules. Env-independent:
 /// semantics is attached or detached from the rules alone, so
 /// `GLOSSIA_DISABLE_SEMANTICS` cannot change what a canonical artifact looks
 /// like.
-fn render_canonical(
+fn prepare_render(
     words: &[String],
-    bytes: &[u8],
     language: &str,
     wordlist: &str,
     rules: &VersionRules,
-) -> Result<String, CanonicalError> {
+) -> Result<
+    (
+        Vec<crate::generator::types::PayloadTok>,
+        HashSet<String>,
+        crate::pipeline::ZoneGenerator,
+    ),
+    CanonicalError,
+> {
     let (toks, payload_word_set, mut gen) =
         prepare_words_encode(words, language, wordlist, rules.dialect)
             .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
@@ -228,7 +292,18 @@ fn render_canonical(
     } else {
         gen.lex = gen.lex.without_semantics();
     }
+    Ok((toks, payload_word_set, gen))
+}
 
+/// Render payload words under a version's frozen rules.
+fn render_canonical(
+    words: &[String],
+    bytes: &[u8],
+    language: &str,
+    wordlist: &str,
+    rules: &VersionRules,
+) -> Result<String, CanonicalError> {
+    let (toks, payload_word_set, gen) = prepare_render(words, language, wordlist, rules)?;
     let seed = checksum_seed(bytes, 0);
     let (text, _set, _k) = crate::generator::core::generate_text_best_of_indexed(
         seed, rules.best_of, &gen.lex, &toks, Some(&payload_word_set), false,

--- a/src/generator/core.rs
+++ b/src/generator/core.rs
@@ -1046,12 +1046,26 @@ pub fn generate_text_best_of_indexed(
     };
 
     let n = n_candidates.max(1);
-    let model = lex.semantics();
-    if n == 1 || model.is_none() {
+    if n == 1 {
         let (text, set) = gen_one(base_seed);
         return (text, set, 0);
     }
-    let model = model.unwrap();
+    let Some(model) = lex.semantics() else {
+        // No coherence model — select purely by density. Strictly-greater
+        // comparison keeps the lowest winning offset on ties, so the choice
+        // is deterministic and a verifier reproduces it exactly.
+        let mut best: Option<(f64, u64, (String, HashSet<String>))> = None;
+        for k in 0..n {
+            let out = gen_one(base_seed.wrapping_add(k as u64));
+            let total = out.0.split_whitespace().count().max(1);
+            let density = payload.len() as f64 / total as f64;
+            if best.as_ref().map_or(true, |b| density > b.0) {
+                best = Some((density, k as u64, out));
+            }
+        }
+        let (_, k, (text, set)) = best.expect("n >= 1 candidates generated");
+        return (text, set, k);
+    };
 
     // Generate and score each candidate sequentially. (Candidates are
     // independent and could be parallelized, but the sequence-cache memo makes

--- a/src/generator/core.rs
+++ b/src/generator/core.rs
@@ -858,6 +858,14 @@ pub fn fill_slots_traced<R: Rng>(
             lex.pick_cover_refined(rng, slot, ref_tag, &recent_words)
         };
 
+        // An empty pick means the language has no cover words for this POS at
+        // all — Latin's open classes live almost entirely in its payload list,
+        // so its cover has no nouns, verbs or adjectives. Omit the slot rather
+        // than emitting an empty token: an empty token widens the whitespace,
+        // steals the sentence-initial capital, and decodes as nothing anyway.
+        if cover_word.is_empty() {
+            continue;
+        }
         update_gov_verb(&mut gov_verb, slot, &cover_word);
         out.push(cover_word);
         trace.push(Some((slot, None)));

--- a/src/generator/data.rs
+++ b/src/generator/data.rs
@@ -106,6 +106,23 @@ pub fn load_semantics_cached(
     model
 }
 
+/// `load_semantics_cached` without the `GLOSSIA_DISABLE_SEMANTICS` escape
+/// hatch. The canonical encoder renders under frozen per-version rules, and an
+/// environment variable must not be able to change what a canonical artifact
+/// looks like — a verifier with the hatch set would reject every valid
+/// artifact. Shares the same cache.
+pub(crate) fn load_semantics_cached_ignore_env(
+    language: &str,
+) -> Option<Arc<crate::generator::semantics::SemanticModel>> {
+    let cache = SEMANTICS_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Some(hit) = cache.lock().unwrap().get(language) {
+        return hit.clone();
+    }
+    let model = load_semantics_uncached(language).map(Arc::new);
+    cache.lock().unwrap().insert(language.to_string(), model.clone());
+    model
+}
+
 /// The parse itself, without the env-var check (which `load_semantics_cached`
 /// applies first) — so a cached entry never bakes in the escape hatch's state.
 fn load_semantics_uncached(language: &str) -> Option<crate::generator::semantics::SemanticModel> {

--- a/src/generator/types.rs
+++ b/src/generator/types.rs
@@ -145,8 +145,8 @@ impl Lexicon {
         let list = self.by_pos.get(&pos).unwrap_or(&empty);
 
         if list.is_empty() {
-            // No cover words for this POS — return empty string (graceful degradation).
-            // The cover.yaml should be updated to include words for all POS categories.
+            // No cover words for this POS. Return empty — `fill_slots` omits
+            // the slot entirely, so no empty token reaches the output.
             return String::new();
         }
 

--- a/src/generator/types.rs
+++ b/src/generator/types.rs
@@ -90,6 +90,14 @@ impl Lexicon {
         self
     }
 
+    /// Detach the semantic model, forcing classic POS-only planning. The
+    /// canonical encoder uses this to render under a version whose rules
+    /// predate a language's semantics, regardless of what the build ships.
+    pub fn without_semantics(mut self) -> Self {
+        self.semantics = None;
+        self
+    }
+
     /// The attached semantic model, if any.
     pub fn semantics(&self) -> Option<&SemanticModel> {
         self.semantics.as_deref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,8 @@ pub use codec::{
 pub use pipeline::{Pipeline, Endpoint, Verb, PipelineError, encode_into_language, decode_from_language, cached_payload_tree};
 
 pub use canonical::{
-    canonical_decode, canonical_encode, canonical_encode_at, rules_for,
+    canonical_decode, canonical_decode_raw, canonical_encode, canonical_encode_at,
+    canonical_encode_traced, rules_for,
     CanonicalDecoded, CanonicalError, VersionRules, CANONICAL_VERSION,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod grammar;
 pub mod generator;
 pub mod merkle;
 pub mod codec;
+pub mod canonical;
 pub mod pipeline;
 pub mod scale;
 pub mod image_codec;
@@ -70,6 +71,11 @@ pub use codec::{
 
 // Re-export pipeline types and functions
 pub use pipeline::{Pipeline, Endpoint, Verb, PipelineError, encode_into_language, decode_from_language, cached_payload_tree};
+
+pub use canonical::{
+    canonical_decode, canonical_encode, canonical_encode_at, rules_for,
+    CanonicalDecoded, CanonicalError, VersionRules, CANONICAL_VERSION,
+};
 
 #[cfg(feature = "native")]
 use nlprule::{Tokenizer, Rules};

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1334,7 +1334,7 @@ fn resolve_dialect_wordlist(ep: Endpoint) -> Endpoint {
 // ═══════════════════════════════════════════════════════════════════════
 
 /// Resolve "default" wordlist to the actual wordlist name for a language.
-fn resolve_wordlist_name<'a>(language: &str, wordlist: &'a str) -> &'a str {
+pub(crate) fn resolve_wordlist_name<'a>(language: &str, wordlist: &'a str) -> &'a str {
     if wordlist == "default" {
         let dw = default_wordlist(language);
         if dw == "default" { wordlist } else { dw }
@@ -1461,7 +1461,7 @@ pub fn encode_words_into_language_traced(
 }
 
 /// Shared setup for the word-driven encode entry points.
-fn prepare_words_encode(
+pub(crate) fn prepare_words_encode(
     words: &[String],
     language: &str,
     wordlist: &str,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1417,11 +1417,54 @@ pub fn canonical_encode(payload_hex: &str, language: &str, wordlist: &str) -> St
     }
 }
 
+/// Canonical encode with placements — the same text as `canonical_encode`, plus
+/// where each payload word landed, for UIs that annotate the prose.
+///
+/// Returns JSON `{ encoded_text, version, placements: [{ word, payload_index,
+/// pos, token_index, sentence, role }] }` or `{ error }`.
+#[wasm_bindgen]
+pub fn canonical_encode_traced(payload_hex: &str, language: &str, wordlist: &str) -> String {
+    let Some(bytes) = codec::hex_decode(payload_hex) else {
+        return serde_json::json!({ "error": "bad payload hex" }).to_string();
+    };
+    match crate::canonical::canonical_encode_traced(&bytes, language, wordlist) {
+        Ok((text, placements)) => {
+            let ps: Vec<serde_json::Value> = placements
+                .iter()
+                .map(|p| {
+                    serde_json::json!({
+                        "word": p.word,
+                        "payload_index": p.payload_index,
+                        "pos": p.pos.to_string(),
+                        "token_index": p.token_index,
+                        "sentence": p.sentence,
+                        "role": match p.role {
+                            Some(crate::generator::core::Role::Subject) => "subject",
+                            Some(crate::generator::core::Role::Object) => "object",
+                            None => "",
+                        },
+                    })
+                })
+                .collect();
+            serde_json::json!({
+                "encoded_text": text,
+                "version": crate::canonical::CANONICAL_VERSION,
+                "placements": ps,
+            })
+            .to_string()
+        }
+        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+    }
+}
+
 /// Decode canonical prose and verify it by re-rendering under the rules of the
 /// version byte the artifact carries — not the current version, so artifacts
-/// from older canonical versions keep verifying.
+/// from older canonical versions keep verifying. `canonical_text` is the
+/// reference rendering the verification compared against, so a checker can
+/// diff wording without generating again.
 ///
-/// Returns JSON `{ version, payload_hex, verified }` or `{ error }`.
+/// Returns JSON `{ version, payload_hex, verified, canonical_text }` or
+/// `{ error }`.
 #[wasm_bindgen]
 pub fn canonical_decode(text: &str, language: &str, wordlist: &str) -> String {
     match crate::canonical::canonical_decode(text, language, wordlist) {
@@ -1429,6 +1472,24 @@ pub fn canonical_decode(text: &str, language: &str, wordlist: &str) -> String {
             "version": d.version,
             "payload_hex": codec::hex_encode(&d.payload),
             "verified": d.verified,
+            "canonical_text": d.canonical_text,
+        })
+        .to_string(),
+        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+    }
+}
+
+/// The decode half alone: payload words → version + payload, no verification
+/// re-render. For repair searches that decode many candidates and render each
+/// through their own (memoized) `canonical_encode` call.
+///
+/// Returns JSON `{ version, payload_hex }` or `{ error }`.
+#[wasm_bindgen]
+pub fn canonical_decode_raw(text: &str, language: &str, wordlist: &str) -> String {
+    match crate::canonical::canonical_decode_raw(text, language, wordlist) {
+        Ok((version, payload)) => serde_json::json!({
+            "version": version,
+            "payload_hex": codec::hex_encode(&payload),
         })
         .to_string(),
         Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1397,6 +1397,44 @@ pub fn encode_words(
     }
 }
 
+/// Canonical, versioned encode: exactly one prose form per payload, rendered
+/// under the frozen rules of the current canonical version (see
+/// `src/canonical.rs`). `payload_hex` is the payload bytes as hex.
+///
+/// Returns JSON `{ encoded_text, version }` or `{ error }`.
+#[wasm_bindgen]
+pub fn canonical_encode(payload_hex: &str, language: &str, wordlist: &str) -> String {
+    let Some(bytes) = codec::hex_decode(payload_hex) else {
+        return serde_json::json!({ "error": "bad payload hex" }).to_string();
+    };
+    match crate::canonical::canonical_encode(&bytes, language, wordlist) {
+        Ok(text) => serde_json::json!({
+            "encoded_text": text,
+            "version": crate::canonical::CANONICAL_VERSION,
+        })
+        .to_string(),
+        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+    }
+}
+
+/// Decode canonical prose and verify it by re-rendering under the rules of the
+/// version byte the artifact carries — not the current version, so artifacts
+/// from older canonical versions keep verifying.
+///
+/// Returns JSON `{ version, payload_hex, verified }` or `{ error }`.
+#[wasm_bindgen]
+pub fn canonical_decode(text: &str, language: &str, wordlist: &str) -> String {
+    match crate::canonical::canonical_decode(text, language, wordlist) {
+        Ok(d) => serde_json::json!({
+            "version": d.version,
+            "payload_hex": codec::hex_encode(&d.payload),
+            "verified": d.verified,
+        })
+        .to_string(),
+        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+    }
+}
+
 /// Derive a cover seed from a payload checksum, so the choice of prose carries the
 /// checksum. `hex` is the exact byte string the checksum covers.
 ///

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -1,0 +1,178 @@
+//! The canonical encoding's contract: deterministic, versioned, verifiable.
+//!
+//! The golden tests here are the freeze that makes version rules meaningful.
+//! If one fails, a change altered what a shipped canonical version renders —
+//! that is a format break for every existing artifact. The fix is never to
+//! update the golden: add a new version in `src/canonical.rs`, bump
+//! `CANONICAL_VERSION`, and pin new goldens for the new version alongside
+//! these.
+
+use glossia::{
+    canonical_decode, canonical_encode, canonical_encode_at, rules_for, CanonicalError,
+    CANONICAL_VERSION,
+};
+
+const LANGS: &[(&str, &str)] = &[
+    ("english", "bip39"),
+    ("latin", "default"),
+    ("czech", "default"),
+];
+
+fn payloads() -> Vec<Vec<u8>> {
+    vec![
+        vec![0xAB],                  // single byte
+        vec![0u8; 8],                // all zeros (leading zeros must survive)
+        (0u8..20).collect(),         // hash160-sized
+        (100u8..132).collect(),      // witness-program-sized
+    ]
+}
+
+#[test]
+fn round_trips_and_verifies_across_languages() {
+    for (language, wordlist) in LANGS {
+        for payload in payloads() {
+            let text = canonical_encode(&payload, language, wordlist)
+                .unwrap_or_else(|e| panic!("{language} encode: {e}"));
+            let d = canonical_decode(&text, language, wordlist)
+                .unwrap_or_else(|e| panic!("{language} decode: {e}"));
+            assert_eq!(d.payload, payload, "{language} payload round trip");
+            assert_eq!(d.version, CANONICAL_VERSION, "{language} version byte");
+            assert!(d.verified, "{language} clean artifact must verify");
+        }
+    }
+}
+
+#[test]
+fn encoding_is_deterministic() {
+    let payload: Vec<u8> = (0u8..20).collect();
+    for (language, wordlist) in LANGS {
+        let a = canonical_encode(&payload, language, wordlist).unwrap();
+        let b = canonical_encode(&payload, language, wordlist).unwrap();
+        let c = canonical_encode_at(&payload, language, wordlist, CANONICAL_VERSION).unwrap();
+        assert_eq!(a, b, "{language} repeat encode");
+        assert_eq!(a, c, "{language} explicit-version encode");
+    }
+}
+
+#[test]
+fn payload_word_swap_decodes_different_and_unverified() {
+    let payload: Vec<u8> = (0u8..20).collect();
+    let text = canonical_encode(&payload, "english", "bip39").unwrap();
+    // "valve" is a payload word in this rendering; "zebra" is a different
+    // BIP39 word not present in it. The swap keeps the word count, so it
+    // decodes cleanly — to different bytes — and only the wording check
+    // catches it.
+    assert!(text.contains("valve"), "expected payload word missing: {text}");
+    let damaged = text.replace("valve", "zebra");
+    let d = canonical_decode(&damaged, "english", "bip39").unwrap();
+    assert_ne!(d.payload, payload, "swapped payload word must change the bytes");
+    assert!(!d.verified, "damaged payload must not verify");
+}
+
+#[test]
+fn cover_word_damage_keeps_payload_but_unverifies() {
+    let payload: Vec<u8> = (0u8..20).collect();
+    let text = canonical_encode(&payload, "english", "bip39").unwrap();
+    // "may" is a cover word here — not in BIP39 — so mangling it leaves the
+    // payload intact and only the wording disagrees.
+    assert!(text.contains(" may "), "expected cover word missing: {text}");
+    let damaged = text.replacen(" may ", " mays ", 1);
+    let d = canonical_decode(&damaged, "english", "bip39").unwrap();
+    assert_eq!(d.payload, payload, "cover damage must not change the payload");
+    assert!(!d.verified, "cover damage must not verify");
+}
+
+#[test]
+fn verification_ignores_punctuation_and_case() {
+    let payload: Vec<u8> = (0u8..20).collect();
+    let text = canonical_encode(&payload, "english", "bip39").unwrap();
+    let reformatted = text.replace('.', " .").to_uppercase();
+    let d = canonical_decode(&reformatted, "english", "bip39").unwrap();
+    assert_eq!(d.payload, payload);
+    assert!(d.verified, "punctuation spacing and case are formatting, not damage");
+}
+
+#[test]
+fn unknown_version_is_refused_by_name() {
+    // Craft an artifact claiming version 200 through the unversioned seam.
+    let tree = glossia::cached_payload_tree("english", "bip39").unwrap();
+    let mut bytes = vec![200u8];
+    bytes.extend(0u8..8);
+    let words = glossia::codec::encode_base_n(&bytes, &tree, "bitpack").unwrap();
+    let (text, _) = glossia::pipeline::encode_words_into_language(
+        &words, "english", "bip39", "body", 7, 1,
+    )
+    .unwrap();
+    match canonical_decode(&text, "english", "bip39") {
+        Err(CanonicalError::UnsupportedVersion(200)) => {}
+        other => panic!("expected UnsupportedVersion(200), got {other:?}"),
+    }
+    // Encoding at an unknown version is refused the same way.
+    match canonical_encode_at(&[1, 2, 3], "english", "bip39", 200) {
+        Err(CanonicalError::UnsupportedVersion(200)) => {}
+        other => panic!("expected UnsupportedVersion(200), got {other:?}"),
+    }
+}
+
+#[test]
+fn empty_payload_is_refused() {
+    match canonical_encode(&[], "english", "bip39") {
+        Err(CanonicalError::EmptyPayload) => {}
+        other => panic!("expected EmptyPayload, got {other:?}"),
+    }
+}
+
+#[test]
+fn canonical_ignores_the_semantics_escape_hatch() {
+    // GLOSSIA_DISABLE_SEMANTICS changes what the unversioned entry points
+    // render. It must NOT change a canonical rendering, or a verifier with the
+    // hatch set would reject every valid artifact. (Safe to toggle here: every
+    // test in this file goes through the canonical path, which ignores it.)
+    let payload: Vec<u8> = (0u8..20).collect();
+    let before = canonical_encode(&payload, "english", "bip39").unwrap();
+    std::env::set_var("GLOSSIA_DISABLE_SEMANTICS", "1");
+    let during = canonical_encode(&payload, "english", "bip39").unwrap();
+    std::env::remove_var("GLOSSIA_DISABLE_SEMANTICS");
+    assert_eq!(before, during, "env hatch must not affect canonical renderings");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Version 1 freeze
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn v1_rules_are_frozen() {
+    let rules = rules_for(1).expect("v1 must always exist");
+    // Changing any of these re-renders every v1 artifact. If a change here is
+    // intended, it belongs in a NEW version — see the module docs.
+    assert_eq!(rules.best_of, 4);
+    assert_eq!(rules.dialect, "body");
+    assert_eq!(rules.semantics_languages, &["english"]);
+}
+
+#[test]
+fn v1_golden_renderings() {
+    // Exact canonical renderings, pinned. These freeze everything the
+    // rendering reads: grammar, dialect config, cover wordlists, English's
+    // semantics.yaml, the RNG, and the best-of selection. A diff here means a
+    // v1 artifact in the wild no longer verifies.
+    let hash160: Vec<u8> = (0u8..20).collect();
+    let zeros = vec![0u8; 8];
+
+    assert_eq!(
+        canonical_encode(&hash160, "english", "bip39").unwrap(),
+        "Its absurd absurd abandon dog. Alcohol may doctor its odd loan. Son bring abuse to anxiety. Flash addict its bright valve. An ancient cow embark our gas."
+    );
+    assert_eq!(
+        canonical_encode(&zeros, "english", "bip39").unwrap(),
+        "The absent absurd abandon abandon. Our abandon abandon abandon to abandon."
+    );
+    assert_eq!(
+        canonical_encode(&zeros, "latin", "default").unwrap(),
+        "Tu aro fas e jul. Fas aro   se  is."
+    );
+    assert_eq!(
+        canonical_encode(&zeros, "czech", "default").unwrap(),
+        "Aktovka mít amputace se abdikace. Abdikace dát ze abdikace. Abdikace mít abdikace se abdikace."
+    );
+}

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -38,6 +38,15 @@ fn round_trips_and_verifies_across_languages() {
             assert_eq!(d.payload, payload, "{language} payload round trip");
             assert_eq!(d.version, CANONICAL_VERSION, "{language} version byte");
             assert!(d.verified, "{language} clean artifact must verify");
+            // A language with no cover words for some POS (Latin's open
+            // classes are almost all payload) must omit the slot, not emit an
+            // empty token that widens whitespace and steals the sentence-
+            // initial capital.
+            assert!(!text.contains("  "), "{language} rendering has a double space: {text:?}");
+            for sentence in text.split(". ") {
+                let first = sentence.chars().next().unwrap();
+                assert!(!first.is_lowercase(), "{language} sentence starts lowercase: {sentence:?}");
+            }
         }
     }
 }
@@ -194,7 +203,7 @@ fn v1_golden_renderings() {
     );
     assert_eq!(
         canonical_encode(&zeros, "latin", "default").unwrap(),
-        "Tu aro fas e jul. Fas aro   se  is."
+        "Tu aro fas e jul. Fas aro se is."
     );
     assert_eq!(
         canonical_encode(&zeros, "czech", "default").unwrap(),

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -115,6 +115,31 @@ fn unknown_version_is_refused_by_name() {
 }
 
 #[test]
+fn traced_and_raw_variants_agree_with_the_plain_pair() {
+    let payload: Vec<u8> = (0u8..20).collect();
+    let text = canonical_encode(&payload, "english", "bip39").unwrap();
+
+    let (traced_text, placements) =
+        glossia::canonical_encode_traced(&payload, "english", "bip39").unwrap();
+    assert_eq!(traced_text, text, "traced text must be the canonical rendering");
+    assert!(!placements.is_empty());
+    let toks: Vec<&str> = text.split_whitespace().collect();
+    for p in &placements {
+        let tok: String = toks[p.token_index]
+            .chars()
+            .filter(|c| c.is_alphanumeric())
+            .collect();
+        assert_eq!(tok.to_lowercase(), p.word.to_lowercase(), "placement resolves to its token");
+    }
+
+    let d = canonical_decode(&text, "english", "bip39").unwrap();
+    assert_eq!(d.canonical_text, text, "clean artifact's reference is itself");
+    let (version, raw_payload) =
+        glossia::canonical_decode_raw(&text, "english", "bip39").unwrap();
+    assert_eq!((version, raw_payload), (d.version, d.payload));
+}
+
+#[test]
 fn empty_payload_is_refused() {
     match canonical_encode(&[], "english", "bip39") {
         Err(CanonicalError::EmptyPayload) => {}

--- a/web/index.html
+++ b/web/index.html
@@ -1154,16 +1154,19 @@ footer a:hover { text-decoration: underline; }
             <span class="addr-glyph">&#8982;</span> OP_HASH160, <span class="addr-glyph">&#8801;</span>
             OP_EQUALVERIFY, <span class="addr-glyph">&#8711;</span> OP_CHECKSIG). Glossia encodes only the
             part that carries entropy &mdash; the 20- or 32-byte program &mdash; which is
-            <strong>15 words</strong> for a hash160 address and <strong>24</strong> for a 32-byte one.</p>
+            <strong>17 words</strong> for a hash160 address and <strong>25</strong> for a 32-byte one.</p>
             <p><strong>&#9450;</strong> and <strong>&#9312;</strong> are worth a note: Unicode counts them
             as <em>alphanumeric</em>, so the decoder&rsquo;s token trim does not strip them. Written flush
             against an address word they would hide it entirely. They are safe here because the format
             <em>declares</em> its glyphs and they are removed by name &mdash; a rule based on character
             category would silently lose a word.</p>
-            <p>The format's version and wordlist size ride in the <strong>bit-packing slack</strong>
-            and cost nothing: 160 data bits + 5 header bits is exactly 15 words, and 256 + 8 is
-            exactly 24. Wordlist size is stored as its log&#8322;, which fits in 4 bits because
-            payload wordlists are powers of two.</p>
+            <p>The words are Glossia&rsquo;s <strong>canonical encoding</strong>: the program is
+            prefixed with a <strong>version byte</strong> and packed with a self-describing codec,
+            so the artifact itself names the rules it was rendered under. When rendering improves
+            &mdash; new languages, better prose &mdash; new artifacts get a new version while an old
+            one keeps verifying under the rules its byte selects. The version and packing cost two
+            words on a hash160 address; that is the price of an artifact that stays valid across
+            releases.</p>
             <p><strong>The wording is the checksum.</strong> The cover words are chosen by a seed
             derived from a CRC-32 of the address, so a different address produces a visibly
             different paragraph. Verification re-renders the address you decoded and compares:
@@ -1388,10 +1391,11 @@ import init, {
   get_default_wordlist as wasmGetDefaultWordlist,
   encode_raw_base_n as wasmEncodeRawBaseN,
   decode_raw_base_n as wasmDecodeRawBaseN,
-  encode_words as wasmEncodeWords,
   get_payload_words as wasmGetPayloadWords,
   get_cover_words as wasmGetCoverWords,
-  checksum_seed_for as wasmChecksumSeed,
+  canonical_encode as wasmCanonicalEncode,
+  canonical_encode_traced as wasmCanonicalEncodeTraced,
+  canonical_decode_raw as wasmCanonicalDecodeRaw,
 } from './glossia.js';
 // Shared, authenticated message pipeline (also used by the bulletin board):
 // AES-256-GCM, with the plumbing carried as a Latin "— attribution" trailer.
@@ -2228,17 +2232,17 @@ const ADDR_MARKUP = new Set(Object.values(ADDR_OPS).map(([g]) => g));
 const addrGlyphs = (type, which) => ((ADDR_SCRIPT[type] || {})[which] || []).map(k => ADDR_OPS[k][0]).join(' ');
 const addrLegend = type => ((ADDR_SCRIPT[type] || {}).lead || []).concat((ADDR_SCRIPT[type] || {}).trail || [])
   .map(k => ADDR_OPS[k][0] + ' ' + ADDR_OPS[k][1]).join('  \u00b7  ');
-// Fluency budget, locked at 4. This is a fixed PARAMETER, not a search: the
-// encoder renders best-of-4 from the checksum seed, and the verifier renders
-// best-of-4 from the same seed and compares. One address, one prose — there is
-// no counter to sweep and no ambiguity about which rendering is canonical.
+// The prose is Glossia's CANONICAL encoding: [version byte | program] packed
+// by the self-describing bitpack codec, cover seeded from a checksum of those
+// exact bytes, rendered under the version's frozen rules (v1 pins best-of-4,
+// the value the fluency sweep chose). One address, one prose — and the version
+// byte means the rules can evolve without re-rendering existing artifacts.
 //
-// 4 is where the marginal return falls off. Measured over 96 payloads x 128
-// candidates at both address sizes, density rises 0.53 -> 0.59 (20B) going from
-// N=1 to N=4, and every doubling past N=8 buys under one word while costing
-// linearly more to verify.
-const ADDR_BEST_OF = 4;
-const ADDR_VERSION = 1;
+// Word counts follow from the packing: 1 pad word + ceil(8·(nBytes+1)/11).
+// The version byte and pad word cost two words over the old slack-packed
+// layout on a hash160 address; that is the price of a self-describing format.
+const ADDR_WORD_COUNT = { 20: 17, 32: 25 };
+const ADDR_BYTES_FOR_COUNT = { 17: 20, 25: 32 };
 const ADDR_PRESETS = [
   { label: 'P2WPKH', addr: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4' },
   { label: 'P2TR',   addr: 'bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9' },
@@ -2358,32 +2362,21 @@ function addrTypeFromGlyphs(text, nBytes) {
   return null;
 }
 
-// ── bit packing: program bits, then the header, filling the slack exactly ──
-const ADDR_BPW = 11;
-function addrHeaderBits(n) { return Math.ceil(n * 8 / ADDR_BPW) * ADDR_BPW - n * 8; }
-function addrPack(program) {
-  const hb = addrHeaderBits(program.length);
-  const header = (ADDR_BPW << (hb - 4)) | ADDR_VERSION;
-  const db = program.length * 8, n = (db + hb) / ADDR_BPW, out = [];
-  const bit = i => i < db ? (program[i >> 3] >> (7 - (i & 7))) & 1 : (header >> (hb - 1 - (i - db))) & 1;
-  for (let w = 0; w < n; w++) { let v = 0; for (let b = 0; b < ADDR_BPW; b++) v = (v << 1) | bit(w * ADDR_BPW + b); out.push(addrWords[v]); }
-  return out;
-}
-function addrUnpack(words, nBytes) {
-  const hb = addrHeaderBits(nBytes);
-  if (words.length !== (nBytes * 8 + hb) / ADDR_BPW) return null;
-  const bits = [];
-  for (const w of words) { const i = addrIndex.get(w.toLowerCase()); if (i === undefined) return null; for (let b = ADDR_BPW - 1; b >= 0; b--) bits.push((i >> b) & 1); }
-  const prog = new Uint8Array(nBytes);
-  for (let i = 0; i < nBytes; i++) { let v = 0; for (let b = 0; b < 8; b++) v = (v << 1) | bits[i * 8 + b]; prog[i] = v; }
-  return prog;
-}
+// ── packing, seeding and rendering all live in the canonical layer now ──
+// The page never touches bits: canonical_encode owns the version byte, the
+// packing, the checksum seed and the frozen rendering rules.
 const addrHex = b => [...b].map(x => x.toString(16).padStart(2, '0')).join('');
+const addrUnhex = h => Uint8Array.from(h.match(/../g) || [], x => parseInt(x, 16));
 
-// The checksum covers the program plus the header bytes, i.e. exactly the
-// encoded bits. Derived in Rust so browser and core agree bit-for-bit.
-function addrSeed(program, counter) {
-  return wasmChecksumSeed(addrHex(program) + ADDR_BPW.toString(16).padStart(2, '0') + ADDR_VERSION.toString(16).padStart(2, '0'), BigInt(counter));
+// Decode payload words to program bytes, no verification render — the repair
+// search decodes many candidates and renders each through the memoized
+// addrProse instead. Returns null if the words do not decode, decode to a
+// different length, or carry a version this build does not know.
+function addrDecodeWords(words, nBytes) {
+  const r = JSON.parse(wasmCanonicalDecodeRaw(words.join(' '), 'english', 'bip39'));
+  if (r.error) return null;
+  const prog = addrUnhex(r.payload_hex);
+  return prog.length === nBytes ? prog : null;
 }
 
 // An address determines its prose exactly, so the rendering is a pure function
@@ -2395,8 +2388,7 @@ const addrProseCache = new Map();
 function addrProse(program) {
   const key = addrHex(program);
   if (addrProseCache.has(key)) return addrProseCache.get(key);
-  const r = JSON.parse(wasmEncodeWords(JSON.stringify(addrPack(program)),
-    'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
+  const r = JSON.parse(wasmCanonicalEncode(key, 'english', 'bip39'));
   const text = r.error ? null : r.encoded_text;
   if (addrProseCache.size > 400) addrProseCache.clear();
   addrProseCache.set(key, text);
@@ -2404,8 +2396,7 @@ function addrProse(program) {
 }
 
 function addrRender(program, type) {
-  const words = addrPack(program);
-  const r = JSON.parse(wasmEncodeWords(JSON.stringify(words), 'english', 'default', 'body', addrSeed(program, 0), ADDR_BEST_OF));
+  const r = JSON.parse(wasmCanonicalEncodeTraced(addrHex(program), 'english', 'bip39'));
   if (r.error) throw new Error(r.error);
   addrProseCache.set(addrHex(program), r.encoded_text);   // the checker will ask for this
   const lead = addrGlyphs(type, 'lead'), trail = addrGlyphs(type, 'trail');
@@ -2413,7 +2404,6 @@ function addrRender(program, type) {
     prose: r.encoded_text,
     artifact: [lead, r.encoded_text, trail].filter(Boolean).join(' '),
     placements: r.placements || [],
-    words,
   };
 }
 
@@ -2428,11 +2418,11 @@ function addrRead(artifact, nBytes) {
     return w.slice(a, b).toLowerCase();
   };
   const harvested = toks.map(stripMarkup).filter(w => w && addrIndex.has(w));
-  const expected = (nBytes * 8 + addrHeaderBits(nBytes)) / ADDR_BPW;
+  const expected = ADDR_WORD_COUNT[nBytes];
   if (harvested.length !== expected)
     return { verdict: 'unreadable', note: `wrong number of address words (${harvested.length}, expected ${expected})` };
-  const program = addrUnpack(harvested, nBytes);
-  if (!program) return { verdict: 'unreadable', note: 'word not in the address vocabulary' };
+  const program = addrDecodeWords(harvested, nBytes);
+  if (!program) return { verdict: 'unreadable', note: 'the address words do not decode' };
 
   // Compare against the re-render with markup removed, so spacing around a glyph
   // (⓪Insect vs ⓪ Insect) is a formatting difference rather than a failed check.
@@ -2543,7 +2533,7 @@ function addrProposeRepairs(artifact, words, budgetMs = ADDR_SEARCH_MS) {
     for (const cand of addrEdit1(words[i])) {
       if (performance.now() > deadline) return hits;
       const w = words.slice(); w[i] = cand;
-      const prog = addrUnpack(w, addrState ? addrState.program.length : 20);
+      const prog = addrDecodeWords(w, addrState ? addrState.program.length : 20);
       if (!prog) continue;
       const text = addrProse(prog);
       if (text === null) continue;
@@ -2666,8 +2656,8 @@ async function addrDecodeRun() {
 
   // A fixed-length address has a fixed word count, so the count picks the size.
   const words = addrHarvest(text);
-  const nBytes = { 15: 20, 24: 32 }[words.length];
-  if (!nBytes) return fail(`${words.length} address words — a prose address has 15 or 24`);
+  const nBytes = ADDR_BYTES_FOR_COUNT[words.length];
+  if (!nBytes) return fail(`${words.length} address words — a prose address has 17 or 25`);
   const type = addrTypeFromGlyphs(text, nBytes);
   if (!type) return fail('no opcode symbol, so the script type is unknown');
   const res = addrRead(text, nBytes);
@@ -2694,7 +2684,7 @@ async function addrEncodeRun() {
     // Structural facts a reader can act on. The checksum and the hash are machine
     // detail — surfacing them invites checking the prose against them, which is
     // the habit this format exists to remove.
-    metaEl.textContent = `${type} · ${r.words.length} address words · ${r.prose.split(/\s+/).length} words total`;
+    metaEl.textContent = `${type} · ${ADDR_WORD_COUNT[program.length]} address words · ${r.prose.split(/\s+/).length} words total`;
     document.getElementById('addr-legend').textContent = addrLegend(type);
     addrPaint(r.artifact, r.placements);
     addrSetVerdict(addrRead(r.artifact, program.length));
@@ -2833,7 +2823,7 @@ function addrCheck(artifact, nBytes, budgetMs = ADDR_SEARCH_MS) {
   const harvestIdx = [];
   toks.forEach((t, i) => { const c = core(t); if (c && addrIndex.has(c)) { harvested.push(c); harvestIdx.push(i); } });
 
-  const expected = (nBytes * 8 + addrHeaderBits(nBytes)) / ADDR_BPW;
+  const expected = ADDR_WORD_COUNT[nBytes];
 
   // ── too few address words: one has been mangled OFF the vocabulary ────
   // That is a misspelling in the strict sense — the word is not in the
@@ -2873,7 +2863,7 @@ function addrCheck(artifact, nBytes, budgetMs = ADDR_SEARCH_MS) {
   if (harvested.length > expected) return { marks, verdict: 'long' };
 
   // ── right count: compare against the re-render ────────────────────────
-  const program = addrUnpack(harvested, nBytes);
+  const program = addrDecodeWords(harvested, nBytes);
   if (!program) return { marks, verdict: 'undecodable' };
   // `rendered` IS the expected wording — the diff just computed it, so asking
   // for it again was a second full generation for an answer already in hand.
@@ -2910,7 +2900,9 @@ function addrCheck(artifact, nBytes, budgetMs = ADDR_SEARCH_MS) {
   // Otherwise an address word is wrong. The cover disagreement is a CONSEQUENCE,
   // not a second fault, so flag only the address word — marking 25 cover words
   // would be technically true and useless.
-  const hits = addrProposeRepairs(artifact, addrPack(program), budgetMs);
+  // The received words round-trip through the program, so they ARE the packed
+  // word list — no need to re-pack.
+  const hits = addrProposeRepairs(artifact, harvested, budgetMs);
   if (hits.length === 1) {
     marks.set(harvestIdx[hits[0].index], { kind: SPELL, suggest: hits[0].to,
       note: `wrong address word; “${hits[0].to}” explains this wording` });


### PR DESCRIPTION
The release Book of Bitcoin switches to. Four commits:

## Canonical encoding (`src/canonical.rs`)

`canonical_encode` / `canonical_decode` (+ WASM exports): the payload is prefixed with a **version byte**, packed via the self-describing bitpack codec, and rendered with cover seeded from a checksum of the encoded bytes — one payload, one prose form. Decode reads the version byte and verifies by re-rendering **under that version's frozen rules** (`rules_for` registry: best_of, dialect, which languages use semantics), so rendering improvements ship as new versions and old artifacts keep verifying. An unknown version is refused by name, not misreported as damage.

v1: best_of=4, dialect `body`, semantics for English only. When Latin/Czech semantics ship later, that's a v2 — existing artifacts are unaffected.

Two supporting changes:
- `generate_text_best_of_indexed` now selects by density when a language has no semantic model (was: silently collapsed to a single render, making best-of meaningless for Latin/Czech). Deterministic lowest-offset tie-break; the with-model path is untouched byte-for-byte.
- The canonical path ignores `GLOSSIA_DISABLE_SEMANTICS` — an env var must not change what an artifact looks like.

`tests/canonical.rs` pins the contract: round trips across english/latin/czech, determinism, damage verdicts, unknown-version refusal, env-hatch immunity, the frozen v1 rules, and exact golden renderings per language (verified identical in debug and release). A golden failure after this release means "add a version", never "update the golden".

## Address format on canonical

The prose address panel drops its hand-rolled bit packing (11-bit layout, slack-packed header, write-only version bit) for the canonical layer: 17 words for a hash160, 25 for a 32-byte witness program — the two extra words are the version byte and pad word, the price of an artifact that names its own rules. New API surface for the checker: `canonical_encode_traced` (role annotations), `canonical_decode_raw` (repair search without a verify render), `CanonicalDecoded::canonical_text` (wording diff without a second generation). Driven in Chromium: 19 checks — all presets verify at the new counts, decode returns the exact address string, all damage verdicts and confirmed suggestions intact, console clean.

## Latin fixed inside v1 (pre-ship window)

Latin rendered with double spaces and lowercase sentence starts: its cover list has no open-class words, and an empty POS bucket became an empty token. `fill_slots` now omits unfillable slots — one guard covering every selection path — and 11 Wiktionary abbreviation artifacts (`bn cp cu ed n nq qa qn s u v`) are removed from the Latin cover list. English and Czech renderings are byte-identical (their unchanged goldens prove it). Re-pinning the Latin golden is legitimate exactly once: v1 exists in no release.

## Version bump

Both crates to 0.3.0; the publish workflow verifies the `v0.3.0` tag against it and publishes `glossia` then `glossia-cli`.

**After merge**: tag the merge commit `v0.3.0` and push the tag to trigger crates.io publication.

451 tests pass throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HL9VNTgsRjARx9Xke47Jqp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HL9VNTgsRjARx9Xke47Jqp)_