### PR TITLE
Canonical format v2: move the envelope behind the payload, add a fixed packing, restore two wordlists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [package]
 name = "glossia"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Encode binary data (BIP39 mnemonics, keys, arbitrary payloads) into grammatically correct, human-readable natural language"

--- a/glossia-cli/Cargo.toml
+++ b/glossia-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glossia-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Command-line interface for glossia: encode binary data into grammatical natural language"
@@ -20,5 +20,5 @@ path = "src/main.rs"
 # Both `path` and `version` so it builds from the workspace during development
 # and resolves to the published crate when installed from crates.io. Publish the
 # `glossia` library first, then this CLI.
-glossia = { path = "..", version = "0.3.0", features = ["native"] }
+glossia = { path = "..", version = "0.4.0", features = ["native"] }
 rand = "0.8"

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -46,21 +46,30 @@
 //! requires a new canonical version if canonical artifacts exist for that
 //! language. The golden tests in `tests/canonical.rs` enforce the freeze.
 //!
-//! # Version 1 is gone, and why that was allowed once
+//! # Two framings, both live
 //!
-//! Version 1 put the version byte in FRONT of the payload, which is what made
-//! the envelope unversionable: the byte had to be readable before the rules were
-//! known, so its position could never move without breaking the mechanism that
-//! is supposed to prevent breaks. Version 2 moves it anyway, and pays for it by
-//! dropping v1 from [`rules_for`] outright rather than pretending both layouts
-//! can coexist — a v1 artifact reads its last byte as a version, finds nothing
-//! registered, and is refused by name.
+//! Version 1 put the version byte in FRONT of the payload, and that position was
+//! meant to be eternal: the byte has to be readable before the rules are known,
+//! so moving it appears to break the very mechanism that keeps artifacts
+//! readable. Version 2 moves it anyway, and the checksum is what pays for the
+//! move. A decoder no longer has to be TOLD which framing it is holding — it
+//! tries [`Envelope::PayloadLeading`], and a wrong guess fails its crc32 with
+//! probability 1 − 2⁻³². So it falls back to [`Envelope::VersionLeading`]
+//! without guesswork, and v1 artifacts keep decoding and keep verifying under
+//! v1's own rules.
 //!
-//! That was affordable exactly once: v1 shipped in 0.3.0, and the only consumer
-//! rendered its prose on demand rather than storing it, so no artifact was
-//! stranded. It is not affordable again. From v2 on the envelope's shape is
-//! frozen along with everything else a version freezes, and a future version
-//! changes rendering rules only.
+//! [`Envelope`] is therefore part of [`VersionRules`], and a version vouches
+//! only for the framing it declares — a v1 attempt is rejected unless the byte
+//! it finds names a version that actually says `VersionLeading`. This is what
+//! `rules_for` is for; dropping an old version would make the whole apparatus
+//! decorative.
+//!
+//! One caveat no version rule can repair: v1 artifacts in LATIN and GERMAN do
+//! not decode under 0.4.0. Those wordlists were one word short of a power of two
+//! until this release, so restoring the words renumbered every index and moved
+//! both languages from base-N to bitpack. That is a wordlist change rather than
+//! a format change, and it sits outside what a canonical version freezes.
+//! English and Czech v1 artifacts are unaffected.
 //!
 //! Callers that want more flexibility — their own seeds, bit packing, headers,
 //! best-of budgets — should use [`crate::pipeline::encode_words_into_language`]
@@ -76,64 +85,106 @@ use crate::codec::{
 use crate::pipeline::{cached_payload_tree, prepare_words_encode, resolve_wordlist_name};
 
 /// The version new canonical artifacts are written at.
-///
-/// Version 2 moved the version byte behind the payload and added the trailing
-/// checksum. Version 1 artifacts carried the version byte in front and cannot be
-/// read under this layout — a v1 artifact decodes its LAST byte as the version,
-/// which names no registered rules, so [`canonical_decode`] refuses it by name
-/// instead of returning a mis-framed payload.
 pub const CANONICAL_VERSION: u8 = 2;
 
-/// The byte↔word packing for the self-describing entry points. Deliberately NOT
-/// part of [`VersionRules`]: the version byte must be readable before the
-/// version is known, so the packing itself can never be versioned.
-/// (`canonical_bitpack` self-describes its padding with a trailing pad word;
-/// non-power-of-two wordlists fall back to base-N big-integer packing inside
-/// `encode_base_n`, deterministically.)
-const ENVELOPE_CODEC: &str = "canonical_bitpack";
-
 /// The byte↔word packing for the length-parameterized entry points. The caller
-/// states the payload's byte count, so no padding word is needed at all.
+/// states the payload's byte count, so no padding word is needed at all. Only
+/// [`Envelope::PayloadLeading`] versions offer it; v1 never had a fixed form.
 const FIXED_ENVELOPE_CODEC: &str = "bitpack_fixed";
 
 /// Width of the trailing crc32 over `payload || version`.
 const CHECKSUM_LEN: usize = 4;
 
-/// The envelope's fixed overhead: one version byte plus the checksum.
-const ENVELOPE_OVERHEAD: usize = 1 + CHECKSUM_LEN;
-
-/// Wrap a payload: `payload || version || crc32(payload || version)`.
-fn seal_envelope(payload: &[u8], version: u8) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(payload.len() + ENVELOPE_OVERHEAD);
-    bytes.extend_from_slice(payload);
-    bytes.push(version);
-    bytes.extend_from_slice(&crc32(&bytes).to_be_bytes());
-    bytes
-}
-
-/// Unwrap an envelope into `(version, payload)`, checking the trailing crc32.
+/// How a version frames its payload, and therefore how its bytes pack into
+/// words.
 ///
-/// The version is NOT checked against the registry here — [`rules_for`] is the
-/// caller's business, because the fixed and self-describing decoders report an
-/// unsupported version identically but reach this point differently.
-fn open_envelope(bytes: &[u8]) -> Result<(u8, Vec<u8>), CanonicalError> {
-    // A canonical artifact is at least one payload byte plus the envelope.
-    if bytes.len() < 1 + ENVELOPE_OVERHEAD {
-        return Err(CanonicalError::Decode(format!(
-            "decoded to {} bytes, fewer than the {} an envelope needs",
-            bytes.len(),
-            1 + ENVELOPE_OVERHEAD
-        )));
-    }
-    let (body, checksum) = bytes.split_at(bytes.len() - CHECKSUM_LEN);
-    let found = u32::from_be_bytes(checksum.try_into().expect("split at CHECKSUM_LEN"));
-    let expected = crc32(body);
-    if found != expected {
-        return Err(CanonicalError::ChecksumMismatch { expected, found });
-    }
-    let version = body[body.len() - 1];
-    Ok((version, body[..body.len() - 1].to_vec()))
+/// This is the one part of a version's format that the decoder must work out
+/// WITHOUT knowing the version — the layout tells it where the version byte is.
+/// v1 solved that by putting the byte first and declaring the framing eternal;
+/// v2 moves it behind the payload and pays for the move with a checksum, which
+/// is what lets a decoder tell the two apart by trying and checking rather than
+/// by being told.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Envelope {
+    /// v1: `version || payload`, packed with `bitpack` (leading padding word).
+    /// No checksum — the wording re-render was the only integrity check.
+    VersionLeading,
+    /// v2: `payload || version || crc32`, packed with `canonical_bitpack`
+    /// (trailing padding word) or `bitpack_fixed` (none).
+    PayloadLeading,
 }
+
+impl Envelope {
+    /// The self-describing codec this framing packs with.
+    fn codec(self) -> &'static str {
+        match self {
+            Envelope::VersionLeading => "bitpack",
+            Envelope::PayloadLeading => "canonical_bitpack",
+        }
+    }
+
+    /// Bytes this framing adds around the payload.
+    fn overhead(self) -> usize {
+        match self {
+            Envelope::VersionLeading => 1,
+            Envelope::PayloadLeading => 1 + CHECKSUM_LEN,
+        }
+    }
+
+    /// Wrap a payload for this framing.
+    fn seal(self, payload: &[u8], version: u8) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(payload.len() + self.overhead());
+        match self {
+            Envelope::VersionLeading => {
+                bytes.push(version);
+                bytes.extend_from_slice(payload);
+            }
+            Envelope::PayloadLeading => {
+                bytes.extend_from_slice(payload);
+                bytes.push(version);
+                bytes.extend_from_slice(&crc32(&bytes).to_be_bytes());
+            }
+        }
+        bytes
+    }
+
+    /// Unwrap into `(version, payload)`, checking the checksum where there is
+    /// one. The version is NOT checked against the registry here — that is the
+    /// caller's business.
+    fn open(self, bytes: &[u8]) -> Result<(u8, Vec<u8>), CanonicalError> {
+        if bytes.len() < 1 + self.overhead() {
+            return Err(CanonicalError::Decode(format!(
+                "decoded to {} bytes, fewer than the {} a {:?} envelope needs",
+                bytes.len(),
+                1 + self.overhead(),
+                self
+            )));
+        }
+        match self {
+            Envelope::VersionLeading => Ok((bytes[0], bytes[1..].to_vec())),
+            Envelope::PayloadLeading => {
+                let (body, checksum) = bytes.split_at(bytes.len() - CHECKSUM_LEN);
+                let found =
+                    u32::from_be_bytes(checksum.try_into().expect("split at CHECKSUM_LEN"));
+                let expected = crc32(body);
+                if found != expected {
+                    return Err(CanonicalError::ChecksumMismatch { expected, found });
+                }
+                Ok((body[body.len() - 1], body[..body.len() - 1].to_vec()))
+            }
+        }
+    }
+}
+
+/// The framings a decoder tries, newest first.
+///
+/// Order matters only for cost, not correctness: `PayloadLeading` carries a
+/// crc32, so a wrong guess is caught with probability 1 − 2⁻³², and
+/// `VersionLeading` is only accepted when the byte it finds names rules that
+/// actually declare that framing. A v2 artifact read as v1 yields a version
+/// byte from the middle of a payload, which all but never lands on a
+/// registered `VersionLeading` version.
+const ENVELOPES: &[Envelope] = &[Envelope::PayloadLeading, Envelope::VersionLeading];
 
 /// The rendering rules a canonical version freezes.
 ///
@@ -154,26 +205,48 @@ pub struct VersionRules {
     /// that lets semantics arrive for a language without re-rendering its
     /// existing artifacts.
     pub semantics_languages: &'static [&'static str],
+    /// How this version frames its payload. Unlike the other fields, the
+    /// decoder must determine this BEFORE it knows the version — see
+    /// [`Envelope`] and [`ENVELOPES`].
+    pub envelope: Envelope,
 }
+
+static V1: VersionRules = VersionRules {
+    best_of: 4,
+    dialect: "body",
+    // English's semantics.yaml is load-bearing for v1 renderings and is
+    // therefore frozen: regenerating it requires a new canonical version.
+    semantics_languages: &["english"],
+    envelope: Envelope::VersionLeading,
+};
 
 static V2: VersionRules = VersionRules {
     best_of: 4,
     dialect: "body",
-    // English's semantics.yaml is load-bearing for v2 renderings and is
-    // therefore frozen: regenerating it requires a new canonical version.
     semantics_languages: &["english"],
+    envelope: Envelope::PayloadLeading,
 };
 
 /// The frozen rules for a canonical version, or `None` if this library release
 /// does not know the version (i.e. the artifact was written by a newer one).
 ///
-/// Version 1 is absent deliberately. Its envelope put the version byte FIRST,
-/// which this release no longer packs or unpacks, so there is no layout under
-/// which a v1 artifact could be re-rendered for verification. Reporting it as
-/// unsupported is the honest answer; silently reading it under v2 framing would
-/// hand back a payload shifted by five bytes.
+/// Version 1 stays registered even though v2 reframed the envelope. Keeping it
+/// is the whole point of versioning rules: an artifact written by 0.3.0 still
+/// decodes and still verifies, because `rules_for` hands the decoder v1's
+/// framing and v1's rendering rules rather than the current ones. What made
+/// that possible is v2's checksum — a decoder can try the new framing, see it
+/// fail its crc32, and fall back to the old one without guessing.
+///
+/// One caveat that no version rule can repair: v1 artifacts in LATIN and GERMAN
+/// do not decode under this release. Those two payload wordlists were one word
+/// short of a power of two until 0.4.0 (YAML resolved `false:` and `null:` to
+/// non-string scalars and the loader dropped them), so restoring the words
+/// renumbered every index and switched the languages from base-N to bitpack.
+/// That is a wordlist change, not a format change, and it is outside what a
+/// canonical version freezes. English and Czech v1 artifacts are unaffected.
 pub fn rules_for(version: u8) -> Option<&'static VersionRules> {
     match version {
+        1 => Some(&V1),
         2 => Some(&V2),
         _ => None,
     }
@@ -192,6 +265,10 @@ pub enum CanonicalError {
     /// The trailing crc32 does not match the payload and version it covers:
     /// the words decoded, but not to the bytes that were encoded.
     ChecksumMismatch { expected: u32, found: u32 },
+    /// The version has no length-parameterized form. Only versions framed
+    /// `payload || version || checksum` offer one; v1's leading version byte
+    /// predates the fixed packing.
+    NoFixedForm(u8),
     Encode(String),
     Decode(String),
 }
@@ -208,6 +285,11 @@ impl fmt::Display for CanonicalError {
                 f,
                 "checksum mismatch: the words carry {:08x}, the payload they decode to checks as {:08x}",
                 found, expected
+            ),
+            CanonicalError::NoFixedForm(v) => write!(
+                f,
+                "canonical version {} has no fixed-length form (its version byte leads)",
+                v
             ),
             CanonicalError::Encode(e) => write!(f, "encode error: {}", e),
             CanonicalError::Decode(e) => write!(f, "decode error: {}", e),
@@ -264,7 +346,8 @@ pub fn canonical_encode_at(
     wordlist: &str,
     version: u8,
 ) -> Result<String, CanonicalError> {
-    encode_canonical_with(payload, language, wordlist, version, ENVELOPE_CODEC)
+    let rules = rules_for(version).ok_or(CanonicalError::UnsupportedVersion(version))?;
+    encode_canonical_with(payload, language, wordlist, version, rules.envelope.codec())
 }
 
 /// Encode `payload` as canonical prose with NO padding word.
@@ -292,6 +375,10 @@ pub fn canonical_encode_fixed_at(
     wordlist: &str,
     version: u8,
 ) -> Result<String, CanonicalError> {
+    let rules = rules_for(version).ok_or(CanonicalError::UnsupportedVersion(version))?;
+    if rules.envelope != Envelope::PayloadLeading {
+        return Err(CanonicalError::NoFixedForm(version));
+    }
     encode_canonical_with(payload, language, wordlist, version, FIXED_ENVELOPE_CODEC)
 }
 
@@ -308,7 +395,7 @@ fn encode_canonical_with(
         return Err(CanonicalError::EmptyPayload);
     }
 
-    let bytes = seal_envelope(payload, version);
+    let bytes = rules.envelope.seal(payload, version);
     let wl = resolve_wordlist_name(language, wordlist);
     let tree = cached_payload_tree(language, wl)
         .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
@@ -376,6 +463,13 @@ pub fn canonical_decode_raw_fixed(
 
 /// The shared decode body. `payload_len` present selects the fixed packing and
 /// states how many bytes to expect; absent selects the self-describing one.
+///
+/// The fixed packing exists only under [`Envelope::PayloadLeading`], so a stated
+/// length pins the framing and there is nothing to search. Without one, each
+/// framing in [`ENVELOPES`] is tried in turn and the first that both unpacks and
+/// names a version declaring that same framing wins. The error reported on total
+/// failure is the FIRST framing's, since that is the one a current artifact was
+/// meant to be.
 fn decode_canonical_with(
     text: &str,
     language: &str,
@@ -393,23 +487,54 @@ fn decode_canonical_with(
         return Err(CanonicalError::NoPayloadWords);
     }
 
-    let bytes = match payload_len {
-        Some(n) => decode_base_n_fixed(&words, &tree, FIXED_ENVELOPE_CODEC, n + ENVELOPE_OVERHEAD),
-        None => decode_base_n(&words, &tree, ENVELOPE_CODEC),
+    if let Some(n) = payload_len {
+        let envelope = Envelope::PayloadLeading;
+        let bytes = decode_base_n_fixed(
+            &words,
+            &tree,
+            FIXED_ENVELOPE_CODEC,
+            n + envelope.overhead(),
+        )
+        .map_err(|e| CanonicalError::Decode(format!("{:?}", e)))?;
+        // The checksum runs before the version lookup on purpose: damaged words
+        // are far likelier than an artifact from the future, so a mangled
+        // paragraph should report itself as mangled rather than as an
+        // unsupported version it never claimed.
+        let (version, payload) = envelope.open(&bytes)?;
+        let rules = rules_for(version).ok_or(CanonicalError::UnsupportedVersion(version))?;
+        if rules.envelope != envelope {
+            return Err(CanonicalError::NoFixedForm(version));
+        }
+        return Ok((version, payload));
     }
-    .map_err(|e| CanonicalError::Decode(format!("{:?}", e)))?;
 
-    // The checksum runs before the version lookup on purpose: damaged words are
-    // far likelier than an artifact from the future, so a mangled paragraph
-    // should report itself as mangled rather than as an unsupported version it
-    // never claimed.
-    let (version, payload) = open_envelope(&bytes)?;
-    // Unknown version: the payload words still decode, but there is no way to
-    // verify the wording without the version's rules. Refusing outright is the
-    // honest answer — "unverifiable" from a canonical decoder would be
-    // indistinguishable from damage.
-    rules_for(version).ok_or(CanonicalError::UnsupportedVersion(version))?;
-    Ok((version, payload))
+    let mut first_error = None;
+    for &envelope in ENVELOPES {
+        let attempt = decode_base_n(&words, &tree, envelope.codec())
+            .map_err(|e| CanonicalError::Decode(format!("{:?}", e)))
+            .and_then(|bytes| envelope.open(&bytes))
+            .and_then(|(version, payload)| {
+                let rules =
+                    rules_for(version).ok_or(CanonicalError::UnsupportedVersion(version))?;
+                // A version only vouches for the framing it declares. Without
+                // this the v1 attempt would accept any artifact whose seventh
+                // byte happened to read 1 or 2.
+                if rules.envelope != envelope {
+                    return Err(CanonicalError::UnsupportedVersion(version));
+                }
+                Ok((version, payload))
+            });
+        match attempt {
+            Ok(found) => return Ok(found),
+            Err(e) => first_error.get_or_insert(e),
+        };
+    }
+    // Unknown version, or nothing that framed cleanly: the payload words may
+    // still unpack, but there is no way to verify the wording without a
+    // version's rules. Refusing outright is the honest answer —
+    // "unverifiable" from a canonical decoder would be indistinguishable from
+    // damage.
+    Err(first_error.expect("ENVELOPES is never empty"))
 }
 
 /// Canonical encode with placements: the current-version rendering plus where
@@ -420,7 +545,8 @@ pub fn canonical_encode_traced(
     language: &str,
     wordlist: &str,
 ) -> Result<(String, Vec<crate::generator::core::Placement>), CanonicalError> {
-    encode_traced_with(payload, language, wordlist, ENVELOPE_CODEC)
+    let rules = rules_for(CANONICAL_VERSION).expect("current version must be registered");
+    encode_traced_with(payload, language, wordlist, rules.envelope.codec())
 }
 
 /// [`canonical_encode_fixed`] with placements. Text identical to
@@ -446,7 +572,7 @@ fn encode_traced_with(
         return Err(CanonicalError::EmptyPayload);
     }
 
-    let bytes = seal_envelope(payload, version);
+    let bytes = rules.envelope.seal(payload, version);
     let wl = resolve_wordlist_name(language, wordlist);
     let tree = cached_payload_tree(language, wl)
         .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;

--- a/src/canonical.rs
+++ b/src/canonical.rs
@@ -1,13 +1,38 @@
 //! Canonical, versioned encoding.
 //!
 //! [`canonical_encode`] produces exactly one prose form for a given
-//! `(payload, language, wordlist)`: the payload is prefixed with a version
-//! byte, packed into payload words, and rendered with the cover seeded from a
-//! checksum of the encoded bytes. Because the rendering rules are frozen per
-//! version in [`rules_for`], an artifact produced under version *n* renders —
-//! and therefore verifies — identically under every later library release:
-//! [`canonical_decode`] reads the version byte from the artifact itself and
-//! re-renders under that version's rules, never the current ones.
+//! `(payload, language, wordlist)`: the payload is wrapped in a version byte
+//! and a checksum, packed into payload words, and rendered with the cover
+//! seeded from a checksum of the encoded bytes. Because the rendering rules are
+//! frozen per version in [`rules_for`], an artifact produced under version *n*
+//! renders — and therefore verifies — identically under every later library
+//! release: [`canonical_decode`] reads the version byte from the artifact
+//! itself and re-renders under that version's rules, never the current ones.
+//!
+//! # The envelope
+//!
+//! ```text
+//!   bytes:  [ payload ][ version:1 ][ crc32:4 ]
+//!   words:  [ data_0 ] ... [ data_N-1 ][ padding ]      (canonical_encode)
+//!           [ data_0 ] ... [ data_N-1 ]                 (canonical_encode_fixed)
+//! ```
+//!
+//! Both envelope fields ride BEHIND the payload, and that placement is the
+//! whole point of the layout. Every byte at a fixed offset from the START of
+//! the packing pins the words a reader meets first: with the version byte
+//! leading, the opening word of every English artifact was one of eight, and
+//! with `bitpack`'s padding word leading it was a single constant word per
+//! field size — every 32-byte hash opened "abandon". Behind the payload, the
+//! opening words are payload entropy, and the checksum's four bytes stand
+//! between the version byte and the end of the paragraph so the closing words
+//! vary too.
+//!
+//! The trailing crc32 covers `payload || version`. It is a transcription check,
+//! not a cryptographic one, and it is deliberately redundant with
+//! [`CanonicalDecoded::verified`]: verification re-renders the whole paragraph
+//! and catches strictly more damage, but it costs a generation pass, so
+//! [`canonical_decode_raw`] — the entry point for callers decoding many
+//! candidates — leans on the checksum alone.
 //!
 //! This is what makes it safe to improve generation later. Shipping a
 //! `semantics.yaml` for a language, changing the best-of budget, or any other
@@ -21,6 +46,22 @@
 //! requires a new canonical version if canonical artifacts exist for that
 //! language. The golden tests in `tests/canonical.rs` enforce the freeze.
 //!
+//! # Version 1 is gone, and why that was allowed once
+//!
+//! Version 1 put the version byte in FRONT of the payload, which is what made
+//! the envelope unversionable: the byte had to be readable before the rules were
+//! known, so its position could never move without breaking the mechanism that
+//! is supposed to prevent breaks. Version 2 moves it anyway, and pays for it by
+//! dropping v1 from [`rules_for`] outright rather than pretending both layouts
+//! can coexist — a v1 artifact reads its last byte as a version, finds nothing
+//! registered, and is refused by name.
+//!
+//! That was affordable exactly once: v1 shipped in 0.3.0, and the only consumer
+//! rendered its prose on demand rather than storing it, so no artifact was
+//! stranded. It is not affordable again. From v2 on the envelope's shape is
+//! frozen along with everything else a version freezes, and a future version
+//! changes rendering rules only.
+//!
 //! Callers that want more flexibility — their own seeds, bit packing, headers,
 //! best-of budgets — should use [`crate::pipeline::encode_words_into_language`]
 //! and friends; those entry points are unversioned by design.
@@ -28,18 +69,71 @@
 use std::collections::HashSet;
 use std::fmt;
 
-use crate::codec::{checksum_seed, decode_base_n, encode_base_n, normalize_token, payload_tokens};
+use crate::codec::{
+    checksum_seed, crc32, decode_base_n, decode_base_n_fixed, encode_base_n, normalize_token,
+    payload_tokens,
+};
 use crate::pipeline::{cached_payload_tree, prepare_words_encode, resolve_wordlist_name};
 
 /// The version new canonical artifacts are written at.
-pub const CANONICAL_VERSION: u8 = 1;
+///
+/// Version 2 moved the version byte behind the payload and added the trailing
+/// checksum. Version 1 artifacts carried the version byte in front and cannot be
+/// read under this layout — a v1 artifact decodes its LAST byte as the version,
+/// which names no registered rules, so [`canonical_decode`] refuses it by name
+/// instead of returning a mis-framed payload.
+pub const CANONICAL_VERSION: u8 = 2;
 
-/// The byte↔word packing used to carry the version byte. Deliberately NOT part
-/// of [`VersionRules`]: the version byte must be readable before the version is
-/// known, so the packing itself can never be versioned. (`bitpack` self-describes
-/// its padding with a leading pad word; non-power-of-two wordlists fall back to
-/// base-N big-integer packing inside `encode_base_n`, deterministically.)
-const ENVELOPE_CODEC: &str = "bitpack";
+/// The byte↔word packing for the self-describing entry points. Deliberately NOT
+/// part of [`VersionRules`]: the version byte must be readable before the
+/// version is known, so the packing itself can never be versioned.
+/// (`canonical_bitpack` self-describes its padding with a trailing pad word;
+/// non-power-of-two wordlists fall back to base-N big-integer packing inside
+/// `encode_base_n`, deterministically.)
+const ENVELOPE_CODEC: &str = "canonical_bitpack";
+
+/// The byte↔word packing for the length-parameterized entry points. The caller
+/// states the payload's byte count, so no padding word is needed at all.
+const FIXED_ENVELOPE_CODEC: &str = "bitpack_fixed";
+
+/// Width of the trailing crc32 over `payload || version`.
+const CHECKSUM_LEN: usize = 4;
+
+/// The envelope's fixed overhead: one version byte plus the checksum.
+const ENVELOPE_OVERHEAD: usize = 1 + CHECKSUM_LEN;
+
+/// Wrap a payload: `payload || version || crc32(payload || version)`.
+fn seal_envelope(payload: &[u8], version: u8) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(payload.len() + ENVELOPE_OVERHEAD);
+    bytes.extend_from_slice(payload);
+    bytes.push(version);
+    bytes.extend_from_slice(&crc32(&bytes).to_be_bytes());
+    bytes
+}
+
+/// Unwrap an envelope into `(version, payload)`, checking the trailing crc32.
+///
+/// The version is NOT checked against the registry here — [`rules_for`] is the
+/// caller's business, because the fixed and self-describing decoders report an
+/// unsupported version identically but reach this point differently.
+fn open_envelope(bytes: &[u8]) -> Result<(u8, Vec<u8>), CanonicalError> {
+    // A canonical artifact is at least one payload byte plus the envelope.
+    if bytes.len() < 1 + ENVELOPE_OVERHEAD {
+        return Err(CanonicalError::Decode(format!(
+            "decoded to {} bytes, fewer than the {} an envelope needs",
+            bytes.len(),
+            1 + ENVELOPE_OVERHEAD
+        )));
+    }
+    let (body, checksum) = bytes.split_at(bytes.len() - CHECKSUM_LEN);
+    let found = u32::from_be_bytes(checksum.try_into().expect("split at CHECKSUM_LEN"));
+    let expected = crc32(body);
+    if found != expected {
+        return Err(CanonicalError::ChecksumMismatch { expected, found });
+    }
+    let version = body[body.len() - 1];
+    Ok((version, body[..body.len() - 1].to_vec()))
+}
 
 /// The rendering rules a canonical version freezes.
 ///
@@ -62,19 +156,25 @@ pub struct VersionRules {
     pub semantics_languages: &'static [&'static str],
 }
 
-static V1: VersionRules = VersionRules {
+static V2: VersionRules = VersionRules {
     best_of: 4,
     dialect: "body",
-    // English's semantics.yaml is load-bearing for v1 renderings and is
+    // English's semantics.yaml is load-bearing for v2 renderings and is
     // therefore frozen: regenerating it requires a new canonical version.
     semantics_languages: &["english"],
 };
 
 /// The frozen rules for a canonical version, or `None` if this library release
 /// does not know the version (i.e. the artifact was written by a newer one).
+///
+/// Version 1 is absent deliberately. Its envelope put the version byte FIRST,
+/// which this release no longer packs or unpacks, so there is no layout under
+/// which a v1 artifact could be re-rendered for verification. Reporting it as
+/// unsupported is the honest answer; silently reading it under v2 framing would
+/// hand back a payload shifted by five bytes.
 pub fn rules_for(version: u8) -> Option<&'static VersionRules> {
     match version {
-        1 => Some(&V1),
+        2 => Some(&V2),
         _ => None,
     }
 }
@@ -89,6 +189,9 @@ pub enum CanonicalError {
     UnsupportedVersion(u8),
     /// No payload words were found in the text.
     NoPayloadWords,
+    /// The trailing crc32 does not match the payload and version it covers:
+    /// the words decoded, but not to the bytes that were encoded.
+    ChecksumMismatch { expected: u32, found: u32 },
     Encode(String),
     Decode(String),
 }
@@ -101,6 +204,11 @@ impl fmt::Display for CanonicalError {
                 write!(f, "canonical version {} is not supported by this build (max {})", v, CANONICAL_VERSION)
             }
             CanonicalError::NoPayloadWords => write!(f, "no payload words found in text"),
+            CanonicalError::ChecksumMismatch { expected, found } => write!(
+                f,
+                "checksum mismatch: the words carry {:08x}, the payload they decode to checks as {:08x}",
+                found, expected
+            ),
             CanonicalError::Encode(e) => write!(f, "encode error: {}", e),
             CanonicalError::Decode(e) => write!(f, "decode error: {}", e),
         }
@@ -133,8 +241,13 @@ pub struct CanonicalDecoded {
 ///
 /// Deterministic: one payload has exactly one canonical rendering per
 /// `(language, wordlist)`. The cover seed is a checksum of the encoded bytes
-/// (version byte included), so any change to the payload re-renders the whole
+/// (envelope included), so any change to the payload re-renders the whole
 /// paragraph, which is what makes damage legible to a reader.
+///
+/// This is the self-describing form: the word list carries its own padding
+/// count, so [`canonical_decode`] needs nothing but the prose. A caller that
+/// already knows the payload's byte count should prefer
+/// [`canonical_encode_fixed`], which spends no word on saying it.
 pub fn canonical_encode(
     payload: &[u8],
     language: &str,
@@ -151,26 +264,62 @@ pub fn canonical_encode_at(
     wordlist: &str,
     version: u8,
 ) -> Result<String, CanonicalError> {
+    encode_canonical_with(payload, language, wordlist, version, ENVELOPE_CODEC)
+}
+
+/// Encode `payload` as canonical prose with NO padding word.
+///
+/// Identical bytes and identical rules to [`canonical_encode`] — same envelope,
+/// same version, same cover seed — but packed with `bitpack_fixed`, so the word
+/// list is pure payload. The reader of the prose cannot tell how long the
+/// payload is, and neither can the decoder: [`canonical_decode_fixed`] must be
+/// told the byte count. That is the right trade wherever the count is already
+/// known and stated (a 32-byte hash, a 20-byte hash160, a 65-byte key), which is
+/// most structured data.
+pub fn canonical_encode_fixed(
+    payload: &[u8],
+    language: &str,
+    wordlist: &str,
+) -> Result<String, CanonicalError> {
+    canonical_encode_fixed_at(payload, language, wordlist, CANONICAL_VERSION)
+}
+
+/// [`canonical_encode_fixed`] at an explicit version — the re-render half of
+/// [`canonical_decode_fixed`]'s verification.
+pub fn canonical_encode_fixed_at(
+    payload: &[u8],
+    language: &str,
+    wordlist: &str,
+    version: u8,
+) -> Result<String, CanonicalError> {
+    encode_canonical_with(payload, language, wordlist, version, FIXED_ENVELOPE_CODEC)
+}
+
+/// The shared encode body: seal the envelope, pack it with `codec`, render.
+fn encode_canonical_with(
+    payload: &[u8],
+    language: &str,
+    wordlist: &str,
+    version: u8,
+    codec: &str,
+) -> Result<String, CanonicalError> {
     let rules = rules_for(version).ok_or(CanonicalError::UnsupportedVersion(version))?;
     if payload.is_empty() {
         return Err(CanonicalError::EmptyPayload);
     }
 
-    let mut bytes = Vec::with_capacity(1 + payload.len());
-    bytes.push(version);
-    bytes.extend_from_slice(payload);
-
+    let bytes = seal_envelope(payload, version);
     let wl = resolve_wordlist_name(language, wordlist);
     let tree = cached_payload_tree(language, wl)
         .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
-    let words = encode_base_n(&bytes, &tree, ENVELOPE_CODEC)
+    let words = encode_base_n(&bytes, &tree, codec)
         .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
 
     render_canonical(&words, &bytes, language, wl, rules)
 }
 
-/// Decode canonical prose: harvest the payload words, unpack the version byte,
-/// and verify by re-rendering under that version's rules.
+/// Decode canonical prose: harvest the payload words, unpack the envelope, and
+/// verify by re-rendering under that version's rules.
 pub fn canonical_decode(
     text: &str,
     language: &str,
@@ -182,17 +331,56 @@ pub fn canonical_decode(
     Ok(CanonicalDecoded { version, payload, verified, canonical_text: reference })
 }
 
-/// The decode half alone: payload words → version byte + payload bytes, with
-/// the version checked against the registry but the wording NOT verified.
+/// Decode prose written by [`canonical_encode_fixed`], given the payload's byte
+/// count, and verify by re-rendering under that version's rules.
+///
+/// `payload_len` is the payload alone — the envelope's own bytes are this
+/// function's business, not the caller's.
+pub fn canonical_decode_fixed(
+    text: &str,
+    language: &str,
+    wordlist: &str,
+    payload_len: usize,
+) -> Result<CanonicalDecoded, CanonicalError> {
+    let (version, payload) = canonical_decode_raw_fixed(text, language, wordlist, payload_len)?;
+    let reference = canonical_encode_fixed_at(&payload, language, wordlist, version)?;
+    let verified = same_wording(text, &reference);
+    Ok(CanonicalDecoded { version, payload, verified, canonical_text: reference })
+}
+
+/// The decode half alone: payload words → version byte + payload bytes, with the
+/// checksum and the version registry checked but the wording NOT verified.
 ///
 /// This is for callers doing many decodes per verification — a repair search
 /// proposing typo corrections decodes every candidate but only needs each
-/// candidate's rendering once, from its own (often memoized) encode call.
+/// candidate's rendering once, from its own (often memoized) encode call. The
+/// trailing checksum is what makes that cheap pass worth anything on its own.
 /// [`canonical_decode`] is this plus the verify re-render.
 pub fn canonical_decode_raw(
     text: &str,
     language: &str,
     wordlist: &str,
+) -> Result<(u8, Vec<u8>), CanonicalError> {
+    decode_canonical_with(text, language, wordlist, None)
+}
+
+/// [`canonical_decode_raw`] for the fixed packing, given the payload byte count.
+pub fn canonical_decode_raw_fixed(
+    text: &str,
+    language: &str,
+    wordlist: &str,
+    payload_len: usize,
+) -> Result<(u8, Vec<u8>), CanonicalError> {
+    decode_canonical_with(text, language, wordlist, Some(payload_len))
+}
+
+/// The shared decode body. `payload_len` present selects the fixed packing and
+/// states how many bytes to expect; absent selects the self-describing one.
+fn decode_canonical_with(
+    text: &str,
+    language: &str,
+    wordlist: &str,
+    payload_len: Option<usize>,
 ) -> Result<(u8, Vec<u8>), CanonicalError> {
     let wl = resolve_wordlist_name(language, wordlist);
     let tree = cached_payload_tree(language, wl)
@@ -205,13 +393,17 @@ pub fn canonical_decode_raw(
         return Err(CanonicalError::NoPayloadWords);
     }
 
-    let bytes = decode_base_n(&words, &tree, ENVELOPE_CODEC)
-        .map_err(|e| CanonicalError::Decode(format!("{:?}", e)))?;
-    if bytes.len() < 2 {
-        return Err(CanonicalError::Decode("decoded to fewer than 2 bytes".to_string()));
+    let bytes = match payload_len {
+        Some(n) => decode_base_n_fixed(&words, &tree, FIXED_ENVELOPE_CODEC, n + ENVELOPE_OVERHEAD),
+        None => decode_base_n(&words, &tree, ENVELOPE_CODEC),
     }
-    let version = bytes[0];
-    let payload = bytes[1..].to_vec();
+    .map_err(|e| CanonicalError::Decode(format!("{:?}", e)))?;
+
+    // The checksum runs before the version lookup on purpose: damaged words are
+    // far likelier than an artifact from the future, so a mangled paragraph
+    // should report itself as mangled rather than as an unsupported version it
+    // never claimed.
+    let (version, payload) = open_envelope(&bytes)?;
     // Unknown version: the payload words still decode, but there is no way to
     // verify the wording without the version's rules. Refusing outright is the
     // honest answer — "unverifiable" from a canonical decoder would be
@@ -228,20 +420,37 @@ pub fn canonical_encode_traced(
     language: &str,
     wordlist: &str,
 ) -> Result<(String, Vec<crate::generator::core::Placement>), CanonicalError> {
+    encode_traced_with(payload, language, wordlist, ENVELOPE_CODEC)
+}
+
+/// [`canonical_encode_fixed`] with placements. Text identical to
+/// [`canonical_encode_fixed`]'s, and one placement fewer than
+/// [`canonical_encode_traced`] returns, there being no padding word to place.
+pub fn canonical_encode_fixed_traced(
+    payload: &[u8],
+    language: &str,
+    wordlist: &str,
+) -> Result<(String, Vec<crate::generator::core::Placement>), CanonicalError> {
+    encode_traced_with(payload, language, wordlist, FIXED_ENVELOPE_CODEC)
+}
+
+fn encode_traced_with(
+    payload: &[u8],
+    language: &str,
+    wordlist: &str,
+    codec: &str,
+) -> Result<(String, Vec<crate::generator::core::Placement>), CanonicalError> {
     let version = CANONICAL_VERSION;
     let rules = rules_for(version).expect("current version must be registered");
     if payload.is_empty() {
         return Err(CanonicalError::EmptyPayload);
     }
 
-    let mut bytes = Vec::with_capacity(1 + payload.len());
-    bytes.push(version);
-    bytes.extend_from_slice(payload);
-
+    let bytes = seal_envelope(payload, version);
     let wl = resolve_wordlist_name(language, wordlist);
     let tree = cached_payload_tree(language, wl)
         .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
-    let words = encode_base_n(&bytes, &tree, ENVELOPE_CODEC)
+    let words = encode_base_n(&bytes, &tree, codec)
         .map_err(|e| CanonicalError::Encode(format!("{:?}", e)))?;
 
     let (toks, payload_word_set, gen) = prepare_render(&words, language, wl, rules)?;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -674,11 +674,27 @@ fn encode_bitpack_fixed(data: &[u8], wordlist: &WordlistTree) -> Result<Vec<Stri
 ///
 /// The caller must supply `expected_bytes` — the original payload byte count.
 /// This resolves the bit-alignment ambiguity without needing a padding word.
+///
+/// The word count must be exactly the one `encode_bitpack_fixed` would produce
+/// for `expected_bytes`. It used to be a floor rather than an equality: too few
+/// words simply left the tail of the output zero, so a truncated artifact — or
+/// prose written at some other length entirely — decoded to a plausible
+/// zero-padded payload instead of an error. A decoder told how many bytes to
+/// expect should say so when it was not handed them.
 fn decode_bitpack_fixed(words: &[String], wordlist: &WordlistTree, expected_bytes: usize) -> Result<Vec<u8>, DecodeError> {
     use std::collections::HashMap;
 
     let bits_per_word = wordlist.len().trailing_zeros() as usize;
     let data_bits = expected_bytes * 8;
+    let expected_words = data_bits.div_ceil(bits_per_word);
+    if words.len() != expected_words {
+        return Err(DecodeError::MalformedPayload(format!(
+            "decode_bitpack_fixed: {} words for {} bytes, expected {}",
+            words.len(),
+            expected_bytes,
+            expected_words
+        )));
+    }
 
     let mut word_to_index: HashMap<String, usize> = HashMap::new();
     for (i, word) in wordlist.words().iter().enumerate() {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -409,6 +409,7 @@ pub fn detect_mode(s: &str) -> (DataMode, Vec<u8>) {
 ///
 /// The `codec` parameter controls encoding strategy:
 /// - `"bitpack"`: fixed-size bit chunks with padding word (uniform distribution, requires power-of-2 wordlist)
+/// - `"canonical_bitpack"`: as `"bitpack"`, but the padding word rides last
 /// - `"bitpack_fixed"`: fixed-size bit chunks without padding word (for known-length payloads)
 /// - `"base_n"` (or anything else): big-integer base-N encoding
 pub fn encode_base_n(data: &[u8], wordlist: &WordlistTree, codec: &str) -> Result<Vec<String>, DecodeError> {
@@ -421,6 +422,7 @@ pub fn encode_base_n(data: &[u8], wordlist: &WordlistTree, codec: &str) -> Resul
     if wordlist.len() > 1 && wordlist.len().is_power_of_two() {
         match codec {
             "bitpack" => return encode_bitpack(data, wordlist),
+            "canonical_bitpack" => return encode_canonical_bitpack(data, wordlist),
             "bitpack_fixed" => return encode_bitpack_fixed(data, wordlist),
             _ => {}
         }
@@ -432,6 +434,7 @@ pub fn encode_base_n(data: &[u8], wordlist: &WordlistTree, codec: &str) -> Resul
 ///
 /// The `codec` parameter controls decoding strategy:
 /// - `"bitpack"`: fixed-size bit chunks with padding word (requires power-of-2 wordlist)
+/// - `"canonical_bitpack"`: as `"bitpack"`, but the padding word rides last
 /// - `"bitpack_fixed"`: fixed-size bit chunks without padding word (requires `expected_bytes`)
 /// - `"base_n"` (or anything else): big-integer base-N decoding
 ///
@@ -446,6 +449,7 @@ pub fn decode_base_n(words: &[String], wordlist: &WordlistTree, codec: &str) -> 
     if wordlist.len() > 1 && wordlist.len().is_power_of_two() {
         match codec {
             "bitpack" => return decode_bitpack(words, wordlist),
+            "canonical_bitpack" => return decode_canonical_bitpack(words, wordlist),
             "bitpack_fixed" => {
                 // Without expected_bytes, infer from word count (exact when aligned)
                 let bits_per_word = wordlist.len().trailing_zeros() as usize;
@@ -589,6 +593,44 @@ fn decode_bitpack(words: &[String], wordlist: &WordlistTree) -> Result<Vec<u8>, 
     }
 
     Ok(result)
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Canonical bitpack encoding (padding word last)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Encode bytes exactly as [`encode_bitpack`] does, but with the padding word
+/// riding LAST instead of first.
+///
+/// Format: `[data_word_0] ... [data_word_N-1] [padding_word]`
+///
+/// Same bits, same padding count, same round trip -- only the position of the
+/// envelope word differs, and the reason is what a reader sees. The padding
+/// count depends solely on the payload's LENGTH, so for any fixed-size field it
+/// is a constant, and at the front of the list it becomes a constant FIRST word
+/// of the prose: every 32-byte hash opened with the wordlist's word 0. Moving it
+/// to the tail puts payload entropy in the opening words, where a reader starts,
+/// and leaves the fixed word where a paragraph is already trailing off.
+fn encode_canonical_bitpack(data: &[u8], wordlist: &WordlistTree) -> Result<Vec<String>, DecodeError> {
+    let mut words = encode_bitpack(data, wordlist)?;
+    if !words.is_empty() {
+        let pad = words.remove(0);
+        words.push(pad);
+    }
+    Ok(words)
+}
+
+/// Decode [`encode_canonical_bitpack`] output: rotate the trailing padding word
+/// back to the front and hand the rest to the shared bitpack decoder, so the two
+/// layouts can never drift apart in their bit handling.
+fn decode_canonical_bitpack(words: &[String], wordlist: &WordlistTree) -> Result<Vec<u8>, DecodeError> {
+    if words.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut rotated = Vec::with_capacity(words.len());
+    rotated.push(words[words.len() - 1].clone());
+    rotated.extend_from_slice(&words[..words.len() - 1]);
+    decode_bitpack(&rotated, wordlist)
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/src/generator/data.rs
+++ b/src/generator/data.rs
@@ -236,6 +236,31 @@ fn payload_cache_file_path(language: &str, wordlist: &str, payload_path: Option<
     glossia_cache_dir().join(format!("payload_cache_{language}_{wordlist}_{key:016x}.bin"))
 }
 
+/// A payload-wordlist YAML key as the word it spells.
+///
+/// A wordlist is a list of words, but YAML's core schema resolves a few of them
+/// to non-string scalars: German's `null` (die Null) becomes the null value,
+/// Latin's `false` becomes a boolean, and a numeric wordlist (math/primes)
+/// becomes numbers. Reading the key with `as_str()` alone drops those entries
+/// silently, which costs the word AND can knock the list off the size its codec
+/// depends on -- `encode_base_n` gates the bitpack codecs on a power-of-two
+/// wordlist, so one lost word sent German (2048 -> 2047) and Latin
+/// (32768 -> 32767) down the big-integer path instead. Spell the scalar back
+/// out rather than skipping it; only a non-scalar key (a sequence or mapping,
+/// which no wordlist writes) is genuinely not a word.
+fn payload_key_word(key: &serde_yaml::Value) -> Option<String> {
+    use serde_yaml::Value;
+    match key {
+        Value::String(s) => Some(s.clone()),
+        // `null` and `~` both land here; a wordlist that wants the word spells
+        // it out, and no wordlist carries `~`.
+        Value::Null => Some("null".to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
 fn load_or_build_payload_cache(language: &str, wordlist: &str) -> Result<Arc<PayloadCacheData>, String> {
     // In-memory cache keyed on (language, wordlist).
     let cache_key = format!("{}:{}", language, wordlist);
@@ -328,7 +353,7 @@ fn load_or_build_payload_cache(language: &str, wordlist: &str) -> Result<Arc<Pay
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::with_capacity(mapping.len());
 
     for (key, value) in mapping {
-        let word = match key.as_str() {
+        let word = match payload_key_word(key) {
             Some(s) => s.to_lowercase(),
             None => continue,
         };
@@ -623,7 +648,7 @@ pub fn load_payload_words_from_yaml_content(yaml_content: &str) -> Result<Vec<St
     let mut words: Vec<String> = Vec::with_capacity(mapping.len());
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::with_capacity(mapping.len());
     for (key, _) in mapping {
-        if let Some(s) = key.as_str() {
+        if let Some(s) = payload_key_word(key) {
             let word = s.to_lowercase();
             if !word.is_empty() && seen.insert(word.clone()) {
                 words.push(word);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub use canonical::{
     canonical_decode, canonical_decode_fixed, canonical_decode_raw, canonical_decode_raw_fixed,
     canonical_encode, canonical_encode_at, canonical_encode_fixed, canonical_encode_fixed_at,
     canonical_encode_fixed_traced, canonical_encode_traced, rules_for,
-    CanonicalDecoded, CanonicalError, VersionRules, CANONICAL_VERSION,
+    CanonicalDecoded, CanonicalError, Envelope, VersionRules, CANONICAL_VERSION,
 };
 
 #[cfg(feature = "native")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,9 @@ pub use codec::{
 pub use pipeline::{Pipeline, Endpoint, Verb, PipelineError, encode_into_language, decode_from_language, cached_payload_tree};
 
 pub use canonical::{
-    canonical_decode, canonical_decode_raw, canonical_encode, canonical_encode_at,
-    canonical_encode_traced, rules_for,
+    canonical_decode, canonical_decode_fixed, canonical_decode_raw, canonical_decode_raw_fixed,
+    canonical_encode, canonical_encode_at, canonical_encode_fixed, canonical_encode_fixed_at,
+    canonical_encode_fixed_traced, canonical_encode_traced, rules_for,
     CanonicalDecoded, CanonicalError, VersionRules, CANONICAL_VERSION,
 };
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1417,6 +1417,31 @@ pub fn canonical_encode(payload_hex: &str, language: &str, wordlist: &str) -> St
     }
 }
 
+/// Canonical encode at an EXPLICIT format version, rather than the current one.
+///
+/// The framing follows the version's own rules, so this writes a version-1
+/// artifact (version byte leading, no checksum) as faithfully as a current one.
+/// It is the re-render half of verification — a JS host checking an old artifact
+/// needs to reproduce it under the rules it was written with — and the escape
+/// hatch for emitting prose an older release can still read.
+///
+/// Returns JSON `{ encoded_text, version }` or `{ error, kind }`.
+#[wasm_bindgen]
+pub fn canonical_encode_at(
+    payload_hex: &str,
+    language: &str,
+    wordlist: &str,
+    version: u8,
+) -> String {
+    let Some(bytes) = codec::hex_decode(payload_hex) else {
+        return serde_json::json!({ "error": "bad payload hex" }).to_string();
+    };
+    match crate::canonical::canonical_encode_at(&bytes, language, wordlist, version) {
+        Ok(text) => serde_json::json!({ "encoded_text": text, "version": version }).to_string(),
+        Err(e) => canonical_error_json(e),
+    }
+}
+
 /// Canonical encode with placements — the same text as `canonical_encode`, plus
 /// where each payload word landed, for UIs that annotate the prose.
 ///
@@ -1445,6 +1470,7 @@ fn canonical_error_json(e: crate::canonical::CanonicalError) -> String {
         E::UnsupportedVersion(_) => "unsupported_version",
         E::NoPayloadWords => "no_payload_words",
         E::ChecksumMismatch { .. } => "checksum_mismatch",
+        E::NoFixedForm(_) => "no_fixed_form",
         E::Encode(_) => "encode",
         E::Decode(_) => "decode",
     };

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1413,7 +1413,7 @@ pub fn canonical_encode(payload_hex: &str, language: &str, wordlist: &str) -> St
             "version": crate::canonical::CANONICAL_VERSION,
         })
         .to_string(),
-        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        Err(e) => canonical_error_json(e),
     }
 }
 
@@ -1428,6 +1428,27 @@ pub fn canonical_encode_traced(payload_hex: &str, language: &str, wordlist: &str
         return serde_json::json!({ "error": "bad payload hex" }).to_string();
     };
     traced_json(crate::canonical::canonical_encode_traced(&bytes, language, wordlist))
+}
+
+/// A canonical error as JSON: the message, plus a stable `kind` slug.
+///
+/// The slug is what lets a caller branch without matching on prose. It matters
+/// most for `checksum_mismatch`: a host that falls back to another decoder when
+/// the canonical one declines needs to know the difference between "this is not
+/// canonical prose" (fall back) and "this is canonical prose and it is damaged"
+/// (do not fall back — quietly returning bytes from a different codec would
+/// hand the caller a plausible wrong answer).
+fn canonical_error_json(e: crate::canonical::CanonicalError) -> String {
+    use crate::canonical::CanonicalError as E;
+    let kind = match e {
+        E::EmptyPayload => "empty_payload",
+        E::UnsupportedVersion(_) => "unsupported_version",
+        E::NoPayloadWords => "no_payload_words",
+        E::ChecksumMismatch { .. } => "checksum_mismatch",
+        E::Encode(_) => "encode",
+        E::Decode(_) => "decode",
+    };
+    serde_json::json!({ "error": e.to_string(), "kind": kind }).to_string()
 }
 
 /// Shared JSON shaping for the traced encoders.
@@ -1460,7 +1481,7 @@ fn traced_json(
             })
             .to_string()
         }
-        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        Err(e) => canonical_error_json(e),
     }
 }
 
@@ -1482,7 +1503,7 @@ pub fn canonical_decode(text: &str, language: &str, wordlist: &str) -> String {
             "canonical_text": d.canonical_text,
         })
         .to_string(),
-        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        Err(e) => canonical_error_json(e),
     }
 }
 
@@ -1499,7 +1520,7 @@ pub fn canonical_decode_raw(text: &str, language: &str, wordlist: &str) -> Strin
             "payload_hex": codec::hex_encode(&payload),
         })
         .to_string(),
-        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        Err(e) => canonical_error_json(e),
     }
 }
 
@@ -1520,7 +1541,7 @@ pub fn canonical_encode_fixed(payload_hex: &str, language: &str, wordlist: &str)
             "version": crate::canonical::CANONICAL_VERSION,
         })
         .to_string(),
-        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        Err(e) => canonical_error_json(e),
     }
 }
 
@@ -1556,7 +1577,7 @@ pub fn canonical_decode_fixed(
             "canonical_text": d.canonical_text,
         })
         .to_string(),
-        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        Err(e) => canonical_error_json(e),
     }
 }
 
@@ -1577,7 +1598,7 @@ pub fn canonical_decode_raw_fixed(
             "payload_hex": codec::hex_encode(&payload),
         })
         .to_string(),
-        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        Err(e) => canonical_error_json(e),
     }
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1427,7 +1427,14 @@ pub fn canonical_encode_traced(payload_hex: &str, language: &str, wordlist: &str
     let Some(bytes) = codec::hex_decode(payload_hex) else {
         return serde_json::json!({ "error": "bad payload hex" }).to_string();
     };
-    match crate::canonical::canonical_encode_traced(&bytes, language, wordlist) {
+    traced_json(crate::canonical::canonical_encode_traced(&bytes, language, wordlist))
+}
+
+/// Shared JSON shaping for the traced encoders.
+fn traced_json(
+    result: Result<(String, Vec<crate::generator::core::Placement>), crate::canonical::CanonicalError>,
+) -> String {
+    match result {
         Ok((text, placements)) => {
             let ps: Vec<serde_json::Value> = placements
                 .iter()
@@ -1487,6 +1494,84 @@ pub fn canonical_decode(text: &str, language: &str, wordlist: &str) -> String {
 #[wasm_bindgen]
 pub fn canonical_decode_raw(text: &str, language: &str, wordlist: &str) -> String {
     match crate::canonical::canonical_decode_raw(text, language, wordlist) {
+        Ok((version, payload)) => serde_json::json!({
+            "version": version,
+            "payload_hex": codec::hex_encode(&payload),
+        })
+        .to_string(),
+        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+    }
+}
+
+/// Canonical encode with NO padding word, for a payload whose byte count the
+/// caller already knows and can restate when decoding. Same envelope, same
+/// version, same rules as `canonical_encode` — one word shorter, and the prose
+/// opens on payload rather than on a constant the payload's length fixed.
+///
+/// Returns JSON `{ encoded_text, version }` or `{ error }`.
+#[wasm_bindgen]
+pub fn canonical_encode_fixed(payload_hex: &str, language: &str, wordlist: &str) -> String {
+    let Some(bytes) = codec::hex_decode(payload_hex) else {
+        return serde_json::json!({ "error": "bad payload hex" }).to_string();
+    };
+    match crate::canonical::canonical_encode_fixed(&bytes, language, wordlist) {
+        Ok(text) => serde_json::json!({
+            "encoded_text": text,
+            "version": crate::canonical::CANONICAL_VERSION,
+        })
+        .to_string(),
+        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+    }
+}
+
+/// `canonical_encode_fixed` with placements, for UIs that annotate the prose.
+///
+/// Returns JSON `{ encoded_text, version, placements: [...] }` or `{ error }`.
+#[wasm_bindgen]
+pub fn canonical_encode_fixed_traced(payload_hex: &str, language: &str, wordlist: &str) -> String {
+    let Some(bytes) = codec::hex_decode(payload_hex) else {
+        return serde_json::json!({ "error": "bad payload hex" }).to_string();
+    };
+    traced_json(crate::canonical::canonical_encode_fixed_traced(&bytes, language, wordlist))
+}
+
+/// Decode prose written by `canonical_encode_fixed` and verify it by
+/// re-rendering. `payload_len` is the payload's byte count, the envelope's own
+/// bytes excluded.
+///
+/// Returns JSON `{ version, payload_hex, verified, canonical_text }` or
+/// `{ error }`.
+#[wasm_bindgen]
+pub fn canonical_decode_fixed(
+    text: &str,
+    language: &str,
+    wordlist: &str,
+    payload_len: usize,
+) -> String {
+    match crate::canonical::canonical_decode_fixed(text, language, wordlist, payload_len) {
+        Ok(d) => serde_json::json!({
+            "version": d.version,
+            "payload_hex": codec::hex_encode(&d.payload),
+            "verified": d.verified,
+            "canonical_text": d.canonical_text,
+        })
+        .to_string(),
+        Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+    }
+}
+
+/// The fixed decode half alone: no verification re-render, checksum still
+/// checked.
+///
+/// Returns JSON `{ version, payload_hex }` or `{ error }`.
+#[wasm_bindgen]
+pub fn canonical_decode_raw_fixed(
+    text: &str,
+    language: &str,
+    wordlist: &str,
+    payload_len: usize,
+) -> String {
+    match crate::canonical::canonical_decode_raw_fixed(text, language, wordlist, payload_len) {
         Ok((version, payload)) => serde_json::json!({
             "version": version,
             "payload_hex": codec::hex_encode(&payload),

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -10,7 +10,7 @@
 use glossia::{
     canonical_decode, canonical_decode_fixed, canonical_encode, canonical_encode_at,
     canonical_encode_fixed, canonical_encode_fixed_at, canonical_encode_fixed_traced, rules_for,
-    CanonicalError, CANONICAL_VERSION,
+    CanonicalError, Envelope, CANONICAL_VERSION,
 };
 
 /// `payload || version || crc32(payload || version)` — the envelope as
@@ -142,26 +142,52 @@ fn unknown_version_is_refused_by_name() {
 }
 
 #[test]
-fn version_1_artifacts_are_refused_rather_than_misread() {
-    // v1 put the version byte FIRST and carried no checksum. This release packs
-    // neither, so a v1 artifact must fail loudly. What it must NOT do is hand
-    // back a payload shifted by five bytes as though it had read it.
-    let tree = glossia::cached_payload_tree("english", "bip39").unwrap();
-    let mut v1_bytes = vec![1u8];
-    v1_bytes.extend(0u8..20);
-    let words = glossia::codec::encode_base_n(&v1_bytes, &tree, "bitpack").unwrap();
-    let (text, _) = glossia::pipeline::encode_words_into_language(
-        &words, "english", "bip39", "body", 7, 1,
-    )
-    .unwrap();
-    match canonical_decode(&text, "english", "bip39") {
-        Err(CanonicalError::ChecksumMismatch { .. }) => {}
-        Err(CanonicalError::UnsupportedVersion(_)) => {}
-        Err(CanonicalError::Decode(_)) => {}
-        other => panic!("a v1 artifact must be refused, got {other:?}"),
+fn version_1_artifacts_still_decode_and_verify() {
+    // The point of versioned rules. v1 frames `version || payload` with a
+    // leading padding word and carries no checksum; v2 frames the other way
+    // round. A v1 artifact must still decode, still report version 1, and still
+    // VERIFY — its wording re-rendered under v1's rules, not the current ones.
+    //
+    // English and Czech only: the 0.4.0 wordlist fix renumbered Latin and
+    // German, which is a wordlist change rather than a format one and is
+    // outside what a canonical version can freeze.
+    for (language, wordlist) in [("english", "bip39"), ("czech", "default")] {
+        for payload in payloads() {
+            let text = canonical_encode_at(&payload, language, wordlist, 1)
+                .unwrap_or_else(|e| panic!("{language} v1 encode: {e}"));
+            let d = canonical_decode(&text, language, wordlist)
+                .unwrap_or_else(|e| panic!("{language} v1 decode: {e}"));
+            assert_eq!(d.version, 1, "{language} must report the artifact's own version");
+            assert_eq!(d.payload, payload, "{language} v1 payload round trip");
+            assert!(d.verified, "{language} v1 artifact must still verify");
+        }
     }
-    // And v1 is gone from the registry, so nothing can be written at it either.
-    assert!(rules_for(1).is_none(), "v1 rules must not be reachable");
+}
+
+#[test]
+fn the_two_framings_do_not_read_each_other() {
+    // Each version vouches only for the framing it declares, so neither
+    // framing can quietly claim the other's artifact. Without that check the v1
+    // attempt would accept any artifact whose leading byte happened to read 1.
+    let payload: Vec<u8> = (0u8..20).collect();
+    let v1 = canonical_encode_at(&payload, "english", "bip39", 1).unwrap();
+    let v2 = canonical_encode_at(&payload, "english", "bip39", 2).unwrap();
+    assert_ne!(v1, v2, "the framings must produce different prose");
+
+    assert_eq!(canonical_decode(&v1, "english", "bip39").unwrap().version, 1);
+    assert_eq!(canonical_decode(&v2, "english", "bip39").unwrap().version, 2);
+
+    // The fixed packing exists only under v2's framing, so asking for it at v1
+    // is refused by name rather than inventing a layout that never shipped.
+    match canonical_encode_fixed_at(&payload, "english", "bip39", 1) {
+        Err(CanonicalError::NoFixedForm(1)) => {}
+        other => panic!("expected NoFixedForm(1), got {other:?}"),
+    }
+    // And a v1 artifact cannot be read through the fixed decoder.
+    match canonical_decode_fixed(&v1, "english", "bip39", payload.len()) {
+        Err(_) => {}
+        Ok(d) => panic!("fixed decoder must not accept a v1 artifact, got {d:?}"),
+    }
 }
 
 #[test]
@@ -364,6 +390,15 @@ fn payload_wordlists_are_powers_of_two() {
 // ═══════════════════════════════════════════════════════════════════════
 
 #[test]
+fn v1_rules_are_frozen() {
+    let rules = rules_for(1).expect("v1 must stay reachable — artifacts exist");
+    assert_eq!(rules.best_of, 4);
+    assert_eq!(rules.dialect, "body");
+    assert_eq!(rules.semantics_languages, &["english"]);
+    assert_eq!(rules.envelope, Envelope::VersionLeading);
+}
+
+#[test]
 fn v2_rules_are_frozen() {
     let rules = rules_for(2).expect("v2 must always exist");
     // Changing any of these re-renders every v2 artifact. If a change here is
@@ -371,6 +406,33 @@ fn v2_rules_are_frozen() {
     assert_eq!(rules.best_of, 4);
     assert_eq!(rules.dialect, "body");
     assert_eq!(rules.semantics_languages, &["english"]);
+    assert_eq!(rules.envelope, Envelope::PayloadLeading);
+}
+
+#[test]
+fn v1_golden_renderings() {
+    // The 0.3.0 renderings, unchanged. These are the artifacts in the wild that
+    // v1's continued registration exists to keep readable — a diff here means
+    // one of them stopped verifying.
+    //
+    // Latin's v1 golden is deliberately absent: the 0.4.0 wordlist fix
+    // renumbered that list, so no v1 Latin rendering from 0.3.0 survives. See
+    // the retired `v1.0-cafe-latin` vector in tests/test_vectors.json.
+    let hash160: Vec<u8> = (0u8..20).collect();
+    let zeros = vec![0u8; 8];
+
+    assert_eq!(
+        canonical_encode_at(&hash160, "english", "bip39", 1).unwrap(),
+        "Its absurd absurd abandon dog. Alcohol may doctor its odd loan. Son bring abuse to anxiety. Flash addict its bright valve. An ancient cow embark our gas."
+    );
+    assert_eq!(
+        canonical_encode_at(&zeros, "english", "bip39", 1).unwrap(),
+        "The absent absurd abandon abandon. Our abandon abandon abandon to abandon."
+    );
+    assert_eq!(
+        canonical_encode_at(&zeros, "czech", "default", 1).unwrap(),
+        "Aktovka mít amputace se abdikace. Abdikace dát ze abdikace. Abdikace mít abdikace se abdikace."
+    );
 }
 
 #[test]

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -8,9 +8,20 @@
 //! these.
 
 use glossia::{
-    canonical_decode, canonical_encode, canonical_encode_at, rules_for, CanonicalError,
-    CANONICAL_VERSION,
+    canonical_decode, canonical_decode_fixed, canonical_encode, canonical_encode_at,
+    canonical_encode_fixed, canonical_encode_fixed_at, canonical_encode_fixed_traced, rules_for,
+    CanonicalError, CANONICAL_VERSION,
 };
+
+/// `payload || version || crc32(payload || version)` — the envelope as
+/// `src/canonical.rs` seals it, rebuilt here so a test can craft bytes the
+/// public API would refuse to write.
+fn envelope(payload: &[u8], version: u8) -> Vec<u8> {
+    let mut bytes = payload.to_vec();
+    bytes.push(version);
+    bytes.extend_from_slice(&glossia::codec::crc32(&bytes).to_be_bytes());
+    bytes
+}
 
 const LANGS: &[(&str, &str)] = &[
     ("english", "bip39"),
@@ -64,28 +75,31 @@ fn encoding_is_deterministic() {
 }
 
 #[test]
-fn payload_word_swap_decodes_different_and_unverified() {
+fn payload_word_swap_is_caught_by_the_checksum() {
     let payload: Vec<u8> = (0u8..20).collect();
     let text = canonical_encode(&payload, "english", "bip39").unwrap();
-    // "valve" is a payload word in this rendering; "zebra" is a different
-    // BIP39 word not present in it. The swap keeps the word count, so it
-    // decodes cleanly — to different bytes — and only the wording check
-    // catches it.
-    assert!(text.contains("valve"), "expected payload word missing: {text}");
-    let damaged = text.replace("valve", "zebra");
-    let d = canonical_decode(&damaged, "english", "bip39").unwrap();
-    assert_ne!(d.payload, payload, "swapped payload word must change the bytes");
-    assert!(!d.verified, "damaged payload must not verify");
+    // "cage" is a payload word in this rendering; "zebra" is a different BIP39
+    // word not present in it. The swap keeps the word count, so the words still
+    // unpack — to different bytes — and it is the trailing checksum that refuses
+    // them. Before the checksum this returned a decode with `verified: false`,
+    // which put the burden on every caller to look at that flag.
+    assert!(text.contains("cage"), "expected payload word missing: {text}");
+    let damaged = text.replace("cage", "zebra");
+    match canonical_decode(&damaged, "english", "bip39") {
+        Err(CanonicalError::ChecksumMismatch { .. }) => {}
+        other => panic!("expected ChecksumMismatch, got {other:?}"),
+    }
 }
 
 #[test]
 fn cover_word_damage_keeps_payload_but_unverifies() {
     let payload: Vec<u8> = (0u8..20).collect();
     let text = canonical_encode(&payload, "english", "bip39").unwrap();
-    // "may" is a cover word here — not in BIP39 — so mangling it leaves the
-    // payload intact and only the wording disagrees.
-    assert!(text.contains(" may "), "expected cover word missing: {text}");
-    let damaged = text.replacen(" may ", " mays ", 1);
+    // "via" is a cover word here — not in BIP39 — so mangling it leaves the
+    // payload and its checksum intact, and only the wording disagrees. This is
+    // the damage the checksum CANNOT see and the re-render can.
+    assert!(text.contains(" via "), "expected cover word missing: {text}");
+    let damaged = text.replacen(" via ", " vias ", 1);
     let d = canonical_decode(&damaged, "english", "bip39").unwrap();
     assert_eq!(d.payload, payload, "cover damage must not change the payload");
     assert!(!d.verified, "cover damage must not verify");
@@ -103,11 +117,11 @@ fn verification_ignores_punctuation_and_case() {
 
 #[test]
 fn unknown_version_is_refused_by_name() {
-    // Craft an artifact claiming version 200 through the unversioned seam.
+    // Craft an artifact claiming version 200 through the unversioned seam. The
+    // checksum has to be well-formed or the decoder would stop at it first.
     let tree = glossia::cached_payload_tree("english", "bip39").unwrap();
-    let mut bytes = vec![200u8];
-    bytes.extend(0u8..8);
-    let words = glossia::codec::encode_base_n(&bytes, &tree, "bitpack").unwrap();
+    let bytes = envelope(&(0u8..8).collect::<Vec<u8>>(), 200);
+    let words = glossia::codec::encode_base_n(&bytes, &tree, "canonical_bitpack").unwrap();
     let (text, _) = glossia::pipeline::encode_words_into_language(
         &words, "english", "bip39", "body", 7, 1,
     )
@@ -116,11 +130,38 @@ fn unknown_version_is_refused_by_name() {
         Err(CanonicalError::UnsupportedVersion(200)) => {}
         other => panic!("expected UnsupportedVersion(200), got {other:?}"),
     }
-    // Encoding at an unknown version is refused the same way.
+    // Encoding at an unknown version is refused the same way, both packings.
     match canonical_encode_at(&[1, 2, 3], "english", "bip39", 200) {
         Err(CanonicalError::UnsupportedVersion(200)) => {}
         other => panic!("expected UnsupportedVersion(200), got {other:?}"),
     }
+    match canonical_encode_fixed_at(&[1, 2, 3], "english", "bip39", 200) {
+        Err(CanonicalError::UnsupportedVersion(200)) => {}
+        other => panic!("expected UnsupportedVersion(200), got {other:?}"),
+    }
+}
+
+#[test]
+fn version_1_artifacts_are_refused_rather_than_misread() {
+    // v1 put the version byte FIRST and carried no checksum. This release packs
+    // neither, so a v1 artifact must fail loudly. What it must NOT do is hand
+    // back a payload shifted by five bytes as though it had read it.
+    let tree = glossia::cached_payload_tree("english", "bip39").unwrap();
+    let mut v1_bytes = vec![1u8];
+    v1_bytes.extend(0u8..20);
+    let words = glossia::codec::encode_base_n(&v1_bytes, &tree, "bitpack").unwrap();
+    let (text, _) = glossia::pipeline::encode_words_into_language(
+        &words, "english", "bip39", "body", 7, 1,
+    )
+    .unwrap();
+    match canonical_decode(&text, "english", "bip39") {
+        Err(CanonicalError::ChecksumMismatch { .. }) => {}
+        Err(CanonicalError::UnsupportedVersion(_)) => {}
+        Err(CanonicalError::Decode(_)) => {}
+        other => panic!("a v1 artifact must be refused, got {other:?}"),
+    }
+    // And v1 is gone from the registry, so nothing can be written at it either.
+    assert!(rules_for(1).is_none(), "v1 rules must not be reachable");
 }
 
 #[test]
@@ -171,13 +212,129 @@ fn canonical_ignores_the_semantics_escape_hatch() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
-// Version 1 freeze
+// The fixed packing
 // ═══════════════════════════════════════════════════════════════════════
 
 #[test]
-fn v1_rules_are_frozen() {
-    let rules = rules_for(1).expect("v1 must always exist");
-    // Changing any of these re-renders every v1 artifact. If a change here is
+fn fixed_round_trips_and_verifies_across_languages() {
+    for (language, wordlist) in LANGS {
+        for payload in payloads() {
+            let text = canonical_encode_fixed(&payload, language, wordlist)
+                .unwrap_or_else(|e| panic!("{language} fixed encode: {e}"));
+            let d = canonical_decode_fixed(&text, language, wordlist, payload.len())
+                .unwrap_or_else(|e| panic!("{language} fixed decode: {e}"));
+            assert_eq!(d.payload, payload, "{language} fixed payload round trip");
+            assert_eq!(d.version, CANONICAL_VERSION, "{language} fixed version");
+            assert!(d.verified, "{language} clean fixed artifact must verify");
+        }
+    }
+}
+
+#[test]
+fn fixed_spends_one_word_less_than_self_describing() {
+    // The padding word is the whole difference: same bytes, same rules, one
+    // fewer word to carry a length the caller already knows.
+    for len in [1usize, 20, 32, 65] {
+        let payload: Vec<u8> = (0..len).map(|i| (i as u8).wrapping_mul(37)).collect();
+        let self_words = glossia::canonical_encode_traced(&payload, "english", "bip39")
+            .unwrap()
+            .1
+            .len();
+        let fixed_words = canonical_encode_fixed_traced(&payload, "english", "bip39")
+            .unwrap()
+            .1
+            .len();
+        assert_eq!(
+            self_words,
+            fixed_words + 1,
+            "len {len}: fixed must be exactly one word shorter"
+        );
+    }
+}
+
+#[test]
+fn the_opening_word_carries_payload_not_envelope() {
+    // The regression this layout exists for. Under v1 the leading padding word
+    // was a function of payload LENGTH alone, so every same-sized payload opened
+    // on the same word — every 32-byte hash began "abandon". Behind the payload,
+    // the opening word is payload.
+    for encode_traced in [
+        glossia::canonical_encode_traced
+            as fn(&[u8], &str, &str) -> Result<_, CanonicalError>,
+        canonical_encode_fixed_traced,
+    ] {
+        let mut firsts = std::collections::HashSet::new();
+        for i in 0..8u8 {
+            let payload: Vec<u8> = (0..32u8).map(|j| j ^ i.wrapping_mul(37)).collect();
+            let (_text, placements) = encode_traced(&payload, "english", "bip39").unwrap();
+            firsts.insert(placements[0].word.clone());
+        }
+        assert!(
+            firsts.len() > 1,
+            "opening word is fixed across distinct 32-byte payloads: {firsts:?}"
+        );
+    }
+}
+
+#[test]
+fn canonical_bitpack_puts_the_padding_word_last() {
+    let tree = glossia::cached_payload_tree("english", "bip39").unwrap();
+    let bits_per_word = 11usize;
+    for len in [1usize, 8, 20, 32] {
+        let data: Vec<u8> = (0..len).map(|i| (i as u8).wrapping_mul(53)).collect();
+        let words = glossia::codec::encode_base_n(&data, &tree, "canonical_bitpack").unwrap();
+        let n_data = (data.len() * 8).div_ceil(bits_per_word);
+        let pad = n_data * bits_per_word - data.len() * 8;
+        assert_eq!(words.len(), n_data + 1, "len {len}: word count");
+        assert_eq!(
+            tree.position(words.last().unwrap()),
+            Some(pad),
+            "len {len}: last word must be the padding count"
+        );
+        let back = glossia::codec::decode_base_n(&words, &tree, "canonical_bitpack").unwrap();
+        assert_eq!(back, data, "len {len}: round trip");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Wordlist sizes
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn payload_wordlists_are_powers_of_two() {
+    // `encode_base_n` gates every bitpack codec on this, falling back to
+    // big-integer base-N without a word of complaint. German and Latin failed it
+    // silently for one release because YAML resolved `null:` (die Null) and
+    // `false:` to non-string scalars and the loader skipped them — 2048 -> 2047
+    // and 32768 -> 32767. The words are the guard that would have caught it.
+    for (language, wordlist, expected) in [
+        ("english", "bip39", 2048usize),
+        ("latin", "default", 32768),
+        ("czech", "default", 2048),
+        ("german", "default", 2048),
+    ] {
+        let tree = glossia::cached_payload_tree(language, wordlist).unwrap();
+        assert_eq!(tree.len(), expected, "{language} wordlist size");
+        assert!(tree.len().is_power_of_two(), "{language} must stay a power of two");
+    }
+    assert!(
+        glossia::cached_payload_tree("german", "default").unwrap().contains("null"),
+        "German's `null` must survive YAML's core schema"
+    );
+    assert!(
+        glossia::cached_payload_tree("latin", "default").unwrap().contains("false"),
+        "Latin's `false` must survive YAML's core schema"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Version 2 freeze
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn v2_rules_are_frozen() {
+    let rules = rules_for(2).expect("v2 must always exist");
+    // Changing any of these re-renders every v2 artifact. If a change here is
     // intended, it belongs in a NEW version — see the module docs.
     assert_eq!(rules.best_of, 4);
     assert_eq!(rules.dialect, "body");
@@ -185,28 +342,32 @@ fn v1_rules_are_frozen() {
 }
 
 #[test]
-fn v1_golden_renderings() {
+fn v2_golden_renderings() {
     // Exact canonical renderings, pinned. These freeze everything the
     // rendering reads: grammar, dialect config, cover wordlists, English's
     // semantics.yaml, the RNG, and the best-of selection. A diff here means a
-    // v1 artifact in the wild no longer verifies.
+    // v2 artifact in the wild no longer verifies.
     let hash160: Vec<u8> = (0u8..20).collect();
     let zeros = vec![0u8; 8];
 
     assert_eq!(
         canonical_encode(&hash160, "english", "bip39").unwrap(),
-        "Its absurd absurd abandon dog. Alcohol may doctor its odd loan. Son bring abuse to anxiety. Flash addict its bright valve. An ancient cow embark our gas."
+        "Abandon amount a liar. Amount expire to adjust via cage. Candy arch to gather. Drum get bullet out an absurd math via equal. Some cop are frozen. Method pistol scale to abuse."
+    );
+    assert_eq!(
+        canonical_encode_fixed(&hash160, "english", "bip39").unwrap(),
+        "Abandon amount a liar. Amount expire to adjust via cage. Candy arch to gather. Drum get bullet out an absurd math via equal. Some cop are frozen. Method may pistol the scale."
     );
     assert_eq!(
         canonical_encode(&zeros, "english", "bip39").unwrap(),
-        "The absent absurd abandon abandon. Our abandon abandon abandon to abandon."
+        "Abandon abandon abandon to abandon. Abandon may abandon the amused abstract. A tap is intact. Son avoid to absorb."
     );
     assert_eq!(
         canonical_encode(&zeros, "latin", "default").unwrap(),
-        "Tu aro fas e jul. Fas aro se is."
+        "Is abs eo. Tu abs eo abs tu. Is eo abs is. Tu aro colonus. Torminalis aca is."
     );
     assert_eq!(
         canonical_encode(&zeros, "czech", "default").unwrap(),
-        "Aktovka mít amputace se abdikace. Abdikace dát ze abdikace. Abdikace mít abdikace se abdikace."
+        "Abdikace ne mít abdikace. Abdikace jít na abdikace. Abdikace mít abdikace si biftek ku alkohol. Nastat mít butik za alej."
     );
 }

--- a/tests/canonical.rs
+++ b/tests/canonical.rs
@@ -277,6 +277,38 @@ fn the_opening_word_carries_payload_not_envelope() {
 }
 
 #[test]
+fn a_truncated_fixed_artifact_is_refused_by_word_count() {
+    // `decode_bitpack_fixed` used to fill `expected_bytes` from whatever words
+    // it had and leave the rest zero, so a paragraph with its tail cut off
+    // decoded to a plausible zero-padded payload. It now counts first, which
+    // catches a truncation as the wrong SHAPE rather than the wrong bytes —
+    // a better error, and the one that lets a host tell "not canonical prose"
+    // (fall back to another decoder) from "canonical prose, damaged" (do not).
+    let payload: Vec<u8> = (0u8..20).collect();
+    let text = canonical_encode_fixed(&payload, "english", "bip39").unwrap();
+    let words: Vec<&str> = text.split_whitespace().collect();
+    let truncated = words[..words.len() * 2 / 3].join(" ");
+    match canonical_decode_fixed(&truncated, "english", "bip39", payload.len()) {
+        Err(CanonicalError::Decode(msg)) => {
+            assert!(msg.contains("expected"), "error should name the count: {msg}");
+        }
+        other => panic!("expected a Decode error on a truncated artifact, got {other:?}"),
+    }
+}
+
+#[test]
+fn prose_of_another_length_does_not_pass_as_a_short_payload() {
+    // The same guard from the other side: prose encoding a 32-byte payload must
+    // not decode as a 20-byte one just because the words are all in the list.
+    let long: Vec<u8> = (0u8..32).collect();
+    let text = canonical_encode_fixed(&long, "english", "bip39").unwrap();
+    match canonical_decode_fixed(&text, "english", "bip39", 20) {
+        Err(CanonicalError::Decode(_)) => {}
+        other => panic!("expected a Decode error for the wrong length, got {other:?}"),
+    }
+}
+
+#[test]
 fn canonical_bitpack_puts_the_padding_word_last() {
     let tree = glossia::cached_payload_tree("english", "bip39").unwrap();
     let bits_per_word = 11usize;

--- a/tests/test_vectors.json
+++ b/tests/test_vectors.json
@@ -222,7 +222,7 @@
   },
 
   "decode_stability_vectors": {
-    "_comment": "APPEND-ONLY. These vectors pin encoded prose from specific versions. Every future glossia build must decode each prose string to the expected value. Never edit or remove existing entries.",
+    "_comment": "APPEND-ONLY. These vectors pin encoded prose from specific versions. Every future glossia build must decode each prose string to the expected value. Never edit or remove existing entries. A vector a release knowingly breaks is RETIRED in place — annotated with retired_in and retired_reason and skipped by the test — never deleted, so the break stays on the record beside the promise it broke.",
     "vectors": [
       {
         "id": "v1.0-single-zero-byte",
@@ -297,6 +297,8 @@
       {
         "id": "v1.0-cafe-latin",
         "pinned_since": "1.0.0",
+        "retired_in": "0.4.0",
+        "retired_reason": "Latin's payload wordlist was one word short of 32768: YAML's core schema resolves the entry `false:` to a boolean, and the loader skipped non-string keys. Off a power of two, encode_base_n silently chose big-integer base-N over bitpack. Restoring the word restores bitpack, which re-encodes every Latin artifact — this prose was written under the fallback and cannot decode under the codec Latin was always meant to use.",
         "encoded_prose": "Aca  e  contritio.",
         "decode_from": { "language": "latin", "wordlist": "default", "dialect": "default" },
         "expected_decoded": { "value": "cafe", "format": "hex" }

--- a/tests/test_vectors_roundtrip.rs
+++ b/tests/test_vectors_roundtrip.rs
@@ -53,6 +53,15 @@ struct DecodeStabilityVector {
     expected_decoded: ValueWithFormat,
     #[serde(default)]
     decode_meta: Option<String>,
+    /// The release that knowingly broke this vector, if any. Retiring a vector
+    /// is a format break being ADMITTED, not tidied away: the entry stays, with
+    /// the version and the reason beside it, so the record of what stopped
+    /// decoding is in the same file as the promise that it wouldn't. A retired
+    /// vector must carry both fields.
+    #[serde(default)]
+    retired_in: Option<String>,
+    #[serde(default)]
+    retired_reason: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -357,6 +366,17 @@ fn decode_stability_vectors() {
     };
 
     for v in &section.vectors {
+        if let Some(ref release) = v.retired_in {
+            let reason = v.retired_reason.as_deref().unwrap_or("");
+            assert!(
+                !reason.is_empty(),
+                "[{}] retired in {release} without a reason — a break has to say what broke it",
+                v.id
+            );
+            eprintln!("[{}] retired in {release}: {reason}", v.id);
+            continue;
+        }
+
         // For crypto formats that need special routing, use the meta pipeline
         if let Some(ref meta) = v.decode_meta {
             let pipe = Pipeline::from_meta(meta).unwrap_or_else(|e| {


### PR DESCRIPTION
## Why

The canonical encoding put two fixed things in front of every payload, and a reader met both before meeting the record.

`bitpack` leads with a word whose index is the padding-bit count — which depends only on the payload's **length**. For any fixed-size field that is a constant, so every 32-byte hash opened on wordlist word 0: `abandon`, in the first sentence, every time. A 20-byte hash160 opened on `absurd`. Behind it, the version byte `0x01` filled the first data word's top eight bits, pinning the second word to one of eight. Two words in, an English artifact had said three bits about its payload.

Observed downstream in the Bitcoin book, where every txid, merkle root and compact signature is 32 or 65 bytes — both of which pad to zero.

## The v2 envelope

```
bytes:  [ payload ][ version:1 ][ crc32:4 ]
words:  [ data_0 ] ... [ data_N-1 ][ padding ]     canonical_encode
        [ data_0 ] ... [ data_N-1 ]               canonical_encode_fixed
```

Both envelope fields ride behind the payload, so the opening words are payload. The checksum's four bytes stand between the version byte and the end of the paragraph, so the closing words vary too.

- **`canonical_bitpack`** — `bitpack` with the padding word last. Implemented as a rotation over the shared coder, so the two layouts cannot drift in their bit handling.
- **`canonical_encode_fixed` / `canonical_decode_fixed`** (+ `_traced` and `_raw_fixed`, all reaching wasm) — no padding word at all when the caller knows the byte count. One word shorter, and the count is something structured data almost always already states.
- **Trailing crc32** over `payload || version`. Redundant with the wording verification by design: verification catches strictly more but costs a generation pass, so `canonical_decode_raw` — the entry point for repair searches decoding many candidates — now has something cheap to lean on. It runs *before* the version lookup, because damaged words are likelier than an artifact from the future.
- **`decode_bitpack_fixed` now counts its words.** It used to treat the count as a floor, filling `expected_bytes` from whatever it had and zeroing the tail — so a truncated paragraph decoded to a plausible zero-padded payload. That distinction is load-bearing for any host that falls back to another decoder: "not canonical prose" (fall through) and "canonical prose, damaged" (do not) must not be handled alike. The wasm entry points now return a stable `kind` slug (`checksum_mismatch`, `unsupported_version`, `no_fixed_form`, …) so a caller branches on that rather than on prose.

## Version 1 stays readable

**Both framings are live.** `Envelope` is a field of `VersionRules` — the one part of a version's format the decoder must resolve *before* it knows the version — and v1 is registered with `VersionLeading`.

Moving the version byte looked impossible precisely because it has to be readable before the rules are known. The checksum is what pays for the move: a decoder tries the payload-leading framing and a wrong guess fails its crc32 with probability 1 − 2⁻³², so falling back to the version-leading framing is not a guess. A version vouches only for the framing it declares, so neither reader can claim the other's artifact.

v1 artifacts decode, report version 1, and **verify** — re-rendered under v1's rules, not the current ones. `v1_golden_renderings` asserts the same strings the 0.3.0 test file pinned, so this is the genuine old rendering rather than a re-pin.

The fixed packing stays v2-only and says so by name (`NoFixedForm`): it spends no word on the payload's length, which is exactly why a framing whose version byte leads cannot have one.

## Two wordlists were not the size they looked

Found while checking whether the padding word even applied to the other languages. It did not — because YAML's core schema resolves `false:` (Latin, an adverb) and `null:` (German, *die Null*) to non-string scalars, and the payload loader read keys with `as_str()` and skipped what came back `None`.

Latin lost one word of 32768; German one of 2048. `encode_base_n` gates every bitpack codec on a power-of-two wordlist — so **both languages had silently been encoding through the big-integer base-N fallback for their entire existence.** English never showed it because its list already quotes `'false'`.

The loader now spells scalar keys back out, which also un-breaks the numeric wordlists under `languages/math`. A test pins all four sizes.

## Breaking changes

1. **Every Latin and German artifact re-encodes**, as a consequence of the wordlist fix — including v1 ones, which no version rule can repair: restoring the words renumbered both lists and moved them from base-N to bitpack. That is a wordlist change rather than a format change, and it sits outside what a canonical version freezes. **English and Czech v1 artifacts are unaffected.** This breaks one pinned decode-stability vector, `v1.0-cafe-latin`, which is **retired in place** — annotated with `retired_in` / `retired_reason` and skipped — rather than deleted or quietly re-pinned. The break belongs on the record beside the promise.

2. **Word cost: +2 per artifact** at v2. The crc32 is 4 bytes ≈ 3 words; dropping the padding word saves 1. A 32-byte payload is 27 words, was 25. A 2-byte CRC16 would make this +0/+1 if the length matters more than the error detection.

## Testing

Whole workspace green — **497 tests**, including new coverage for the trailing padding word, the crc32 trailer, the fixed pair's word count, truncation and wrong-length refusal, the two framings not reading each other, v1 round-trip + verify, and the restored wordlist sizes. v1 goldens restored unchanged; v2 goldens pinned.

Driven end to end through a locally built wasm against real chain values — genesis merkle root, the pizza txid, a hash160, the genesis pubkey — round-tripping and verifying at version 2 in all four book languages, with a swapped payload word refused and a v1 artifact still reading. Openings now:

```
v2  merkle root  Desert may get buyer.
v2  pizza txid   Miss police to leave per our profit.
v2  hash160      A glass else see guy.
v2  genesis key  Guy afford detail to satoshi via giggle.
v1  hash160      Absurd may see accident.      ← the old constant opener, still readable
```

`cargo package -p glossia` passes, verification build included; all four `payload.yaml` files ship in the crate with both restored entries intact.

## Releasing

Versions are already bumped to `0.4.0` (root `Cargo.toml`, `glossia-cli/Cargo.toml`, and the path-dependency requirement), so `publish.yml`'s tag check passes as-is. After merge: `git tag v0.4.0 && git push origin v0.4.0`.

asherp/Book-of-Bitcoin#57 is blocked on that publish — its `rehearsal` job pins `0.4.0` and currently 403s from crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vrp4qNfg3BYb1PmDmF8p2b